### PR TITLE
feat: add path payment explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.kiro

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Contracts from './components/dashboard/Contracts'
 import NetworkStats from './components/dashboard/NetworkStats'
 import Faucet from './components/dashboard/Faucet'
 import Builder from './components/dashboard/Builder'
+import PathExplorer from './components/dashboard/PathExplorer'
 import { useStore } from './lib/store'
 
 const TABS = {
@@ -18,6 +19,7 @@ const TABS = {
   network:      NetworkStats,
   builder:      Builder,
   faucet:       Faucet,
+  paths:        PathExplorer,
 }
 
 export default function App() {

--- a/src/components/dashboard/PathExplorer.jsx
+++ b/src/components/dashboard/PathExplorer.jsx
@@ -1,0 +1,380 @@
+import React, { useState } from 'react'
+import { useStore } from '../../lib/store'
+import { fetchPaymentPaths } from '../../lib/stellar'
+
+const PRESET_ASSETS = [
+  { label: 'XLM (native)', value: { type: 'native', code: 'XLM' } },
+  { label: 'USDC (testnet)', value: { type: 'credit', code: 'USDC', issuer: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5' } },
+  { label: 'USDC (mainnet)', value: { type: 'credit', code: 'USDC', issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' } },
+]
+
+function AssetInput({ label, value, onChange }) {
+  const [mode, setMode] = useState('preset') // 'preset' | 'custom'
+  const [customCode, setCustomCode] = useState('')
+  const [customIssuer, setCustomIssuer] = useState('')
+
+  const inputStyle = {
+    background: 'var(--bg-surface)',
+    border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)',
+    color: 'var(--text-primary)',
+    fontFamily: 'var(--font-mono)',
+    fontSize: '12px',
+    padding: '7px 10px',
+    width: '100%',
+    boxSizing: 'border-box',
+    outline: 'none',
+  }
+
+  const toggleStyle = (active) => ({
+    padding: '4px 10px',
+    fontSize: '11px',
+    fontFamily: 'var(--font-mono)',
+    background: active ? 'var(--cyan-glow)' : 'transparent',
+    border: `1px solid ${active ? 'var(--cyan)' : 'var(--border)'}`,
+    color: active ? 'var(--cyan)' : 'var(--text-muted)',
+    borderRadius: 'var(--radius-sm)',
+    cursor: 'pointer',
+    transition: 'var(--transition)',
+  })
+
+  function handlePresetChange(e) {
+    const preset = PRESET_ASSETS.find(a => a.label === e.target.value)
+    if (preset) onChange(preset.value)
+  }
+
+  function handleCustomChange(code, issuer) {
+    if (code === 'XLM' && !issuer) {
+      onChange({ type: 'native', code: 'XLM' })
+    } else if (code && issuer) {
+      onChange({ type: 'credit', code, issuer })
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: '11px', color: 'var(--text-muted)', letterSpacing: '1px', textTransform: 'uppercase' }}>{label}</span>
+        <div style={{ display: 'flex', gap: '4px' }}>
+          <button style={toggleStyle(mode === 'preset')} onClick={() => setMode('preset')}>Preset</button>
+          <button style={toggleStyle(mode === 'custom')} onClick={() => setMode('custom')}>Custom</button>
+        </div>
+      </div>
+      {mode === 'preset' ? (
+        <select onChange={handlePresetChange} style={{ ...inputStyle, cursor: 'pointer' }}
+          defaultValue="">
+          <option value="" disabled>Select asset…</option>
+          {PRESET_ASSETS.map(a => <option key={a.label} value={a.label}>{a.label}</option>)}
+        </select>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+          <input
+            placeholder="Asset code (e.g. USDC, or XLM for native)"
+            style={inputStyle}
+            value={customCode}
+            onChange={e => { setCustomCode(e.target.value.toUpperCase()); handleCustomChange(e.target.value.toUpperCase(), customIssuer) }}
+          />
+          {customCode !== 'XLM' && (
+            <input
+              placeholder="Issuer public key"
+              style={inputStyle}
+              value={customIssuer}
+              onChange={e => { setCustomIssuer(e.target.value); handleCustomChange(customCode, e.target.value) }}
+            />
+          )}
+        </div>
+      )}
+      {value && (
+        <div style={{ fontSize: '11px', color: 'var(--cyan)', fontFamily: 'var(--font-mono)' }}>
+          {value.type === 'native' ? '✦ XLM (native)' : `✦ ${value.code}`}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function PathCard({ path, mode, index }) {
+  const sourceAmount = parseFloat(path.source_amount)
+  const destAmount = parseFloat(path.destination_amount)
+  const rate = mode === 'strict-send'
+    ? (destAmount / sourceAmount).toFixed(6)
+    : (sourceAmount / destAmount).toFixed(6)
+
+  // Estimate slippage vs best path (index 0 = best)
+  const slippage = index === 0 ? null : null // computed by parent
+
+  function assetLabel(a) {
+    if (a.asset_type === 'native') return 'XLM'
+    return a.asset_code
+  }
+
+  const pathAssets = path.path || []
+
+  return (
+    <div style={{
+      background: 'var(--bg-card)',
+      border: `1px solid ${index === 0 ? 'var(--cyan-dim)' : 'var(--border)'}`,
+      borderRadius: 'var(--radius-lg)',
+      padding: '16px 20px',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '12px',
+      position: 'relative',
+    }}>
+      {index === 0 && (
+        <div style={{
+          position: 'absolute', top: '12px', right: '14px',
+          fontSize: '10px', color: 'var(--cyan)', fontFamily: 'var(--font-mono)',
+          background: 'var(--cyan-glow)', border: '1px solid var(--cyan-dim)',
+          borderRadius: 'var(--radius-sm)', padding: '2px 8px', letterSpacing: '1px',
+        }}>BEST RATE</div>
+      )}
+
+      {/* Path route */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+        <AssetBadge label={assetLabel(path.source_asset_type !== undefined ? path : { asset_type: path.source_asset_type, asset_code: path.source_asset_code })} isSource />
+        {pathAssets.map((a, i) => (
+          <React.Fragment key={i}>
+            <span style={{ color: 'var(--text-muted)', fontSize: '12px' }}>→</span>
+            <AssetBadge label={assetLabel(a)} />
+          </React.Fragment>
+        ))}
+        <span style={{ color: 'var(--text-muted)', fontSize: '12px' }}>→</span>
+        <AssetBadge label={assetLabel({ asset_type: path.destination_asset_type, asset_code: path.destination_asset_code })} isDest />
+      </div>
+
+      {/* Amounts & rate */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '12px' }}>
+        <Metric label="Send" value={`${sourceAmount.toLocaleString('en-US', { maximumFractionDigits: 7 })} ${assetLabel({ asset_type: path.source_asset_type, asset_code: path.source_asset_code })}`} />
+        <Metric label="Receive" value={`${destAmount.toLocaleString('en-US', { maximumFractionDigits: 7 })} ${assetLabel({ asset_type: path.destination_asset_type, asset_code: path.destination_asset_code })}`} accent="var(--green)" />
+        <Metric label={mode === 'strict-send' ? 'Rate (dest/src)' : 'Rate (src/dest)'} value={rate} accent="var(--cyan)" />
+      </div>
+
+      {path.slippagePct !== undefined && (
+        <div style={{ fontSize: '11px', color: 'var(--amber)', fontFamily: 'var(--font-mono)' }}>
+          ~{path.slippagePct}% vs best path
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AssetBadge({ label, isSource, isDest }) {
+  return (
+    <span style={{
+      padding: '3px 8px',
+      background: isSource ? 'var(--cyan-glow)' : isDest ? 'rgba(74,222,128,0.08)' : 'var(--bg-surface)',
+      border: `1px solid ${isSource ? 'var(--cyan-dim)' : isDest ? 'rgba(74,222,128,0.3)' : 'var(--border)'}`,
+      borderRadius: 'var(--radius-sm)',
+      fontSize: '11px',
+      fontFamily: 'var(--font-mono)',
+      color: isSource ? 'var(--cyan)' : isDest ? 'var(--green)' : 'var(--text-secondary)',
+    }}>{label}</span>
+  )
+}
+
+function Metric({ label, value, accent }) {
+  return (
+    <div>
+      <div style={{ fontSize: '10px', color: 'var(--text-muted)', letterSpacing: '1px', textTransform: 'uppercase', marginBottom: '4px' }}>{label}</div>
+      <div style={{ fontSize: '13px', fontFamily: 'var(--font-mono)', color: accent || 'var(--text-primary)' }}>{value}</div>
+    </div>
+  )
+}
+
+export default function PathExplorer() {
+  const { network } = useStore()
+  const [sourceAsset, setSourceAsset] = useState(null)
+  const [destAsset, setDestAsset] = useState(null)
+  const [amount, setAmount] = useState('')
+  const [mode, setMode] = useState('strict-send')
+  const [paths, setPaths] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  async function handleFind() {
+    if (!sourceAsset || !destAsset || !amount) return
+    setLoading(true)
+    setError(null)
+    setPaths(null)
+    try {
+      const results = await fetchPaymentPaths({ sourceAsset, destAsset, amount, mode, network })
+      // Sort by best rate and annotate slippage
+      const sorted = [...results].sort((a, b) => {
+        const rateA = mode === 'strict-send'
+          ? parseFloat(a.destination_amount) / parseFloat(a.source_amount)
+          : parseFloat(a.source_amount) / parseFloat(a.destination_amount)
+        const rateB = mode === 'strict-send'
+          ? parseFloat(b.destination_amount) / parseFloat(b.source_amount)
+          : parseFloat(b.source_amount) / parseFloat(b.destination_amount)
+        return mode === 'strict-send' ? rateB - rateA : rateA - rateB
+      })
+      const bestRate = sorted[0]
+        ? (mode === 'strict-send'
+          ? parseFloat(sorted[0].destination_amount) / parseFloat(sorted[0].source_amount)
+          : parseFloat(sorted[0].source_amount) / parseFloat(sorted[0].destination_amount))
+        : 1
+      const annotated = sorted.map((p, i) => {
+        if (i === 0) return p
+        const rate = mode === 'strict-send'
+          ? parseFloat(p.destination_amount) / parseFloat(p.source_amount)
+          : parseFloat(p.source_amount) / parseFloat(p.destination_amount)
+        const slippagePct = (((bestRate - rate) / bestRate) * 100).toFixed(2)
+        return { ...p, slippagePct }
+      })
+      setPaths(annotated)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const canSearch = sourceAsset && destAsset && amount && parseFloat(amount) > 0
+
+  const modeToggle = (m, label) => (
+    <button
+      onClick={() => setMode(m)}
+      style={{
+        padding: '6px 14px',
+        fontSize: '12px',
+        fontFamily: 'var(--font-mono)',
+        background: mode === m ? 'var(--cyan-glow)' : 'transparent',
+        border: `1px solid ${mode === m ? 'var(--cyan)' : 'var(--border)'}`,
+        color: mode === m ? 'var(--cyan)' : 'var(--text-secondary)',
+        borderRadius: 'var(--radius-sm)',
+        cursor: 'pointer',
+        transition: 'var(--transition)',
+      }}
+    >{label}</button>
+  )
+
+  return (
+    <div className="animate-in" style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div>
+          <div style={{ fontFamily: 'var(--font-display)', fontSize: '22px', fontWeight: 700 }}>Path Explorer</div>
+          <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginTop: '4px', fontFamily: 'var(--font-mono)' }}>
+            Find DEX conversion paths via Horizon
+          </div>
+        </div>
+        <div style={{
+          padding: '6px 12px',
+          background: network === 'testnet' ? 'var(--amber-glow)' : 'var(--green-glow)',
+          border: `1px solid ${network === 'testnet' ? 'var(--amber)' : 'var(--green)'}`,
+          borderRadius: 'var(--radius-sm)',
+          fontSize: '11px',
+          color: network === 'testnet' ? 'var(--amber)' : 'var(--green)',
+          fontFamily: 'var(--font-mono)',
+          textTransform: 'uppercase',
+          letterSpacing: '1px',
+        }}>{network}</div>
+      </div>
+
+      {/* Form */}
+      <div style={{ background: 'var(--bg-card)', border: '1px solid var(--border)', borderRadius: 'var(--radius-lg)', padding: '20px', display: 'flex', flexDirection: 'column', gap: '20px' }}>
+        {/* Mode */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <span style={{ fontSize: '11px', color: 'var(--text-muted)', letterSpacing: '1px', textTransform: 'uppercase' }}>Mode</span>
+          <div style={{ display: 'flex', gap: '6px' }}>
+            {modeToggle('strict-send', 'Strict Send')}
+            {modeToggle('strict-receive', 'Strict Receive')}
+          </div>
+          <div style={{ fontSize: '11px', color: 'var(--text-muted)' }}>
+            {mode === 'strict-send'
+              ? 'Fix the amount you send — see how much you receive'
+              : 'Fix the amount you receive — see how much you need to send'}
+          </div>
+        </div>
+
+        {/* Assets + amount */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px' }}>
+          <AssetInput label="Source Asset" value={sourceAsset} onChange={setSourceAsset} />
+          <AssetInput label="Destination Asset" value={destAsset} onChange={setDestAsset} />
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+          <span style={{ fontSize: '11px', color: 'var(--text-muted)', letterSpacing: '1px', textTransform: 'uppercase' }}>
+            {mode === 'strict-send' ? 'Amount to Send' : 'Amount to Receive'}
+          </span>
+          <input
+            type="number"
+            min="0"
+            step="any"
+            placeholder="e.g. 100"
+            value={amount}
+            onChange={e => setAmount(e.target.value)}
+            style={{
+              background: 'var(--bg-surface)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-sm)',
+              color: 'var(--text-primary)',
+              fontFamily: 'var(--font-mono)',
+              fontSize: '14px',
+              padding: '9px 12px',
+              width: '200px',
+              outline: 'none',
+            }}
+          />
+        </div>
+
+        <button
+          onClick={handleFind}
+          disabled={!canSearch || loading}
+          style={{
+            alignSelf: 'flex-start',
+            padding: '9px 24px',
+            background: canSearch && !loading ? 'var(--cyan-glow)' : 'transparent',
+            border: `1px solid ${canSearch && !loading ? 'var(--cyan)' : 'var(--border)'}`,
+            borderRadius: 'var(--radius-sm)',
+            color: canSearch && !loading ? 'var(--cyan)' : 'var(--text-muted)',
+            fontFamily: 'var(--font-mono)',
+            fontSize: '13px',
+            cursor: canSearch && !loading ? 'pointer' : 'not-allowed',
+            transition: 'var(--transition)',
+            letterSpacing: '0.5px',
+          }}
+        >
+          {loading ? 'Searching…' : 'Find Paths'}
+        </button>
+      </div>
+
+      {/* Results */}
+      {loading && (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '40px' }}>
+          <div className="spinner" />
+        </div>
+      )}
+
+      {error && (
+        <div style={{
+          background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.3)',
+          borderRadius: 'var(--radius-lg)', padding: '16px 20px',
+          color: '#ef4444', fontFamily: 'var(--font-mono)', fontSize: '13px',
+        }}>
+          {error}
+        </div>
+      )}
+
+      {paths !== null && !loading && (
+        paths.length === 0 ? (
+          <div style={{
+            background: 'var(--bg-card)', border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-lg)', padding: '40px',
+            textAlign: 'center', color: 'var(--text-muted)', fontSize: '13px',
+          }}>
+            No payment paths found for this pair on {network}. Try different assets or a different network.
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+            <div style={{ fontSize: '11px', color: 'var(--text-muted)', letterSpacing: '1px', textTransform: 'uppercase' }}>
+              {paths.length} path{paths.length !== 1 ? 's' : ''} found — sorted by best rate
+            </div>
+            {paths.map((p, i) => <PathCard key={i} path={p} mode={mode} index={i} />)}
+          </div>
+        )
+      )}
+    </div>
+  )
+}

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -8,6 +8,7 @@ const NAV_ITEMS = [
   { id: 'contracts',    label: 'Contracts',       icon: '◻' },
   { id: 'network',      label: 'Network',         icon: '◎' },
   { id: 'builder',      label: 'Builder',         icon: '⚒' },
+  { id: 'paths',        label: 'Path Explorer',   icon: '⇢' },
   { id: 'faucet',       label: 'Faucet',          icon: '⬡' },
 ]
 

--- a/src/lib/stellar.js
+++ b/src/lib/stellar.js
@@ -207,4 +207,32 @@ export async function exportTransactionXDR(params) {
   return transaction.toXDR()
 }
 
+export async function fetchPaymentPaths({ sourceAsset, destAsset, amount, mode = 'strict-send', network = 'testnet' }) {
+  const horizonUrl = NETWORKS[network].horizonUrl
+
+  function assetParams(asset, prefix) {
+    if (asset.type === 'native') {
+      return `${prefix}_asset_type=native`
+    }
+    return `${prefix}_asset_type=credit_alphanum${asset.code.length <= 4 ? '4' : '12'}&${prefix}_asset_code=${asset.code}&${prefix}_asset_issuer=${asset.issuer}`
+  }
+
+  function assetString(asset) {
+    if (asset.type === 'native') return 'native'
+    return `${asset.code}:${asset.issuer}`
+  }
+
+  let url
+  if (mode === 'strict-send') {
+    url = `${horizonUrl}/paths/strict-send?${assetParams(sourceAsset, 'source')}&source_amount=${amount}&destination_assets=${encodeURIComponent(assetString(destAsset))}`
+  } else {
+    url = `${horizonUrl}/paths/strict-receive?${assetParams(destAsset, 'destination')}&destination_amount=${amount}&source_assets=${encodeURIComponent(assetString(sourceAsset))}`
+  }
+
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`Horizon error: ${res.status}`)
+  const data = await res.json()
+  return data._embedded?.records || []
+}
+
 export { StellarSdk }


### PR DESCRIPTION
# feat: add path payment explorer

## Summary

Stellar supports path payments — sending one asset while the recipient receives another, with the network finding the best conversion route through the DEX. This PR adds a Path Explorer to the dashboard so developers can discover and preview those routes before building transactions.

## Changes

- `src/lib/stellar.js` — added `fetchPaymentPaths()` which calls Horizon's `/paths/strict-send` or `/paths/strict-receive` endpoints, handling both native (XLM) and credit assets
- `src/components/dashboard/PathExplorer.jsx` — new dashboard component with full explorer UI
- `src/App.jsx` — registered `paths` tab in the TABS map
- `src/components/layout/Sidebar.jsx` — added Path Explorer nav item (`⇢`)

## Feature Details

### Asset Input
- Preset selector for common assets (XLM, USDC testnet, USDC mainnet)
- Custom mode for entering any asset code + issuer, with native XLM shortcut

### Mode Toggle
- Strict Send — fix the amount you send, see how much you receive
- Strict Receive — fix the amount you receive, see how much you need to send

### Results
- Paths sorted by best exchange rate
- Each path card shows: route (intermediate assets), send amount, receive amount, exchange rate
- Slippage % displayed on non-best paths relative to the best available rate
- Best path highlighted with a BEST RATE badge
- Empty state when no paths are found with a helpful message
- Error state for Horizon failures

### Network Support
- Works on both Testnet and Mainnet, respects the active network from the global store

## Screenshots

<img width="1767" height="947" alt="image" src="https://github.com/user-attachments/assets/583251c2-6eb7-4d1e-bb02-437c6562e6c4" />

## Testing

1. Switch to Testnet in the sidebar
2. Navigate to Path Explorer
3. Select XLM as source, USDC as destination
4. Enter an amount (e.g. `100`) and click Find Paths
5. Verify paths are returned and sorted by best rate
6. Switch to Strict Receive mode and confirm the amount label updates
7. Try an asset pair with no liquidity and confirm the empty state message appears
8. Switch to Mainnet and repeat

## Related

Closes #13

