### PR TITLE
feat(contracts): add soroban invocation panel

### DIFF
--- a/src/components/dashboard/Contracts.jsx
+++ b/src/components/dashboard/Contracts.jsx
@@ -1,30 +1,260 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useStore } from '../../lib/store'
-import { fetchContractInfo, isValidContractId, getSorobanServer, NETWORKS } from '../../lib/stellar'
+import {
+  fetchContractInfo,
+  invokeContract,
+  isValidContractId,
+  NETWORKS,
+  simulateContractCall,
+} from '../../lib/stellar'
+
+const ARGUMENT_TYPES = [
+  { value: 'string', label: 'String' },
+  { value: 'int', label: 'Int' },
+  { value: 'address', label: 'Address' },
+  { value: 'bool', label: 'Bool' },
+]
+
+function Panel({ title, subtitle, children }) {
+  return (
+    <div style={{
+      background: 'var(--bg-card)',
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--radius-lg)',
+      overflow: 'hidden',
+    }}>
+      <div style={{ padding: '14px 18px', borderBottom: '1px solid var(--border)' }}>
+        <div style={{ fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: '13px' }}>{title}</div>
+        {subtitle && (
+          <div style={{ marginTop: '4px', fontSize: '11px', color: 'var(--text-muted)', lineHeight: 1.5 }}>
+            {subtitle}
+          </div>
+        )}
+      </div>
+      <div style={{ padding: '18px' }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function LabeledField({ label, children }) {
+  return (
+    <label style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <span style={{ fontSize: '11px', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.8px' }}>
+        {label}
+      </span>
+      {children}
+    </label>
+  )
+}
+
+function textInputStyle(hasError = false) {
+  return {
+    width: '100%',
+    background: 'var(--bg-elevated)',
+    border: `1px solid ${hasError ? 'var(--red)' : 'var(--border-bright)'}`,
+    borderRadius: 'var(--radius-md)',
+    padding: '10px 14px',
+    color: 'var(--text-primary)',
+    fontSize: '13px',
+    fontFamily: 'var(--font-mono)',
+    outline: 'none',
+    transition: 'var(--transition)',
+    boxSizing: 'border-box',
+  }
+}
+
+function ActionButton({ label, onClick, disabled, tone = 'primary' }) {
+  const palette = tone === 'secondary'
+    ? {
+        background: 'var(--bg-elevated)',
+        color: 'var(--text-primary)',
+        border: '1px solid var(--border-bright)',
+      }
+    : {
+        background: 'var(--cyan)',
+        color: 'var(--bg-base)',
+        border: 'none',
+      }
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        padding: '10px 16px',
+        background: disabled ? 'var(--bg-elevated)' : palette.background,
+        color: disabled ? 'var(--text-muted)' : palette.color,
+        border: disabled ? '1px solid var(--border)' : palette.border,
+        borderRadius: 'var(--radius-md)',
+        fontFamily: 'var(--font-mono)',
+        fontWeight: 700,
+        fontSize: '12px',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        transition: 'var(--transition)',
+      }}
+    >
+      {label}
+    </button>
+  )
+}
+
+function ResultBlock({ label, data }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div style={{ fontSize: '11px', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.8px' }}>
+        {label}
+      </div>
+      <pre style={{
+        margin: 0,
+        background: 'var(--bg-elevated)',
+        border: '1px solid var(--border)',
+        borderRadius: 'var(--radius-md)',
+        padding: '14px',
+        fontSize: '11px',
+        color: 'var(--text-secondary)',
+        overflowX: 'auto',
+        lineHeight: 1.6,
+        fontFamily: 'var(--font-mono)',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+      }}>
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  )
+}
 
 export default function Contracts() {
-  const { network, contractId, setContractId, contractData, setContractData, contractLoading, setContractLoading, contractError, setContractError } = useStore()
-  const [input, setInput] = useState('')
-  const [ledgerEntries, setLedgerEntries] = useState([])
+  const {
+    network,
+    contractId,
+    setContractId,
+    contractData,
+    setContractData,
+    contractLoading,
+    setContractLoading,
+    contractError,
+    setContractError,
+    connectedAddress,
+  } = useStore()
+
+  const [inspectInput, setInspectInput] = useState(contractId || '')
+  const [invokeForm, setInvokeForm] = useState({
+    contractId: contractId || '',
+    functionName: '',
+    sourceAccount: connectedAddress || '',
+    secretKey: '',
+    args: [{ type: 'string', value: '' }],
+  })
+  const [simulateLoading, setSimulateLoading] = useState(false)
+  const [submitLoading, setSubmitLoading] = useState(false)
+  const [invokeError, setInvokeError] = useState('')
+  const [simulationResult, setSimulationResult] = useState(null)
+  const [submitResult, setSubmitResult] = useState(null)
+
+  const isMainnet = network === 'mainnet'
+  const inspectInputError = inspectInput.trim() !== '' && !isValidContractId(inspectInput.trim())
+  const invokeContractError = invokeForm.contractId.trim() !== '' && !isValidContractId(invokeForm.contractId.trim())
+
+  const invocationPreview = useMemo(() => ({
+    contractId: invokeForm.contractId.trim(),
+    functionName: invokeForm.functionName.trim(),
+    sourceAccount: invokeForm.sourceAccount.trim() || connectedAddress || '',
+    args: invokeForm.args.filter(arg => arg.value.trim() !== ''),
+    network,
+  }), [connectedAddress, invokeForm, network])
+
+  function updateField(field, value) {
+    setInvokeForm((current) => ({ ...current, [field]: value }))
+  }
+
+  function updateArgument(index, field, value) {
+    setInvokeForm((current) => ({
+      ...current,
+      args: current.args.map((arg, argIndex) => (
+        argIndex === index ? { ...arg, [field]: value } : arg
+      )),
+    }))
+  }
+
+  function addArgument() {
+    setInvokeForm((current) => ({
+      ...current,
+      args: [...current.args, { type: 'string', value: '' }],
+    }))
+  }
+
+  function removeArgument(index) {
+    setInvokeForm((current) => ({
+      ...current,
+      args: current.args.filter((_, argIndex) => argIndex !== index),
+    }))
+  }
 
   async function handleFetch() {
-    const id = input.trim()
+    const id = inspectInput.trim()
     setContractId(id)
     setContractError(null)
     setContractData(null)
-    setLedgerEntries([])
 
-    if (!id) { setContractError('Enter a contract ID'); return }
+    if (!id) {
+      setContractError('Enter a contract ID')
+      return
+    }
+
+    if (!isValidContractId(id)) {
+      setContractError('Enter a valid Soroban contract address')
+      return
+    }
 
     setContractLoading(true)
     try {
-      const server = getSorobanServer(network)
       const result = await fetchContractInfo(id, network)
       setContractData(result)
-    } catch (e) {
-      setContractError(e.message || 'Failed to fetch contract')
+      setInvokeForm((current) => ({ ...current, contractId: id }))
+    } catch (error) {
+      setContractError(error.message || 'Failed to fetch contract')
     } finally {
       setContractLoading(false)
+    }
+  }
+
+  async function handleSimulate() {
+    setInvokeError('')
+    setSubmitResult(null)
+    setSimulationResult(null)
+    setSimulateLoading(true)
+
+    try {
+      const result = await simulateContractCall(invocationPreview)
+      setSimulationResult(result)
+    } catch (error) {
+      setInvokeError(error.message || 'Simulation failed')
+    } finally {
+      setSimulateLoading(false)
+    }
+  }
+
+  async function handleSubmit() {
+    setInvokeError('')
+    setSubmitResult(null)
+    setSubmitLoading(true)
+
+    try {
+      const result = await invokeContract({
+        contractId: invocationPreview.contractId,
+        functionName: invocationPreview.functionName,
+        args: invocationPreview.args,
+        secretKey: invokeForm.secretKey,
+        network,
+      })
+      setSubmitResult(result)
+    } catch (error) {
+      setInvokeError(error.message || 'Submission failed')
+    } finally {
+      setSubmitLoading(false)
     }
   }
 
@@ -32,129 +262,202 @@ export default function Contracts() {
     <div className="animate-in" style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
       <div style={{ fontFamily: 'var(--font-display)', fontSize: '22px', fontWeight: 700 }}>Soroban Contracts</div>
 
-      {/* Search */}
-      <div style={{
-        background: 'var(--bg-card)',
-        border: '1px solid var(--border)',
-        borderRadius: 'var(--radius-lg)',
-        padding: '20px',
-      }}>
-        <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '12px', letterSpacing: '0.5px' }}>
-          Enter a Soroban contract address (C...) to inspect
-        </div>
-        <div style={{ display: 'flex', gap: '10px' }}>
+      <Panel
+        title="Inspect Contract"
+        subtitle={`Read deployed contract data from ${NETWORKS[network].name}.`}
+      >
+        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
           <input
-            value={input}
-            onChange={e => setInput(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && handleFetch()}
+            value={inspectInput}
+            onChange={(event) => setInspectInput(event.target.value)}
+            onKeyDown={(event) => event.key === 'Enter' && handleFetch()}
             placeholder="C... contract address"
-            style={{
-              flex: 1,
-              background: 'var(--bg-elevated)',
-              border: `1px solid ${contractError ? 'var(--red)' : 'var(--border-bright)'}`,
-              borderRadius: 'var(--radius-md)',
-              padding: '10px 14px',
-              color: 'var(--text-primary)',
-              fontSize: '13px',
-              fontFamily: 'var(--font-mono)',
-              outline: 'none',
-              transition: 'var(--transition)',
-            }}
-            onFocus={e => e.target.style.borderColor = 'var(--cyan-dim)'}
-            onBlur={e => e.target.style.borderColor = contractError ? 'var(--red)' : 'var(--border-bright)'}
+            style={{ ...textInputStyle(inspectInputError), flex: 1, minWidth: '280px' }}
           />
-          <button
+          <ActionButton
+            label={contractLoading ? 'Loading...' : 'Inspect'}
             onClick={handleFetch}
             disabled={contractLoading}
-            style={{
-              padding: '10px 20px',
-              background: contractLoading ? 'var(--bg-elevated)' : 'var(--cyan)',
-              color: contractLoading ? 'var(--text-muted)' : 'var(--bg-base)',
-              border: 'none',
-              borderRadius: 'var(--radius-md)',
-              fontFamily: 'var(--font-mono)',
-              fontWeight: 700,
-              fontSize: '13px',
-              cursor: contractLoading ? 'not-allowed' : 'pointer',
-              transition: 'var(--transition)',
-              display: 'flex',
-              alignItems: 'center',
-              gap: '8px',
-            }}
-          >
-            {contractLoading ? <><div className="spinner" /> Loading</> : 'INSPECT →'}
-          </button>
+          />
         </div>
         {contractError && (
-          <div style={{ marginTop: '10px', fontSize: '12px', color: 'var(--red)' }}>✗ {contractError}</div>
-        )}
-      </div>
-
-      {/* Contract data */}
-      {contractData && (
-        <div className="animate-in">
-          <div style={{ background: 'var(--bg-card)', border: '1px solid var(--cyan-dim)', borderRadius: 'var(--radius-lg)', overflow: 'hidden', boxShadow: '0 0 24px var(--cyan-glow-sm)' }}>
-            <div style={{ padding: '14px 18px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: '10px' }}>
-              <span style={{ width: '8px', height: '8px', borderRadius: '50%', background: 'var(--green)', display: 'inline-block' }} />
-              <div style={{ fontFamily: 'var(--font-display)', fontWeight: 600, fontSize: '13px' }}>Contract Found</div>
-            </div>
-            <div style={{ padding: '16px 18px' }}>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px', letterSpacing: '1px' }}>CONTRACT DATA</div>
-              <pre style={{
-                background: 'var(--bg-elevated)',
-                border: '1px solid var(--border)',
-                borderRadius: 'var(--radius-md)',
-                padding: '14px',
-                fontSize: '11px',
-                color: 'var(--text-secondary)',
-                overflowX: 'auto',
-                lineHeight: 1.6,
-                fontFamily: 'var(--font-mono)',
-              }}>
-                {JSON.stringify(contractData, null, 2)}
-              </pre>
-            </div>
+          <div style={{ marginTop: '12px', fontSize: '12px', color: 'var(--red)' }}>
+            {contractError}
           </div>
+        )}
+      </Panel>
+
+      {contractData && (
+        <ResultBlock label="Contract Data" data={contractData} />
+      )}
+
+      <Panel
+        title="Invoke Contract"
+        subtitle="Build a contract call, simulate it through Soroban RPC, and optionally submit it on Testnet using a secret key."
+      >
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))', gap: '14px', marginBottom: '18px' }}>
+          <LabeledField label="Contract ID">
+            <input
+              value={invokeForm.contractId}
+              onChange={(event) => updateField('contractId', event.target.value)}
+              placeholder="C... contract address"
+              style={textInputStyle(invokeContractError)}
+            />
+          </LabeledField>
+
+          <LabeledField label="Function">
+            <input
+              value={invokeForm.functionName}
+              onChange={(event) => updateField('functionName', event.target.value)}
+              placeholder="increment"
+              style={textInputStyle()}
+            />
+          </LabeledField>
+
+          <LabeledField label="Source Account">
+            <input
+              value={invokeForm.sourceAccount}
+              onChange={(event) => updateField('sourceAccount', event.target.value)}
+              placeholder={connectedAddress || 'G... source account'}
+              style={textInputStyle()}
+            />
+          </LabeledField>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '12px', gap: '12px', flexWrap: 'wrap' }}>
+          <div style={{ fontSize: '11px', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.8px' }}>
+            Typed Arguments
+          </div>
+          <ActionButton label="Add Argument" onClick={addArgument} tone="secondary" />
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', marginBottom: '18px' }}>
+          {invokeForm.args.map((arg, index) => (
+            <div key={index} style={{ display: 'grid', gridTemplateColumns: '140px 1fr auto', gap: '10px', alignItems: 'center' }}>
+              <select
+                value={arg.type}
+                onChange={(event) => updateArgument(index, 'type', event.target.value)}
+                style={textInputStyle()}
+              >
+                {ARGUMENT_TYPES.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+
+              <input
+                value={arg.value}
+                onChange={(event) => updateArgument(index, 'value', event.target.value)}
+                placeholder={arg.type === 'bool' ? 'true or false' : 'Argument value'}
+                style={textInputStyle()}
+              />
+
+              <ActionButton
+                label="Remove"
+                onClick={() => removeArgument(index)}
+                disabled={invokeForm.args.length === 1}
+                tone="secondary"
+              />
+            </div>
+          ))}
+        </div>
+
+        <div style={{
+          marginBottom: '18px',
+          padding: '14px',
+          borderRadius: 'var(--radius-md)',
+          border: `1px solid ${isMainnet ? 'var(--amber)' : 'var(--border)'}`,
+          background: isMainnet ? 'rgba(255, 184, 0, 0.08)' : 'var(--bg-elevated)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '10px',
+        }}>
+          <div style={{ fontSize: '12px', color: isMainnet ? 'var(--amber)' : 'var(--text-secondary)', lineHeight: 1.6 }}>
+            {isMainnet
+              ? 'Mainnet safety mode is active. Simulation still works, but transaction submission is disabled.'
+              : 'Submission is available on Testnet only. Your secret key is used locally to sign the prepared transaction before it is sent to Soroban RPC.'}
+          </div>
+
+          <LabeledField label="Secret Key For Submit">
+            <input
+              type="password"
+              value={invokeForm.secretKey}
+              onChange={(event) => updateField('secretKey', event.target.value)}
+              placeholder="S... testnet secret key"
+              style={textInputStyle()}
+            />
+          </LabeledField>
+        </div>
+
+        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+          <ActionButton
+            label={simulateLoading ? 'Simulating...' : 'Simulate'}
+            onClick={handleSimulate}
+            disabled={simulateLoading || submitLoading}
+          />
+          <ActionButton
+            label={submitLoading ? 'Submitting...' : 'Submit'}
+            onClick={handleSubmit}
+            disabled={isMainnet || submitLoading || simulateLoading}
+            tone="secondary"
+          />
+        </div>
+
+        {invokeError && (
+          <div style={{ marginTop: '14px', fontSize: '12px', color: 'var(--red)', lineHeight: 1.5 }}>
+            {invokeError}
+          </div>
+        )}
+      </Panel>
+
+      {simulationResult && (
+        <div style={{ display: 'grid', gap: '16px' }}>
+          <ResultBlock
+            label="Simulation Summary"
+            data={{
+              result: simulationResult.result,
+              cost: simulationResult.cost,
+              latestLedger: simulationResult.latestLedger,
+              transactionXdr: simulationResult.xdr,
+            }}
+          />
+          <ResultBlock label="Simulation Events" data={simulationResult.events} />
+          <ResultBlock label="Simulation Footprint" data={simulationResult.footprint} />
         </div>
       )}
 
-      {/* Info panel when empty */}
+      {submitResult && (
+        <ResultBlock label="Submission Result" data={submitResult} />
+      )}
+
       {!contractData && !contractLoading && !contractError && (
-        <div style={{
-          background: 'var(--bg-card)',
-          border: '1px solid var(--border)',
-          borderRadius: 'var(--radius-lg)',
-          padding: '32px',
-          textAlign: 'center',
-        }}>
-          <div style={{ fontSize: '32px', marginBottom: '12px', opacity: 0.4 }}>◻</div>
-          <div style={{ fontFamily: 'var(--font-display)', fontSize: '15px', fontWeight: 600, marginBottom: '6px' }}>
-            Soroban Contract Explorer
-          </div>
-          <div style={{ fontSize: '12px', color: 'var(--text-muted)', maxWidth: '340px', margin: '0 auto', lineHeight: 1.6 }}>
-            Enter a contract address above to inspect its ledger data, instance storage, and WASM hash on {network === 'testnet' ? 'Testnet' : 'Mainnet'}.
-          </div>
-          <div style={{ marginTop: '20px', display: 'flex', gap: '12px', justifyContent: 'center', flexWrap: 'wrap' }}>
+        <Panel
+          title="Contract Toolkit"
+          subtitle={`Inspect storage, simulate calls, and safely test submissions against ${NETWORKS[network].name}.`}
+        >
+          <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
             {[
-              { label: 'Contract Instance', desc: 'View Wasm hash & storage' },
-              { label: 'Ledger Keys', desc: 'Inspect persistent data' },
-              { label: 'Network RPC', desc: NETWORKS[network].sorobanUrl },
-            ].map(item => (
+              { label: 'Storage Inspector', desc: 'Look up deployed instance data.' },
+              { label: 'Call Simulator', desc: 'Preview return values, events, and footprint.' },
+              { label: 'RPC Endpoint', desc: NETWORKS[network].sorobanUrl },
+            ].map((item) => (
               <div key={item.label} style={{
                 background: 'var(--bg-elevated)',
                 border: '1px solid var(--border)',
                 borderRadius: 'var(--radius-md)',
-                padding: '10px 14px',
-                fontSize: '12px',
-                textAlign: 'left',
-                minWidth: '180px',
+                padding: '12px 14px',
+                minWidth: '190px',
+                flex: '1 1 190px',
               }}>
-                <div style={{ color: 'var(--text-primary)', fontWeight: 600, marginBottom: '3px' }}>{item.label}</div>
-                <div style={{ color: 'var(--text-muted)', fontSize: '11px' }}>{item.desc}</div>
+                <div style={{ color: 'var(--text-primary)', fontWeight: 600, marginBottom: '4px', fontSize: '12px' }}>
+                  {item.label}
+                </div>
+                <div style={{ color: 'var(--text-muted)', fontSize: '11px', lineHeight: 1.6 }}>
+                  {item.desc}
+                </div>
               </div>
             ))}
           </div>
-        </div>
+        </Panel>
       )}
     </div>
   )

--- a/src/lib/stellar.js
+++ b/src/lib/stellar.js
@@ -96,6 +96,436 @@ export async function fetchContractInfo(contractId, network = 'testnet') {
   }
 }
 
+function getLedgerKeyType(key) {
+  const kind = key.switch()
+  return kind?.name || kind?.toString?.() || 'unknown'
+}
+
+function serializeLedgerKey(key) {
+  return {
+    type: getLedgerKeyType(key),
+    xdr: key.toXDR('base64'),
+  }
+}
+
+function serializeScVal(value) {
+  try {
+    return StellarSdk.scValToNative(value)
+  } catch {
+    return value.toXDR('base64')
+  }
+}
+
+function serializeDiagnosticEvent(event) {
+  const contractEvent = event.event()
+  const body = contractEvent.body().v0()
+  const contractId = contractEvent.contractId()
+
+  return {
+    inSuccessfulContractCall: event.inSuccessfulContractCall(),
+    type: contractEvent.type().name || contractEvent.type().toString(),
+    contractId: contractId ? StellarSdk.Address.fromScAddress(contractId).toString() : null,
+    topics: body.topics().map(serializeScVal),
+    value: serializeScVal(body.data()),
+  }
+}
+
+function parseContractArgument({ type, value }, index) {
+  const trimmedValue = value?.trim?.() ?? ''
+
+  if (trimmedValue === '') {
+    throw new Error(`Argument ${index + 1} is empty`)
+  }
+
+  switch (type) {
+    case 'string':
+      return StellarSdk.nativeToScVal(trimmedValue, { type: 'string' })
+    case 'int': {
+      let parsed
+      try {
+        parsed = BigInt(trimmedValue)
+      } catch {
+        throw new Error(`Argument ${index + 1} must be a valid integer`)
+      }
+      return StellarSdk.nativeToScVal(parsed, { type: 'i128' })
+    }
+    case 'address':
+      try {
+        return StellarSdk.Address.fromString(trimmedValue).toScVal()
+      } catch {
+        throw new Error(`Argument ${index + 1} must be a valid Stellar address`)
+      }
+    case 'bool':
+      if (trimmedValue !== 'true' && trimmedValue !== 'false') {
+        throw new Error(`Argument ${index + 1} must be true or false`)
+      }
+      return StellarSdk.nativeToScVal(trimmedValue === 'true', { type: 'bool' })
+    default:
+      throw new Error(`Unsupported argument type: ${type}`)
+  }
+}
+
+async function buildContractInvocationTransaction({
+  contractId,
+  functionName,
+  args = [],
+  sourceAccount,
+  network = 'testnet',
+}) {
+  if (!isValidContractId(contractId)) {
+    throw new Error('Invalid contract address')
+  }
+
+  if (!functionName?.trim()) {
+    throw new Error('Function name is required')
+  }
+
+  if (!isValidPublicKey(sourceAccount)) {
+    throw new Error('A valid source account is required')
+  }
+
+  const horizon = getServer(network)
+  const account = await horizon.loadAccount(sourceAccount)
+  const contract = new StellarSdk.Contract(contractId.trim())
+  const parsedArgs = args.map(parseContractArgument)
+
+  return new StellarSdk.TransactionBuilder(account, {
+    fee: StellarSdk.BASE_FEE.toString(),
+    networkPassphrase: NETWORKS[network].passphrase,
+  })
+    .setTimeout(30)
+    .addOperation(contract.call(functionName.trim(), ...parsedArgs))
+    .build()
+}
+
+export async function simulateContractCall({
+  contractId,
+  functionName,
+  args = [],
+  sourceAccount,
+  network = 'testnet',
+}) {
+  const server = getSorobanServer(network)
+  const transaction = await buildContractInvocationTransaction({
+    contractId,
+    functionName,
+    args,
+    sourceAccount,
+    network,
+  })
+
+  const simulation = await server.simulateTransaction(transaction)
+
+  if (simulation.error) {
+    throw new Error(simulation.error)
+  }
+
+  const footprint = simulation.transactionData
+    ? {
+        readOnly: simulation.transactionData.getReadOnly().map(serializeLedgerKey),
+        readWrite: simulation.transactionData.getReadWrite().map(serializeLedgerKey),
+        minResourceFee: simulation.minResourceFee,
+      }
+    : null
+
+  return {
+    xdr: transaction.toXDR(),
+    latestLedger: simulation.latestLedger,
+    cost: simulation.cost,
+    result: simulation.result ? serializeScVal(simulation.result.retval) : null,
+    events: (simulation.events || []).map(serializeDiagnosticEvent),
+    footprint,
+  }
+}
+
+export async function invokeContract({
+  contractId,
+  functionName,
+  args = [],
+  secretKey,
+  network = 'testnet',
+}) {
+  if (network !== 'testnet') {
+    throw new Error('Transaction submission is only enabled on Testnet')
+  }
+
+  if (!secretKey?.trim()) {
+    throw new Error('Secret key is required to submit a transaction')
+  }
+
+  let keypair
+  try {
+    keypair = StellarSdk.Keypair.fromSecret(secretKey.trim())
+  } catch {
+    throw new Error('Invalid secret key')
+  }
+
+  const sourceAccount = keypair.publicKey()
+  const server = getSorobanServer(network)
+  const transaction = await buildContractInvocationTransaction({
+    contractId,
+    functionName,
+    args,
+    sourceAccount,
+    network,
+  })
+  const prepared = await server.prepareTransaction(transaction)
+
+  prepared.sign(keypair)
+
+  const response = await server.sendTransaction(prepared)
+
+  return {
+    hash: response.hash,
+    status: response.status,
+    errorResult: response.errorResult ? response.errorResult.toXDR('base64') : null,
+    diagnosticEvents: (response.diagnosticEvents || []).map(event => event.toXDR('base64')),
+  }
+}
+
+function normalizeContractValue(value) {
+  if (typeof value === 'bigint') return value.toString()
+  if (value instanceof Uint8Array) return Array.from(value)
+  if (Array.isArray(value)) return value.map(normalizeContractValue)
+
+  if (value && typeof value === 'object') {
+    if (typeof value.toString === 'function' && value.constructor && value.constructor.name === 'Address') {
+      return value.toString()
+    }
+
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, normalizeContractValue(entry)])
+    )
+  }
+
+  return value
+}
+
+function formatLedgerKey(key) {
+  return {
+    type: key.switch().name,
+    xdr: key.toXDR('base64'),
+  }
+}
+
+function formatFootprint(transactionData) {
+  if (!transactionData) return { readOnly: [], readWrite: [] }
+
+  return {
+    readOnly: transactionData.getReadOnly().map(formatLedgerKey),
+    readWrite: transactionData.getReadWrite().map(formatLedgerKey),
+  }
+}
+
+function toContractScVal(arg, index) {
+  const value = arg.value?.trim?.() ?? ''
+
+  switch (arg.type) {
+    case 'string':
+      return StellarSdk.nativeToScVal(value)
+    case 'int':
+      if (!value) throw new Error(`Argument ${index + 1}: Enter an integer value`)
+      try {
+        return StellarSdk.nativeToScVal(BigInt(value), { type: 'i128' })
+      } catch {
+        throw new Error(`Argument ${index + 1}: Invalid integer value`)
+      }
+    case 'address':
+      if (!value) throw new Error(`Argument ${index + 1}: Enter an address`)
+      try {
+        return StellarSdk.Address.fromString(value).toScVal()
+      } catch {
+        throw new Error(`Argument ${index + 1}: Invalid Stellar address`)
+      }
+    case 'bool':
+      if (value !== 'true' && value !== 'false') {
+        throw new Error(`Argument ${index + 1}: Boolean values must be true or false`)
+      }
+      return StellarSdk.nativeToScVal(value === 'true')
+    default:
+      throw new Error(`Argument ${index + 1}: Unsupported argument type`)
+  }
+}
+
+async function buildContractInvocationTransaction({
+  sourceAccount,
+  contractId,
+  functionName,
+  args = [],
+  network = 'testnet',
+  fee = StellarSdk.BASE_FEE,
+}) {
+  if (!sourceAccount || !isValidPublicKey(sourceAccount)) {
+    throw new Error('Enter a valid source account public key')
+  }
+
+  if (!contractId || !isValidContractId(contractId)) {
+    throw new Error('Enter a valid contract ID')
+  }
+
+  if (!functionName?.trim()) {
+    throw new Error('Enter a contract function name')
+  }
+
+  const account = await getServer(network).loadAccount(sourceAccount)
+  const contract = new StellarSdk.Contract(contractId)
+  const scArgs = args.map(toContractScVal)
+
+  return new StellarSdk.TransactionBuilder(account, {
+    fee: String(fee),
+    networkPassphrase: NETWORKS[network].passphrase,
+  })
+    .addOperation(contract.call(functionName.trim(), ...scArgs))
+    .setTimeout(30)
+    .build()
+}
+
+function formatSimulation(simulation) {
+  const isSuccess = StellarSdk.SorobanRpc.Api.isSimulationSuccess(simulation)
+  const isRestore = StellarSdk.SorobanRpc.Api.isSimulationRestore(simulation)
+
+  return {
+    success: isSuccess,
+    error: simulation.error || null,
+    latestLedger: simulation.latestLedger,
+    cost: simulation.cost || null,
+    minResourceFee: simulation.minResourceFee || null,
+    result: simulation.result ? normalizeContractValue(StellarSdk.scValToNative(simulation.result.retval)) : null,
+    resultXdr: simulation.result?.retval?.toXDR('base64') || null,
+    auth: simulation.result?.auth?.map((entry) => entry.toXDR('base64')) || [],
+    events: StellarSdk.humanizeEvents(simulation.events || []).map(normalizeContractValue),
+    footprint: isSuccess ? formatFootprint(simulation.transactionData) : { readOnly: [], readWrite: [] },
+    stateChanges: simulation.stateChanges?.map((change) => ({
+      type: change.type,
+      key: change.key.toXDR('base64'),
+      before: change.before ? change.before.toXDR('base64') : null,
+      after: change.after ? change.after.toXDR('base64') : null,
+    })) || [],
+    restoreRequired: isRestore,
+    restorePreamble: isRestore ? {
+      minResourceFee: simulation.restorePreamble.minResourceFee,
+      footprint: formatFootprint(simulation.restorePreamble.transactionData),
+    } : null,
+  }
+}
+
+async function waitForTransaction(server, hash, attempts = 12, delayMs = 1500) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const response = await server.getTransaction(hash)
+
+    if (response.status !== StellarSdk.SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
+      return response
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delayMs))
+  }
+
+  return null
+}
+
+function formatSubmittedTransaction(transaction) {
+  if (!transaction) return null
+
+  const diagnosticEvents = transaction.diagnosticEventsXdr
+    ? StellarSdk.humanizeEvents(transaction.diagnosticEventsXdr).map(normalizeContractValue)
+    : []
+
+  return {
+    status: transaction.status,
+    ledger: transaction.ledger,
+    createdAt: transaction.createdAt,
+    returnValue: transaction.returnValue
+      ? normalizeContractValue(StellarSdk.scValToNative(transaction.returnValue))
+      : null,
+    returnValueXdr: transaction.returnValue?.toXDR('base64') || null,
+    events: diagnosticEvents,
+    resultXdr: transaction.resultXdr?.toXDR('base64') || null,
+  }
+}
+
+export async function simulateContractCall({
+  sourceAccount,
+  contractId,
+  functionName,
+  args = [],
+  network = 'testnet',
+}) {
+  const server = getSorobanServer(network)
+  const transaction = await buildContractInvocationTransaction({
+    sourceAccount,
+    contractId,
+    functionName,
+    args,
+    network,
+  })
+  const simulation = await server.simulateTransaction(transaction)
+
+  return {
+    transactionXdr: transaction.toXDR(),
+    ...formatSimulation(simulation),
+  }
+}
+
+export async function invokeContract({
+  contractId,
+  functionName,
+  args = [],
+  secretKey,
+  sourceAccount,
+  network = 'testnet',
+}) {
+  if (network !== 'testnet') {
+    throw new Error('Submitting contract invocations is only enabled on Testnet')
+  }
+
+  const trimmedSecret = secretKey?.trim()
+  if (!trimmedSecret || !StellarSdk.StrKey.isValidEd25519SecretSeed(trimmedSecret)) {
+    throw new Error('Enter a valid Stellar secret key')
+  }
+
+  const keypair = StellarSdk.Keypair.fromSecret(trimmedSecret)
+  const derivedSourceAccount = keypair.publicKey()
+
+  if (sourceAccount && sourceAccount !== derivedSourceAccount) {
+    throw new Error('Source account must match the provided secret key')
+  }
+
+  const server = getSorobanServer(network)
+  const transaction = await buildContractInvocationTransaction({
+    sourceAccount: derivedSourceAccount,
+    contractId,
+    functionName,
+    args,
+    network,
+  })
+
+  const preparedTransaction = await server.prepareTransaction(transaction)
+  preparedTransaction.sign(keypair)
+
+  const sendResponse = await server.sendTransaction(preparedTransaction)
+
+  if (sendResponse.status === 'ERROR') {
+    throw new Error(sendResponse.errorResult
+      ? sendResponse.errorResult.toXDR('base64')
+      : 'Soroban RPC rejected the transaction')
+  }
+
+  const finalized = await waitForTransaction(server, sendResponse.hash)
+
+  if (finalized?.status === StellarSdk.SorobanRpc.Api.GetTransactionStatus.FAILED) {
+    throw new Error(finalized.resultXdr?.toXDR('base64') || 'Submitted transaction failed')
+  }
+
+  return {
+    hash: sendResponse.hash,
+    sendStatus: sendResponse.status,
+    latestLedger: sendResponse.latestLedger,
+    transactionXdr: preparedTransaction.toXDR(),
+    transaction: formatSubmittedTransaction(finalized),
+    pending: !finalized,
+  }
+}
+
 export function isValidPublicKey(key) {
   return StellarSdk.StrKey.isValidEd25519PublicKey(key)
 }

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -99,6 +99,20 @@ export async function fetchNetworkStats(network: NetworkName = 'testnet'): Promi
   }
 }
 
+export function streamLedgers(
+  callback: (ledger: StellarSdk.Horizon.ServerApi.LedgerRecord) => void,
+  network: NetworkName = 'testnet'
+): () => void {
+  const server = getServer(network)
+  return server
+    .ledgers()
+    .cursor('now')
+    .stream({
+      onmessage: (ledger) => callback(ledger as unknown as StellarSdk.Horizon.ServerApi.LedgerRecord),
+      onerror: () => {},
+    })
+}
+
 // ─── Faucet ───────────────────────────────────────────────────────────────────
 
 export async function fundTestnetAccount(publicKey: string): Promise<unknown> {
@@ -123,6 +137,251 @@ export async function fetchContractInfo(
     return instance
   } catch (e) {
     throw new Error(`Contract not found: ${(e as Error).message}`)
+  }
+}
+
+export interface ContractInvocationArg {
+  type: 'string' | 'int' | 'address' | 'bool'
+  value: string
+}
+
+export interface SerializedLedgerKey {
+  type: string
+  xdr: string
+}
+
+export interface SerializedContractEvent {
+  inSuccessfulContractCall: boolean
+  type: string
+  contractId: string | null
+  topics: unknown[]
+  value: unknown
+}
+
+export interface ContractSimulationResult {
+  xdr: string
+  latestLedger: number
+  cost?: StellarSdk.SorobanRpc.Api.Cost
+  result: unknown
+  events: SerializedContractEvent[]
+  footprint: {
+    readOnly: SerializedLedgerKey[]
+    readWrite: SerializedLedgerKey[]
+    minResourceFee: string
+  } | null
+}
+
+export interface ContractSubmitResult {
+  hash: string
+  status: StellarSdk.SorobanRpc.Api.SendTransactionStatus
+  errorResult: string | null
+  diagnosticEvents: string[]
+}
+
+function getLedgerKeyType(key: StellarSdk.xdr.LedgerKey): string {
+  const kind = key.switch()
+  return kind?.name || kind?.toString?.() || 'unknown'
+}
+
+function serializeLedgerKey(key: StellarSdk.xdr.LedgerKey): SerializedLedgerKey {
+  return {
+    type: getLedgerKeyType(key),
+    xdr: key.toXDR('base64'),
+  }
+}
+
+function serializeScVal(value: StellarSdk.xdr.ScVal): unknown {
+  try {
+    return StellarSdk.scValToNative(value)
+  } catch {
+    return value.toXDR('base64')
+  }
+}
+
+function serializeDiagnosticEvent(
+  event: StellarSdk.xdr.DiagnosticEvent
+): SerializedContractEvent {
+  const contractEvent = event.event()
+  const body = contractEvent.body().v0()
+  const contractId = contractEvent.contractId()
+
+  return {
+    inSuccessfulContractCall: event.inSuccessfulContractCall(),
+    type: contractEvent.type().name || contractEvent.type().toString(),
+    contractId: contractId ? StellarSdk.Address.fromScAddress(contractId).toString() : null,
+    topics: body.topics().map(serializeScVal),
+    value: serializeScVal(body.data()),
+  }
+}
+
+function parseContractArgument(
+  arg: ContractInvocationArg,
+  index: number
+): StellarSdk.xdr.ScVal {
+  const trimmedValue = arg.value?.trim?.() ?? ''
+
+  if (!trimmedValue) {
+    throw new Error(`Argument ${index + 1} is empty`)
+  }
+
+  switch (arg.type) {
+    case 'string':
+      return StellarSdk.nativeToScVal(trimmedValue, { type: 'string' })
+    case 'int': {
+      let parsed: bigint
+      try {
+        parsed = BigInt(trimmedValue)
+      } catch {
+        throw new Error(`Argument ${index + 1} must be a valid integer`)
+      }
+      return StellarSdk.nativeToScVal(parsed, { type: 'i128' })
+    }
+    case 'address':
+      try {
+        return StellarSdk.Address.fromString(trimmedValue).toScVal()
+      } catch {
+        throw new Error(`Argument ${index + 1} must be a valid Stellar address`)
+      }
+    case 'bool':
+      if (trimmedValue !== 'true' && trimmedValue !== 'false') {
+        throw new Error(`Argument ${index + 1} must be true or false`)
+      }
+      return StellarSdk.nativeToScVal(trimmedValue === 'true', { type: 'bool' })
+    default:
+      throw new Error(`Unsupported argument type: ${arg.type}`)
+  }
+}
+
+interface BuildContractInvocationParams {
+  contractId: string
+  functionName: string
+  args?: ContractInvocationArg[]
+  sourceAccount: string
+  network?: NetworkName
+}
+
+async function buildContractInvocationTransaction(
+  params: BuildContractInvocationParams
+): Promise<StellarSdk.Transaction> {
+  const {
+    contractId,
+    functionName,
+    args = [],
+    sourceAccount,
+    network = 'testnet',
+  } = params
+
+  if (!isValidContractId(contractId)) {
+    throw new Error('Invalid contract address')
+  }
+
+  if (!functionName.trim()) {
+    throw new Error('Function name is required')
+  }
+
+  if (!isValidPublicKey(sourceAccount)) {
+    throw new Error('A valid source account is required')
+  }
+
+  const horizon = getServer(network)
+  const account = await horizon.loadAccount(sourceAccount)
+  const contract = new StellarSdk.Contract(contractId.trim())
+  const parsedArgs = args.map(parseContractArgument)
+
+  return new StellarSdk.TransactionBuilder(account, {
+    fee: StellarSdk.BASE_FEE.toString(),
+    networkPassphrase: NETWORKS[network].passphrase,
+  })
+    .setTimeout(30)
+    .addOperation(contract.call(functionName.trim(), ...parsedArgs))
+    .build()
+}
+
+export async function simulateContractCall(
+  params: BuildContractInvocationParams
+): Promise<ContractSimulationResult> {
+  const { network = 'testnet' } = params
+  const server = getSorobanServer(network)
+  const transaction = await buildContractInvocationTransaction(params)
+  const simulation = await server.simulateTransaction(transaction)
+
+  if ('error' in simulation && simulation.error) {
+    throw new Error(simulation.error)
+  }
+
+  const successfulSimulation = simulation as Exclude<
+    StellarSdk.SorobanRpc.Api.SimulateTransactionResponse,
+    StellarSdk.SorobanRpc.Api.SimulateTransactionErrorResponse
+  >
+
+  const footprint = successfulSimulation.transactionData
+    ? {
+        readOnly: successfulSimulation.transactionData.getReadOnly().map(serializeLedgerKey),
+        readWrite: successfulSimulation.transactionData.getReadWrite().map(serializeLedgerKey),
+        minResourceFee: successfulSimulation.minResourceFee,
+      }
+    : null
+
+  return {
+    xdr: transaction.toXDR(),
+    latestLedger: successfulSimulation.latestLedger,
+    cost: successfulSimulation.cost,
+    result: successfulSimulation.result ? serializeScVal(successfulSimulation.result.retval) : null,
+    events: (successfulSimulation.events || []).map(serializeDiagnosticEvent),
+    footprint,
+  }
+}
+
+interface InvokeContractParams {
+  contractId: string
+  functionName: string
+  args?: ContractInvocationArg[]
+  secretKey: string
+  network?: NetworkName
+}
+
+export async function invokeContract(
+  params: InvokeContractParams
+): Promise<ContractSubmitResult> {
+  const { contractId, functionName, args = [], secretKey, network = 'testnet' } = params
+
+  if (network !== 'testnet') {
+    throw new Error('Transaction submission is only enabled on Testnet')
+  }
+
+  if (!secretKey.trim()) {
+    throw new Error('Secret key is required to submit a transaction')
+  }
+
+  let keypair: StellarSdk.Keypair
+  try {
+    keypair = StellarSdk.Keypair.fromSecret(secretKey.trim())
+  } catch {
+    throw new Error('Invalid secret key')
+  }
+
+  const sourceAccount = keypair.publicKey()
+  const server = getSorobanServer(network)
+  const transaction = await buildContractInvocationTransaction({
+    contractId,
+    functionName,
+    args,
+    sourceAccount,
+    network,
+  })
+  const prepared = await server.prepareTransaction(transaction)
+
+  prepared.sign(keypair)
+
+  const response = await server.sendTransaction(prepared)
+
+  return {
+    hash: response.hash,
+    status: response.status,
+    errorResult: response.errorResult ? response.errorResult.toXDR('base64') : null,
+    diagnosticEvents: (response.diagnosticEvents || []).map((event) =>
+      event.toXDR('base64')
+    ),
   }
 }
 


### PR DESCRIPTION
## What
Add a Soroban contract invocation panel to the Contracts tab.

## Why
Resolves #11
Developers need to simulate contract calls and inspect the return data before submitting transactions.

## How
Added RPC helpers to build, simulate, and submit contract invocations with typed arguments.
Updated the Contracts screen to collect contract/function inputs, decode simulation output, and gate transaction submission to Testnet with a clear warning.
Kept the TypeScript helper module in sync and restored the missing ledger stream export so type checks pass.

## Testing
npm run build
./node_modules/.bin/tsc --noEmit --pretty false