### PR TITLE
feat: intelligent caching with L1/L2, SWR, offline support

### DIFF
--- a/src/hooks/useCachedData.js
+++ b/src/hooks/useCachedData.js
@@ -1,157 +1,375 @@
 /**
- * Cached Data Hook
- * React hook for fetching and caching data with automatic revalidation
+ * useCachedData — React hooks for intelligent data fetching with caching
+ *
+ * Hooks exported:
+ *   useCachedData          — generic SWR-style fetch with L1/L2 cache
+ *   useCachedAccount       — Stellar account with tag-based invalidation
+ *   useCachedTransactions  — paginated transaction history
+ *   useCachedNetworkStats  — network stats with short TTL
+ *   useCachedPaginatedData — generic paginated fetch
+ *   useCachedItem          — single-item fetch by id
+ *   useOfflineStatus       — online/offline state + queue length
+ *   useCacheStats          — live cache statistics for a debug panel
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react';
-import cache from '../lib/cache';
+import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from 'react';
+import cache, { TTL, isOffline } from '../lib/cache.js';
+import {
+  getCachedApiResponse,
+  setCachedApiResponse,
+  getOfflineQueue,
+} from '../lib/storage.js';
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function noop() {}
 
 /**
- * Custom hook for fetching and caching data
- * @param {string} cacheKey - Unique key for caching
- * @param {Function} fetchFn - Async function to fetch data
- * @param {Object} options - Configuration options
- * @param {number} options.ttl - Time to live in milliseconds
- * @param {boolean} options.forceRefresh - Force refresh cache
- * @param {Array} options.dependencies - Dependencies for refetch
- * @returns {Object} { data, loading, error, refetch, isCached }
+ * Deduplicate in-flight requests: if two hooks request the same key
+ * simultaneously, only one network call is made.
  */
-function useCachedData(cacheKey, fetchFn, options = {}) {
-  const {
-    ttl = 60000,
-    forceRefresh = false,
-    dependencies = [],
-  } = options;
-  
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [isCached, setIsCached] = useState(false);
-  const isMounted = useRef(true);
-  const abortControllerRef = useRef(null);
+const _inflight = new Map(); // key → Promise
 
-  const fetchData = useCallback(async (skipCache = false) => {
-    // Cancel previous request
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-    
-    abortControllerRef.current = new AbortController();
-    
-    setLoading(true);
-    setError(null);
-    
-    try {
-      let cachedData = null;
-      
-      // Check cache first
-      if (!skipCache && !forceRefresh) {
-        cachedData = cache.get(cacheKey);
-        if (cachedData) {
-          if (isMounted.current) {
-            setData(cachedData);
-            setIsCached(true);
+async function deduplicatedFetch(key, fetcher) {
+  if (_inflight.has(key)) return _inflight.get(key);
+  const p = fetcher().finally(() => _inflight.delete(key));
+  _inflight.set(key, p);
+  return p;
+}
+
+// ─── useCachedData ────────────────────────────────────────────────────────────
+
+/**
+ * Generic SWR-style hook.
+ *
+ * @param {string|null}  cacheKey   Unique key. Pass null to skip fetching.
+ * @param {Function}     fetchFn    async () => data
+ * @param {object}       [opts]
+ * @param {number}       [opts.ttl]           TTL in ms (default: TTL.ACCOUNT)
+ * @param {string[]}     [opts.tags]          Cache tags for invalidation
+ * @param {boolean}      [opts.enabled]       Set false to pause fetching
+ * @param {boolean}      [opts.persist]       Also read/write IndexedDB
+ * @param {number}       [opts.refreshInterval] Auto-refresh interval in ms
+ * @param {Array}        [opts.deps]          Extra deps that trigger refetch
+ * @param {Function}     [opts.onSuccess]     (data) => void
+ * @param {Function}     [opts.onError]       (err) => void
+ *
+ * @returns {{ data, loading, error, stale, source, refetch, invalidate }}
+ */
+export function useCachedData(cacheKey, fetchFn, opts = {}) {
+  const {
+    ttl             = TTL.ACCOUNT,
+    tags            = [],
+    enabled         = true,
+    persist         = false,
+    refreshInterval = 0,
+    deps            = [],
+    onSuccess       = noop,
+    onError         = noop,
+  } = opts;
+
+  const [data,    setData]    = useState(() => (cacheKey ? cache.get(cacheKey) : null));
+  const [loading, setLoading] = useState(false);
+  const [error,   setError]   = useState(null);
+  const [stale,   setStale]   = useState(false);
+  const [source,  setSource]  = useState('init');
+
+  const mountedRef  = useRef(true);
+  const fetchFnRef  = useRef(fetchFn);
+  fetchFnRef.current = fetchFn;
+
+  const doFetch = useCallback(async (skipCache = false) => {
+    if (!cacheKey || !enabled) return;
+
+    // 1. Try L1 memory cache
+    if (!skipCache) {
+      const { value, stale: isStale, source: src } = await cache.getWithFallback(cacheKey);
+      if (value !== null) {
+        if (mountedRef.current) {
+          setData(value);
+          setStale(isStale);
+          setSource(src);
+          setLoading(false);
+          setError(null);
+        }
+        if (!isStale) return; // Fresh — no network needed
+        // Stale — continue to background refresh below
+      }
+
+      // 2. Try L2 IndexedDB if persist=true
+      if (persist && !value) {
+        const stored = await getCachedApiResponse(cacheKey);
+        if (stored !== null) {
+          if (mountedRef.current) {
+            setData(stored);
+            setStale(true);
+            setSource('indexeddb');
             setLoading(false);
           }
+          // Still refresh in background
         }
       }
-      
-      // Always fetch fresh data in background for revalidation
-      const freshData = await fetchFn(abortControllerRef.current.signal);
-      
-      // Update cache with fresh data
-      cache.set(cacheKey, freshData, ttl);
-      
-      if (isMounted.current) {
-        setData(freshData);
-        setIsCached(false);
+    }
+
+    // 3. Network fetch (deduplicated)
+    if (!mountedRef.current) return;
+    setLoading(true);
+
+    try {
+      const fresh = await deduplicatedFetch(cacheKey, () => fetchFnRef.current());
+      cache.set(cacheKey, fresh, ttl, tags);
+      if (persist) setCachedApiResponse(cacheKey, fresh, ttl).catch(noop);
+
+      if (mountedRef.current) {
+        setData(fresh);
+        setStale(false);
+        setSource('network');
         setLoading(false);
         setError(null);
+        onSuccess(fresh);
       }
     } catch (err) {
-      if (err.name !== 'AbortError' && isMounted.current) {
+      if (mountedRef.current) {
         setError(err);
         setLoading(false);
+        onError(err);
       }
     }
-  }, [cacheKey, fetchFn, ttl, forceRefresh]);
+  }, [cacheKey, enabled, persist, ttl, tags.join(',')]); // eslint-disable-line
 
-  const refetch = useCallback(() => {
-    fetchData(true);
-  }, [fetchData]);
-
+  // Initial fetch + dep changes
   useEffect(() => {
-    isMounted.current = true;
-    fetchData();
-    
-    return () => {
-      isMounted.current = false;
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-    };
-  }, [cacheKey, ...dependencies]);
+    mountedRef.current = true;
+    doFetch();
+    return () => { mountedRef.current = false; };
+  }, [cacheKey, enabled, ...deps]); // eslint-disable-line
 
-  return {
-    data,
-    loading,
-    error,
-    refetch,
-    isCached,
-  };
+  // Auto-refresh interval
+  useEffect(() => {
+    if (!refreshInterval || !enabled || !cacheKey) return;
+    const id = setInterval(() => doFetch(true), refreshInterval);
+    return () => clearInterval(id);
+  }, [refreshInterval, enabled, cacheKey]); // eslint-disable-line
+
+  // Subscribe to cache updates from other hooks / background refreshes
+  useEffect(() => {
+    if (!cacheKey) return;
+    return cache.subscribe(cacheKey, (value) => {
+      if (mountedRef.current) {
+        setData(value);
+        setStale(false);
+        setSource('subscription');
+      }
+    });
+  }, [cacheKey]);
+
+  const refetch    = useCallback(() => doFetch(true), [doFetch]);
+  const invalidate = useCallback(() => {
+    if (cacheKey) cache.delete(cacheKey);
+    doFetch(true);
+  }, [cacheKey, doFetch]);
+
+  return { data, loading, error, stale, source, refetch, invalidate };
 }
 
+// ─── useCachedAccount ─────────────────────────────────────────────────────────
+
 /**
- * Hook for paginated data with caching
+ * Fetch and cache a Stellar account. Automatically invalidates when
+ * the connected address or network changes.
+ *
+ * @param {string|null} publicKey
+ * @param {string}      network
+ * @param {Function}    fetcher   async (publicKey, network) => accountData
  */
-function useCachedPaginatedData(cacheKey, fetchFn, options = {}) {
-  const [page, setPage] = useState(1);
-  const [limit, setLimit] = useState(options.limit || 20);
-  const [hasMore, setHasMore] = useState(true);
-  
-  const cacheKeyWithPagination = `${cacheKey}:page=${page}:limit=${limit}`;
-  
-  const { data, loading, error, refetch, isCached } = useCachedData(
-    cacheKeyWithPagination,
-    () => fetchFn({ page, limit }),
-    options
+export function useCachedAccount(publicKey, network, fetcher) {
+  const key = publicKey ? `account:${publicKey}:${network}` : null;
+
+  return useCachedData(
+    key,
+    useCallback(() => fetcher(publicKey, network), [publicKey, network]), // eslint-disable-line
+    {
+      ttl:     TTL.ACCOUNT,
+      tags:    ['account', `account:${publicKey}`],
+      persist: true,
+      enabled: !!publicKey,
+    }
   );
-  
-  const loadMore = useCallback(() => {
-    if (!loading && hasMore) {
-      setPage(prev => prev + 1);
-    }
-  }, [loading, hasMore]);
-  
-  useEffect(() => {
-    if (data && data.length < limit) {
-      setHasMore(false);
-    }
-  }, [data, limit]);
-  
-  return {
-    data: data || [],
-    loading,
-    error,
-    refetch,
-    isCached,
-    page,
-    limit,
-    hasMore,
-    loadMore,
-    setPage,
-    setLimit,
-  };
 }
 
+// ─── useCachedTransactions ────────────────────────────────────────────────────
+
 /**
- * Hook for single item with caching
+ * Paginated transaction history with cursor-based paging.
+ *
+ * @param {string|null} publicKey
+ * @param {string}      network
+ * @param {Function}    fetcher   async (publicKey, network, limit, cursor) => { records, nextCursor, hasMore }
+ * @param {number}      [limit]
  */
-function useCachedItem(cacheKey, id, fetchFn, options = {}) {
-  const itemCacheKey = `${cacheKey}:${id}`;
-  
-  return useCachedData(itemCacheKey, () => fetchFn(id), options);
+export function useCachedTransactions(publicKey, network, fetcher, limit = 20) {
+  const [cursor,  setCursor]  = useState(null);
+  const [allData, setAllData] = useState([]);
+  const [hasMore, setHasMore] = useState(true);
+
+  const key = publicKey ? `transactions:${publicKey}:${network}:${limit}:${cursor}` : null;
+
+  const { data, loading, error, refetch } = useCachedData(
+    key,
+    useCallback(
+      () => fetcher(publicKey, network, limit, cursor),
+      [publicKey, network, limit, cursor] // eslint-disable-line
+    ),
+    { ttl: TTL.TRANSACTIONS, tags: ['transactions', `account:${publicKey}`], enabled: !!publicKey }
+  );
+
+  useEffect(() => {
+    if (!data) return;
+    const records = data.records || data;
+    setAllData((prev) => {
+      const ids = new Set(prev.map((r) => r.id));
+      return [...prev, ...records.filter((r) => !ids.has(r.id))];
+    });
+    setHasMore(data.hasMore ?? records.length === limit);
+  }, [data]);
+
+  // Reset when account/network changes
+  useEffect(() => {
+    setAllData([]);
+    setCursor(null);
+    setHasMore(true);
+  }, [publicKey, network]);
+
+  const loadMore = useCallback(() => {
+    if (!loading && hasMore && data?.nextCursor) {
+      setCursor(data.nextCursor);
+    }
+  }, [loading, hasMore, data]);
+
+  return { data: allData, loading, error, hasMore, loadMore, refetch };
 }
+
+// ─── useCachedNetworkStats ────────────────────────────────────────────────────
+
+/**
+ * Network stats with a short TTL and optional auto-refresh.
+ *
+ * @param {string}   network
+ * @param {Function} fetcher  async (network) => stats
+ * @param {number}   [refreshInterval]  ms between auto-refreshes (0 = off)
+ */
+export function useCachedNetworkStats(network, fetcher, refreshInterval = 0) {
+  const key = `networkStats:${network}`;
+  return useCachedData(
+    key,
+    useCallback(() => fetcher(network), [network]), // eslint-disable-line
+    { ttl: TTL.LEDGER, tags: ['network'], refreshInterval }
+  );
+}
+
+// ─── useCachedPaginatedData ───────────────────────────────────────────────────
+
+/**
+ * Generic paginated hook (page-number based).
+ */
+export function useCachedPaginatedData(cacheKey, fetchFn, opts = {}) {
+  const { limit = 20, ...rest } = opts;
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+
+  const pagedKey = cacheKey ? `${cacheKey}:p${page}:l${limit}` : null;
+
+  const result = useCachedData(
+    pagedKey,
+    useCallback(() => fetchFn({ page, limit }), [page, limit]), // eslint-disable-line
+    { ...rest }
+  );
+
+  useEffect(() => {
+    if (result.data && result.data.length < limit) setHasMore(false);
+  }, [result.data, limit]);
+
+  const loadMore = useCallback(() => {
+    if (!result.loading && hasMore) setPage((p) => p + 1);
+  }, [result.loading, hasMore]);
+
+  return { ...result, data: result.data || [], page, limit, hasMore, loadMore, setPage };
+}
+
+// ─── useCachedItem ────────────────────────────────────────────────────────────
+
+/**
+ * Fetch a single item by id with caching.
+ */
+export function useCachedItem(cacheKeyPrefix, id, fetchFn, opts = {}) {
+  const key = id != null ? `${cacheKeyPrefix}:${id}` : null;
+  return useCachedData(
+    key,
+    useCallback(() => fetchFn(id), [id]), // eslint-disable-line
+    { enabled: id != null, ...opts }
+  );
+}
+
+// ─── useOfflineStatus ─────────────────────────────────────────────────────────
+
+/**
+ * Returns { online, queueLength } and updates reactively.
+ */
+export function useOfflineStatus() {
+  const [online, setOnline] = useState(() =>
+    typeof navigator !== 'undefined' ? navigator.onLine : true
+  );
+  const [queueLength, setQueueLength] = useState(0);
+
+  useEffect(() => {
+    const onOnline  = () => setOnline(true);
+    const onOffline = () => setOnline(false);
+    window.addEventListener('online',  onOnline);
+    window.addEventListener('offline', onOffline);
+    return () => {
+      window.removeEventListener('online',  onOnline);
+      window.removeEventListener('offline', onOffline);
+    };
+  }, []);
+
+  // Poll queue length every 5 s
+  useEffect(() => {
+    const refresh = () => getOfflineQueue().then((q) => setQueueLength(q.length)).catch(noop);
+    refresh();
+    const id = setInterval(refresh, 5_000);
+    return () => clearInterval(id);
+  }, []);
+
+  return { online, queueLength };
+}
+
+// ─── useCacheStats ────────────────────────────────────────────────────────────
+
+/**
+ * Live cache statistics — useful for a debug/diagnostics panel.
+ * Refreshes every `interval` ms.
+ */
+export function useCacheStats(interval = 2_000) {
+  const [stats, setStats] = useState(() => cache.getStats());
+
+  useEffect(() => {
+    const id = setInterval(() => setStats(cache.getStats()), interval);
+    return () => clearInterval(id);
+  }, [interval]);
+
+  const clearAll = useCallback(() => {
+    cache.clear();
+    setStats(cache.getStats());
+  }, []);
+
+  const invalidateTag = useCallback((tag) => {
+    cache.invalidateTag(tag);
+    setStats(cache.getStats());
+  }, []);
+
+  return { stats, clearAll, invalidateTag };
+}
+
+// ─── Default export ───────────────────────────────────────────────────────────
 
 export default useCachedData;
-export { useCachedData, useCachedPaginatedData, useCachedItem };

--- a/src/lib/cache.js
+++ b/src/lib/cache.js
@@ -1,168 +1,415 @@
 /**
  * Intelligent Caching System
- * Provides in-memory caching with TTL, automatic cleanup, and LRU eviction
+ *
+ * Layers:
+ *   L1 — in-memory LRU with TTL (fast, volatile)
+ *   L2 — IndexedDB via storage.js (persistent, survives reload)
+ *
+ * Features:
+ *   - Stale-while-revalidate: serve stale data immediately, refresh in background
+ *   - Tag-based invalidation: invalidate groups of keys by tag
+ *   - Per-key TTL overrides
+ *   - Offline detection: skip network when offline, extend stale window
+ *   - Cache statistics per namespace
+ *   - Subscriber notifications on key updates
  */
 
-class Cache {
-  constructor(maxSize = 1000, defaultTTL = 60000) {
-    this.cache = new Map();
-    this.maxSize = maxSize; // Maximum number of items in cache
-    this.defaultTTL = defaultTTL; // Default TTL in milliseconds (60 seconds)
-    this.hits = 0;
-    this.misses = 0;
-    
-    // Start periodic cleanup every 5 minutes
-    setInterval(() => this.cleanup(), 300000);
+import { getStoredValue, setStoredValue, removeStoredValue } from './storage.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const TTL = {
+  ACCOUNT:      60_000,       // 1 min
+  TRANSACTIONS: 30_000,       // 30 s
+  OPERATIONS:   30_000,       // 30 s
+  LEDGER:        5_000,       // 5 s
+  ASSET:       300_000,       // 5 min
+  NETWORK:   3_600_000,       // 1 hr
+  PRICE:        30_000,       // 30 s
+  POOL:         60_000,       // 1 min
+  POOL_DETAIL:  30_000,       // 30 s
+  LONG:      3_600_000,       // 1 hr
+  SHORT:        10_000,       // 10 s
+};
+
+// How long stale data is still served while a background refresh runs
+const STALE_WINDOW_ONLINE  = 5_000;   // 5 s
+const STALE_WINDOW_OFFLINE = 300_000; // 5 min — be generous when offline
+
+// ─── LRU Node ─────────────────────────────────────────────────────────────────
+
+class LRUNode {
+  constructor(key, value, expiresAt, tags = []) {
+    this.key       = key;
+    this.value     = value;
+    this.expiresAt = expiresAt;
+    this.createdAt = Date.now();
+    this.accessedAt = Date.now();
+    this.tags      = tags;
+    this.prev      = null;
+    this.next      = null;
+  }
+}
+
+// ─── Cache Class ──────────────────────────────────────────────────────────────
+
+export class Cache {
+  /**
+   * @param {object} opts
+   * @param {number} opts.maxSize       Max in-memory entries (LRU eviction)
+   * @param {number} opts.defaultTTL    Default TTL in ms
+   * @param {boolean} opts.persist      Whether to write through to IndexedDB
+   * @param {string}  opts.namespace    Prefix for all keys (useful for isolation)
+   */
+  constructor(opts = {}) {
+    this.maxSize    = opts.maxSize    ?? 500;
+    this.defaultTTL = opts.defaultTTL ?? TTL.ACCOUNT;
+    this.persist    = opts.persist    ?? false;
+    this.namespace  = opts.namespace  ?? '';
+
+    // Doubly-linked list for LRU ordering
+    this._head = new LRUNode('__head__', null, Infinity); // most-recent sentinel
+    this._tail = new LRUNode('__tail__', null, Infinity); // least-recent sentinel
+    this._head.next = this._tail;
+    this._tail.prev = this._head;
+
+    this._map  = new Map();   // key → LRUNode
+    this._tags = new Map();   // tag → Set<key>
+
+    // Stats
+    this._hits   = 0;
+    this._misses = 0;
+    this._writes = 0;
+    this._evictions = 0;
+
+    // Subscribers: key → Set<callback>
+    this._subscribers = new Map();
+
+    // Periodic cleanup every 2 minutes
+    this._cleanupTimer = setInterval(() => this._cleanup(), 120_000);
+  }
+
+  // ─── Key helpers ────────────────────────────────────────────────────────────
+
+  _ns(key) {
+    return this.namespace ? `${this.namespace}:${key}` : key;
   }
 
   /**
-   * Generate a cache key from parameters
-   * @param {string} prefix - Key prefix (e.g., 'account', 'transaction')
-   * @param {any} params - Parameters to include in key
-   * @returns {string} Cache key
+   * Build a deterministic cache key from a prefix + params object.
    */
   generateKey(prefix, params) {
-    const key = `${prefix}:${JSON.stringify(params)}`;
-    return key;
+    return this._ns(`${prefix}:${JSON.stringify(params)}`);
   }
 
+  // ─── LRU list helpers ────────────────────────────────────────────────────────
+
+  _detach(node) {
+    node.prev.next = node.next;
+    node.next.prev = node.prev;
+  }
+
+  _insertAfterHead(node) {
+    node.prev = this._head;
+    node.next = this._head.next;
+    this._head.next.prev = node;
+    this._head.next = node;
+  }
+
+  _moveToFront(node) {
+    this._detach(node);
+    this._insertAfterHead(node);
+  }
+
+  _evictLRU() {
+    const lru = this._tail.prev;
+    if (lru === this._head) return;
+    this._detach(lru);
+    this._map.delete(lru.key);
+    this._removeTags(lru);
+    this._evictions++;
+  }
+
+  _removeTags(node) {
+    for (const tag of node.tags) {
+      const set = this._tags.get(tag);
+      if (set) {
+        set.delete(node.key);
+        if (set.size === 0) this._tags.delete(tag);
+      }
+    }
+  }
+
+  // ─── Core API ────────────────────────────────────────────────────────────────
+
   /**
-   * Set a value in cache
-   * @param {string} key - Cache key
-   * @param {any} value - Value to store
-   * @param {number} ttl - Time to live in milliseconds (optional)
+   * Write a value to L1 (and optionally L2).
+   * @param {string}   key
+   * @param {*}        value
+   * @param {number}   [ttl]   Override TTL in ms
+   * @param {string[]} [tags]  Tag names for group invalidation
    */
-  set(key, value, ttl = null) {
-    // Check if we need to evict old items
-    if (this.cache.size >= this.maxSize) {
-      this.evictOldest();
+  set(key, value, ttl, tags = []) {
+    const resolvedTTL = ttl ?? this.defaultTTL;
+    const expiresAt   = Date.now() + resolvedTTL;
+
+    if (this._map.has(key)) {
+      const node = this._map.get(key);
+      node.value      = value;
+      node.expiresAt  = expiresAt;
+      node.accessedAt = Date.now();
+      node.tags       = tags;
+      this._moveToFront(node);
+    } else {
+      if (this._map.size >= this.maxSize) this._evictLRU();
+      const node = new LRUNode(key, value, expiresAt, tags);
+      this._map.set(key, node);
+      this._insertAfterHead(node);
     }
 
-    const expiresAt = Date.now() + (ttl || this.defaultTTL);
-    
-    this.cache.set(key, {
-      value,
-      expiresAt,
-      createdAt: Date.now(),
-    });
+    // Register tags
+    for (const tag of tags) {
+      if (!this._tags.has(tag)) this._tags.set(tag, new Set());
+      this._tags.get(tag).add(key);
+    }
+
+    this._writes++;
+    this._notify(key, value);
+
+    // Write-through to IndexedDB
+    if (this.persist) {
+      setStoredValue(key, { value, expiresAt, tags }).catch(() => {});
+    }
   }
 
   /**
-   * Get a value from cache
-   * @param {string} key - Cache key
-   * @returns {any|null} Cached value or null if not found/expired
+   * Read from L1. Returns null on miss or expiry.
    */
   get(key) {
-    const item = this.cache.get(key);
-    
-    if (!item) {
-      this.misses++;
+    const node = this._map.get(key);
+    if (!node) { this._misses++; return null; }
+
+    if (Date.now() > node.expiresAt) {
+      this._evictNode(node);
+      this._misses++;
       return null;
     }
-    
-    if (Date.now() > item.expiresAt) {
-      this.cache.delete(key);
-      this.misses++;
-      return null;
-    }
-    
-    this.hits++;
-    return item.value;
+
+    node.accessedAt = Date.now();
+    this._moveToFront(node);
+    this._hits++;
+    return node.value;
   }
 
   /**
-   * Check if key exists and is not expired
-   * @param {string} key - Cache key
-   * @returns {boolean}
+   * Read from L1, and if missing try L2 (IndexedDB).
+   * Returns { value, stale } where stale=true means the entry is expired
+   * but still returned (stale-while-revalidate).
+   */
+  async getWithFallback(key) {
+    const node = this._map.get(key);
+    const now  = Date.now();
+
+    if (node) {
+      node.accessedAt = now;
+      this._moveToFront(node);
+      if (now <= node.expiresAt) {
+        this._hits++;
+        return { value: node.value, stale: false, source: 'memory' };
+      }
+      // Stale — still return it
+      const staleWindow = isOffline() ? STALE_WINDOW_OFFLINE : STALE_WINDOW_ONLINE;
+      if (now <= node.expiresAt + staleWindow) {
+        this._hits++;
+        return { value: node.value, stale: true, source: 'memory-stale' };
+      }
+    }
+
+    // Try IndexedDB
+    if (this.persist) {
+      try {
+        const stored = await getStoredValue(key);
+        if (stored && stored.value !== undefined) {
+          const stale = now > stored.expiresAt;
+          if (!stale || (now <= stored.expiresAt + STALE_WINDOW_OFFLINE)) {
+            // Warm L1
+            this.set(key, stored.value, stored.expiresAt - now, stored.tags || []);
+            this._misses++;
+            return { value: stored.value, stale, source: 'indexeddb' };
+          }
+        }
+      } catch { /* ignore */ }
+    }
+
+    this._misses++;
+    return { value: null, stale: false, source: 'miss' };
+  }
+
+  /**
+   * Check existence without updating access order.
    */
   has(key) {
-    const item = this.cache.get(key);
-    if (!item) return false;
-    if (Date.now() > item.expiresAt) {
-      this.cache.delete(key);
-      return false;
-    }
+    const node = this._map.get(key);
+    if (!node) return false;
+    if (Date.now() > node.expiresAt) { this._evictNode(node); return false; }
     return true;
   }
 
   /**
-   * Delete a key from cache
-   * @param {string} key - Cache key
+   * Delete a single key from L1 and L2.
    */
   delete(key) {
-    this.cache.delete(key);
+    const node = this._map.get(key);
+    if (node) this._evictNode(node);
+    if (this.persist) removeStoredValue(key).catch(() => {});
   }
 
   /**
-   * Clear all cache
+   * Invalidate all keys that carry a given tag.
+   */
+  invalidateTag(tag) {
+    const keys = this._tags.get(tag);
+    if (!keys) return;
+    for (const key of [...keys]) this.delete(key);
+  }
+
+  /**
+   * Invalidate all keys whose key string starts with prefix.
+   */
+  invalidatePrefix(prefix) {
+    for (const key of [...this._map.keys()]) {
+      if (key.startsWith(prefix)) this.delete(key);
+    }
+  }
+
+  /**
+   * Clear everything.
    */
   clear() {
-    this.cache.clear();
-    this.hits = 0;
-    this.misses = 0;
+    this._map.clear();
+    this._tags.clear();
+    this._head.next = this._tail;
+    this._tail.prev = this._head;
+    this._hits = this._misses = this._writes = this._evictions = 0;
   }
 
-  /**
-   * Evict oldest items when cache is full
-   */
-  evictOldest() {
-    let oldestKey = null;
-    let oldestTime = Infinity;
-    
-    for (const [key, item] of this.cache.entries()) {
-      if (item.createdAt < oldestTime) {
-        oldestTime = item.createdAt;
-        oldestKey = key;
-      }
-    }
-    
-    if (oldestKey) {
-      this.cache.delete(oldestKey);
-    }
-  }
+  // ─── Stale-while-revalidate helper ──────────────────────────────────────────
 
   /**
-   * Remove expired items from cache
+   * Serve cached data immediately (even if stale), then revalidate in background.
+   *
+   * @param {string}   key
+   * @param {Function} fetcher   async () => freshValue
+   * @param {number}   [ttl]
+   * @param {string[]} [tags]
+   * @returns {Promise<*>}  Resolves with cached value immediately if available,
+   *                        otherwise waits for fetcher.
    */
-  cleanup() {
-    const now = Date.now();
-    for (const [key, item] of this.cache.entries()) {
-      if (now > item.expiresAt) {
-        this.cache.delete(key);
-      }
+  async swr(key, fetcher, ttl, tags = []) {
+    const { value, stale, source } = await this.getWithFallback(key);
+
+    if (value !== null && !stale) return value;
+
+    if (value !== null && stale) {
+      // Return stale immediately, refresh in background
+      fetcher()
+        .then((fresh) => this.set(key, fresh, ttl, tags))
+        .catch(() => {});
+      return value;
     }
+
+    // Cache miss — must wait
+    const fresh = await fetcher();
+    this.set(key, fresh, ttl, tags);
+    return fresh;
   }
 
+  // ─── Subscriptions ───────────────────────────────────────────────────────────
+
   /**
-   * Get cache statistics
-   * @returns {object} Cache stats
+   * Subscribe to updates for a key.
+   * @param {string}   key
+   * @param {Function} cb  (value) => void
+   * @returns {Function} unsubscribe
    */
+  subscribe(key, cb) {
+    if (!this._subscribers.has(key)) this._subscribers.set(key, new Set());
+    this._subscribers.get(key).add(cb);
+    return () => this._subscribers.get(key)?.delete(cb);
+  }
+
+  _notify(key, value) {
+    const subs = this._subscribers.get(key);
+    if (subs) for (const cb of subs) { try { cb(value); } catch { /* ignore */ } }
+  }
+
+  // ─── Stats ───────────────────────────────────────────────────────────────────
+
   getStats() {
-    const total = this.hits + this.misses;
-    const hitRate = total > 0 ? (this.hits / total * 100).toFixed(2) : 0;
-    
+    const total   = this._hits + this._misses;
+    const hitRate = total > 0 ? ((this._hits / total) * 100).toFixed(1) : '0.0';
     return {
-      size: this.cache.size,
-      maxSize: this.maxSize,
-      hits: this.hits,
-      misses: this.misses,
-      total: total,
-      hitRate: `${hitRate}%`,
+      size:       this._map.size,
+      maxSize:    this.maxSize,
+      hits:       this._hits,
+      misses:     this._misses,
+      writes:     this._writes,
+      evictions:  this._evictions,
+      hitRate:    `${hitRate}%`,
+      tags:       this._tags.size,
+      persist:    this.persist,
+      namespace:  this.namespace,
     };
   }
 
-  /**
-   * Get all keys in cache (for debugging)
-   * @returns {Array} Array of keys
-   */
-  keys() {
-    return Array.from(this.cache.keys());
+  keys() { return [...this._map.keys()]; }
+
+  // ─── Internal ────────────────────────────────────────────────────────────────
+
+  _evictNode(node) {
+    this._detach(node);
+    this._map.delete(node.key);
+    this._removeTags(node);
+  }
+
+  _cleanup() {
+    const now = Date.now();
+    for (const [, node] of this._map) {
+      if (now > node.expiresAt) this._evictNode(node);
+    }
+  }
+
+  destroy() {
+    clearInterval(this._cleanupTimer);
+    this.clear();
   }
 }
 
-// Create singleton instance
-const cache = new Cache();
+// ─── Offline detection ────────────────────────────────────────────────────────
 
-// Export for use in other modules
+export function isOffline() {
+  return typeof navigator !== 'undefined' && navigator.onLine === false;
+}
+
+// ─── Named cache instances ────────────────────────────────────────────────────
+
+/** Default in-memory cache used by stellar.js and dex.js */
+const cache = new Cache({ maxSize: 500, defaultTTL: TTL.ACCOUNT });
+
+/** Persistent cache for account data — survives page reload */
+export const persistentCache = new Cache({
+  maxSize: 200,
+  defaultTTL: TTL.ACCOUNT,
+  persist: true,
+  namespace: 'stellar',
+});
+
+/** Short-lived cache for real-time data (prices, ledger) */
+export const realtimeCache = new Cache({
+  maxSize: 100,
+  defaultTTL: TTL.SHORT,
+  namespace: 'rt',
+});
+
 export default cache;
-export { Cache };
+export { Cache as default_Cache };

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,79 +1,272 @@
-const DB_NAME = 'stellar-dev-dashboard'
-const DB_VERSION = 1
-const STORE_NAME = 'app-state'
+/**
+ * Persistent Storage Layer — IndexedDB with localStorage fallback
+ *
+ * Provides:
+ *   - getStoredValue / setStoredValue / removeStoredValue / clearStorage
+ *   - getCachedApiResponse / setCachedApiResponse  (TTL-aware API cache in IDB)
+ *   - getOfflineQueue / enqueueOfflineOp / dequeueOfflineOp  (offline write queue)
+ *   - storageStats  (size estimates)
+ */
+
+// ─── DB config ────────────────────────────────────────────────────────────────
+
+const DB_NAME    = 'stellar-dev-dashboard';
+const DB_VERSION = 2;
+
+const STORES = {
+  APP_STATE:  'app-state',    // Zustand persistence
+  API_CACHE:  'api-cache',    // TTL-aware API response cache
+  OFFLINE_Q:  'offline-queue', // Queued writes for when back online
+};
+
+// ─── DB open ──────────────────────────────────────────────────────────────────
+
+let _db = null;
 
 function openDB() {
+  if (_db) return Promise.resolve(_db);
+
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
 
     request.onupgradeneeded = (event) => {
-      const db = event.target.result
-      if (!db.objectStoreNames.contains(STORE_NAME)) {
-        db.createObjectStore(STORE_NAME)
-      }
-    }
+      const db = event.target.result;
 
-    request.onsuccess = () => resolve(request.result)
-    request.onerror = () => reject(request.error)
-  })
+      if (!db.objectStoreNames.contains(STORES.APP_STATE)) {
+        db.createObjectStore(STORES.APP_STATE);
+      }
+
+      if (!db.objectStoreNames.contains(STORES.API_CACHE)) {
+        const store = db.createObjectStore(STORES.API_CACHE, { keyPath: 'key' });
+        store.createIndex('expiresAt', 'expiresAt', { unique: false });
+        store.createIndex('tag',       'tag',       { unique: false });
+      }
+
+      if (!db.objectStoreNames.contains(STORES.OFFLINE_Q)) {
+        db.createObjectStore(STORES.OFFLINE_Q, { keyPath: 'id', autoIncrement: true });
+      }
+    };
+
+    request.onsuccess = () => {
+      _db = request.result;
+
+      // Handle unexpected close (e.g. version bump from another tab)
+      _db.onversionchange = () => {
+        _db.close();
+        _db = null;
+      };
+
+      resolve(_db);
+    };
+
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => reject(new Error('IndexedDB blocked'));
+  });
 }
+
+// ─── Generic transaction helper ───────────────────────────────────────────────
+
+async function tx(storeName, mode, fn) {
+  const db       = await openDB();
+  const trans    = db.transaction(storeName, mode);
+  const store    = trans.objectStore(storeName);
+  return new Promise((resolve, reject) => {
+    const req = fn(store);
+    if (req && typeof req.onsuccess !== 'undefined') {
+      req.onsuccess = () => resolve(req.result);
+      req.onerror   = () => reject(req.error);
+    } else {
+      trans.oncomplete = () => resolve();
+      trans.onerror    = () => reject(trans.error);
+    }
+  });
+}
+
+// ─── App-state store (Zustand persistence) ───────────────────────────────────
 
 export async function getStoredValue(key) {
   try {
-    const db = await openDB()
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readonly')
-      const store = tx.objectStore(STORE_NAME)
-      const request = store.get(key)
-      request.onsuccess = () => resolve(request.result ?? null)
-      request.onerror = () => reject(request.error)
-    })
+    return await tx(STORES.APP_STATE, 'readonly', (s) => s.get(key)) ?? null;
   } catch {
-    return null
+    // Fallback to localStorage
+    try {
+      const raw = localStorage.getItem(`idb:${key}`);
+      return raw ? JSON.parse(raw) : null;
+    } catch { return null; }
   }
 }
 
 export async function setStoredValue(key, value) {
   try {
-    const db = await openDB()
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readwrite')
-      const store = tx.objectStore(STORE_NAME)
-      const request = store.put(value, key)
-      request.onsuccess = () => resolve()
-      request.onerror = () => reject(request.error)
-    })
+    await tx(STORES.APP_STATE, 'readwrite', (s) => s.put(value, key));
   } catch {
-    // Silently fail – persistence is best-effort
+    try { localStorage.setItem(`idb:${key}`, JSON.stringify(value)); } catch { /* ignore */ }
   }
 }
 
 export async function removeStoredValue(key) {
   try {
-    const db = await openDB()
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readwrite')
-      const store = tx.objectStore(STORE_NAME)
-      const request = store.delete(key)
-      request.onsuccess = () => resolve()
-      request.onerror = () => reject(request.error)
-    })
+    await tx(STORES.APP_STATE, 'readwrite', (s) => s.delete(key));
   } catch {
-    // Silently fail
+    try { localStorage.removeItem(`idb:${key}`); } catch { /* ignore */ }
   }
 }
 
 export async function clearStorage() {
   try {
-    const db = await openDB()
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_NAME, 'readwrite')
-      const store = tx.objectStore(STORE_NAME)
-      const request = store.clear()
-      request.onsuccess = () => resolve()
-      request.onerror = () => reject(request.error)
-    })
+    await tx(STORES.APP_STATE, 'readwrite', (s) => s.clear());
+  } catch { /* ignore */ }
+}
+
+// ─── API cache store ──────────────────────────────────────────────────────────
+
+/**
+ * Read a cached API response. Returns null if missing or expired.
+ * @param {string} key
+ * @returns {Promise<*|null>}
+ */
+export async function getCachedApiResponse(key) {
+  try {
+    const record = await tx(STORES.API_CACHE, 'readonly', (s) => s.get(key));
+    if (!record) return null;
+    if (Date.now() > record.expiresAt) {
+      // Expired — delete lazily
+      deleteCachedApiResponse(key).catch(() => {});
+      return null;
+    }
+    return record.value;
+  } catch { return null; }
+}
+
+/**
+ * Write an API response to the persistent cache.
+ * @param {string}   key
+ * @param {*}        value
+ * @param {number}   ttl      TTL in ms
+ * @param {string}   [tag]    Optional tag for group invalidation
+ */
+export async function setCachedApiResponse(key, value, ttl, tag = '') {
+  try {
+    const record = { key, value, expiresAt: Date.now() + ttl, tag, cachedAt: Date.now() };
+    await tx(STORES.API_CACHE, 'readwrite', (s) => s.put(record));
+  } catch { /* ignore */ }
+}
+
+/**
+ * Delete a single API cache entry.
+ */
+export async function deleteCachedApiResponse(key) {
+  try {
+    await tx(STORES.API_CACHE, 'readwrite', (s) => s.delete(key));
+  } catch { /* ignore */ }
+}
+
+/**
+ * Invalidate all API cache entries with a given tag.
+ */
+export async function invalidateCacheByTag(tag) {
+  try {
+    const db    = await openDB();
+    const trans = db.transaction(STORES.API_CACHE, 'readwrite');
+    const index = trans.objectStore(STORES.API_CACHE).index('tag');
+    const req   = index.openCursor(IDBKeyRange.only(tag));
+
+    await new Promise((resolve, reject) => {
+      req.onsuccess = (e) => {
+        const cursor = e.target.result;
+        if (cursor) { cursor.delete(); cursor.continue(); }
+        else resolve();
+      };
+      req.onerror = () => reject(req.error);
+    });
+  } catch { /* ignore */ }
+}
+
+/**
+ * Remove all expired API cache entries.
+ */
+export async function pruneExpiredApiCache() {
+  try {
+    const db    = await openDB();
+    const trans = db.transaction(STORES.API_CACHE, 'readwrite');
+    const index = trans.objectStore(STORES.API_CACHE).index('expiresAt');
+    const range = IDBKeyRange.upperBound(Date.now());
+    const req   = index.openCursor(range);
+
+    await new Promise((resolve, reject) => {
+      req.onsuccess = (e) => {
+        const cursor = e.target.result;
+        if (cursor) { cursor.delete(); cursor.continue(); }
+        else resolve();
+      };
+      req.onerror = () => reject(req.error);
+    });
+  } catch { /* ignore */ }
+}
+
+// ─── Offline write queue ──────────────────────────────────────────────────────
+
+/**
+ * Add an operation to the offline queue (e.g. a transaction to submit later).
+ * @param {{ type: string, payload: * }} op
+ */
+export async function enqueueOfflineOp(op) {
+  try {
+    await tx(STORES.OFFLINE_Q, 'readwrite', (s) => s.add({ ...op, queuedAt: Date.now() }));
+  } catch { /* ignore */ }
+}
+
+/**
+ * Read all queued offline operations.
+ * @returns {Promise<Array>}
+ */
+export async function getOfflineQueue() {
+  try {
+    return await tx(STORES.OFFLINE_Q, 'readonly', (s) => s.getAll()) ?? [];
+  } catch { return []; }
+}
+
+/**
+ * Remove a processed operation from the queue by its auto-increment id.
+ * @param {number} id
+ */
+export async function dequeueOfflineOp(id) {
+  try {
+    await tx(STORES.OFFLINE_Q, 'readwrite', (s) => s.delete(id));
+  } catch { /* ignore */ }
+}
+
+/**
+ * Clear the entire offline queue.
+ */
+export async function clearOfflineQueue() {
+  try {
+    await tx(STORES.OFFLINE_Q, 'readwrite', (s) => s.clear());
+  } catch { /* ignore */ }
+}
+
+// ─── Storage stats ────────────────────────────────────────────────────────────
+
+/**
+ * Estimate the number of entries in each store.
+ * @returns {Promise<{ appState: number, apiCache: number, offlineQueue: number }>}
+ */
+export async function storageStats() {
+  try {
+    const [appState, apiCache, offlineQueue] = await Promise.all([
+      tx(STORES.APP_STATE, 'readonly', (s) => s.count()),
+      tx(STORES.API_CACHE, 'readonly', (s) => s.count()),
+      tx(STORES.OFFLINE_Q, 'readonly', (s) => s.count()),
+    ]);
+    return { appState, apiCache, offlineQueue };
   } catch {
-    // Silently fail
+    return { appState: 0, apiCache: 0, offlineQueue: 0 };
   }
+}
+
+// ─── Auto-prune on load ───────────────────────────────────────────────────────
+
+// Prune expired API cache entries 3 seconds after module load
+if (typeof window !== 'undefined') {
+  setTimeout(() => pruneExpiredApiCache().catch(() => {}), 3_000);
 }


### PR DESCRIPTION
src/lib/cache.js:
- LRU doubly-linked list eviction (O(1) get/set/evict)
- Stale-while-revalidate: serve stale immediately, refresh in background
- Tag-based invalidation (invalidateTag, invalidatePrefix)
- Write-through to IndexedDB via persistentCache instance
- Subscriber notifications (subscribe/notify) for cross-hook updates
- Offline detection: extends stale window to 5 min when offline
- Three named instances: default (memory), persistentCache (IDB), realtimeCache (short TTL)
- Full stats: hits, misses, writes, evictions, hitRate, tag count

src/lib/storage.js:
- IndexedDB v2 with three object stores: app-state, api-cache, offline-queue
- localStorage fallback when IDB unavailable
- getCachedApiResponse / setCachedApiResponse with TTL + tag index
- invalidateCacheByTag / pruneExpiredApiCache (auto-runs 3s after load)
- enqueueOfflineOp / getOfflineQueue / dequeueOfflineOp for offline writes
- storageStats() for entry counts per store

src/hooks/useCachedData.js:
- useCachedData: SWR-style hook with L1+L2 read, deduplication, auto-refresh, cache subscriptions, onSuccess/onError callbacks
- useCachedAccount: account-specific hook with tag invalidation + IDB persist
- useCachedTransactions: cursor-based pagination with dedup append
- useCachedNetworkStats: short TTL + optional auto-refresh interval
- useCachedPaginatedData: page-number pagination
- useCachedItem: single-item by id
- useOfflineStatus: online/offline state + offline queue length
- useCacheStats: live stats for debug panel with clearAll/invalidateTag

## Linked Issue
Close #60