### PR TITLE
feat: docs, PWA, transaction builder, backup/export (#108 #110 #111 #114)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -12,6 +12,9 @@ This directory documents the public JavaScript modules exposed by the dashboard.
 | [tutorialSystem.js](./tutorial.md) | Guided tours and contextual help system |
 | [multisig.js](./multisig.md) | Multi-signature transaction coordination |
 | [priceFeed.js](./priceFeed.md) | XLM and asset price feeds |
+| [transactionBuilder.js](./transactionBuilder.md) | Multi-operation transaction builder and simulator |
+| [transactionTemplates.js](./transactionTemplates.md) | Pre-built transaction templates |
+| [import.js / export.js](./dataExport.md) | Dashboard backup, export, and import utilities |
 
 ## Quick Start
 

--- a/docs/api/dataExport.md
+++ b/docs/api/dataExport.md
@@ -1,0 +1,71 @@
+# export.js / import.js / useDataExport
+
+Dashboard backup, CSV/JSON export, and restore functionality.
+
+## export.js
+
+### `exportJson(data, filename)`
+
+Serialise `data` to JSON and trigger a browser download as `filename.json`.
+
+### `exportCsv(rows, filename, columns?)`
+
+Convert an array of objects to CSV and download as `filename.csv`. Column order follows the `columns` array, or `Object.keys(rows[0])` if omitted. Values containing commas, quotes, or newlines are properly escaped.
+
+### `exportDashboardBackup(state, filename?)`
+
+Build and download a complete dashboard backup including theme, network, and watched addresses.
+
+### `buildBackupPayload(state)`
+
+Return the backup object without triggering a download. Useful for testing or server-side serialisation.
+
+### `flattenTransaction(tx)`
+
+Flatten a Horizon transaction record to a plain `{ id, hash, ledger, … }` CSV-friendly row.
+
+### `flattenBalance(balance)`
+
+Flatten a Horizon balance record to a plain `{ asset_type, balance, … }` CSV-friendly row.
+
+---
+
+## import.js
+
+### `parseBackup(jsonString)`
+
+Parse and validate a backup JSON string.
+
+**Returns:** `{ ok: true, data } | { ok: false, error: string }`
+
+### `readFileAsText(file)`
+
+Read a `File` object (from `<input type="file">`) and return its text content as a `Promise<string>`.
+
+### `validateBackupPayload(data)`
+
+Check required fields. Returns an array of error strings (empty = valid).
+
+### `applyBackupToStore(data, store)`
+
+Apply whitelisted fields from a backup payload to the Zustand store. Only `theme`, `network`, and `watchedAddresses` are restored (prototype pollution guard).
+
+---
+
+## useDataExport hook
+
+```js
+import { useDataExport } from './src/hooks/useDataExport';
+
+const {
+  isExporting,
+  isImporting,
+  exportError,
+  importError,
+  importSuccess,
+  exportDashboard,        // () => void  — downloads JSON backup
+  exportTransactions,     // (txs) => void — downloads CSV
+  exportBalances,         // (balances) => void — downloads CSV
+  importBackup,           // async (File) => void
+} = useDataExport();
+```

--- a/docs/api/transactionBuilder.md
+++ b/docs/api/transactionBuilder.md
@@ -1,0 +1,85 @@
+# transactionBuilder.js
+
+Multi-operation Stellar transaction builder and simulator.
+
+## `OPERATION_TYPES`
+
+Array of `{ value, label }` objects listing all supported operation types for use in UI selects.
+
+```js
+import { OPERATION_TYPES } from './src/lib/transactionBuilder';
+// [{ value: 'payment', label: 'Payment' }, ...]
+```
+
+## `createOperation(type, params)`
+
+Build a single `StellarSdk.Operation` from a type string and a params object.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `type` | `string` | One of the values in `OPERATION_TYPES` |
+| `params` | `Object` | Operation-specific fields (see below) |
+
+**Returns:** `StellarSdk.xdr.Operation`
+
+### Supported operation types
+
+| type | Required params |
+|------|----------------|
+| `payment` | `destination`, `assetType`, `amount` (+ `assetCode`/`assetIssuer` for non-native) |
+| `createAccount` | `destination`, `startingBalance` |
+| `changeTrust` | `assetCode`, `assetIssuer`, `limit?` |
+| `manageSellOffer` | `sellingAsset*`, `buyingAsset*`, `amount`, `price` |
+| `manageBuyOffer` | `sellingAsset*`, `buyingAsset*`, `buyAmount`, `price` |
+| `setOptions` | `homeDomain?`, `setFlags?`, `clearFlags?` |
+| `accountMerge` | `destination` |
+| `manageData` | `name`, `value?` |
+| `pathPaymentStrictSend` | `sendAsset*`, `sendAmount`, `destination`, `destAsset*`, `destMin`, `path?` |
+| `pathPaymentStrictReceive` | `sendAsset*`, `sendMax`, `destination`, `destAsset*`, `destAmount`, `path?` |
+| `claimClaimableBalance` | `balanceId` |
+| `createClaimableBalance` | `asset*`, `amount`, `claimants` |
+| `bumpSequence` | `bumpTo` |
+| `revokeSponsorship` | `account` |
+| `beginSponsoringFutureReserves` | `sponsoredId` |
+| `endSponsoringFutureReserves` | _(none)_ |
+
+## `buildTransaction(params)`
+
+Async. Loads the source account from Horizon and builds a signed-ready `Transaction` object.
+
+```js
+const tx = await buildTransaction({
+  sourceAccount: 'G...',
+  operations: [{ type: 'payment', params: { destination: 'G...', assetType: 'native', amount: '10' } }],
+  memo: 'Hello',
+  memoType: 'text',  // 'text' | 'id' | 'hash' | 'return'
+  baseFee: 100,
+  timeout: 180,
+  network: 'testnet',
+});
+```
+
+## `simulateTransaction(params)`
+
+Async. Builds and validates a transaction without submitting it.
+
+**Returns:**
+```js
+{
+  success: boolean,
+  errors: string[],
+  fee: number,
+  operationCount: number,
+  xdr: string,
+  hash: string,
+}
+```
+
+## `signAndSubmitTransaction(transaction, secretKey, network?)`
+
+Sign a built transaction with a secret key and submit it to the network.
+
+**Returns:**
+```js
+{ hash: string, ledger: number, successful: boolean }
+```

--- a/docs/api/transactionTemplates.md
+++ b/docs/api/transactionTemplates.md
@@ -1,0 +1,46 @@
+# transactionTemplates.js
+
+Pre-built transaction templates for the Advanced Transaction Builder.
+
+## `TRANSACTION_TEMPLATES`
+
+Array of template objects. Each template has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Unique identifier |
+| `label` | `string` | Human-readable name |
+| `description` | `string` | One-line explanation |
+| `operations` | `Array` | Default operation list (same shape as `buildTransaction` input) |
+| `memo` | `string` | Default memo text |
+| `memoType` | `string` | Default memo type (`text` \| `id` \| …) |
+
+### Available templates
+
+| id | label |
+|----|-------|
+| `simple_payment` | Simple XLM Payment |
+| `asset_payment` | Custom Asset Payment |
+| `add_trustline` | Add Trustline |
+| `create_account` | Create & Fund Account |
+| `path_payment` | Path Payment (Cross-Asset) |
+| `set_home_domain` | Set Home Domain |
+| `account_merge` | Merge Account |
+| `bump_sequence` | Bump Sequence |
+
+## `getTemplate(id)`
+
+Return the template with the given `id`, or `undefined` if not found.
+
+## `cloneTemplate(id)`
+
+Deep-clone a template so edits don't mutate the original constant. Returns `null` if the id is not found.
+
+```js
+import { cloneTemplate } from './src/lib/transactionTemplates';
+
+const tpl = cloneTemplate('simple_payment');
+tpl.operations[0].params.destination = 'G...';
+tpl.operations[0].params.amount = '50';
+// tpl is now ready to pass to buildTransaction()
+```

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,192 @@
+# Component Reference
+
+This document describes every public React component in the dashboard.
+
+## Layout Components
+
+### `<Sidebar>`
+**File:** `src/components/layout/Sidebar.jsx`
+
+Fixed left-hand navigation for desktop viewports. Displays the network selector, connected account badge, nav items, and theme toggle.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isMobile` | `boolean` | `false` | Renders in mobile-drawer mode when true |
+
+---
+
+### `<MobileSidebar>`
+**File:** `src/components/layout/MobileSidebar.jsx`
+
+Slide-in navigation drawer for mobile viewports. Controlled by the `isMobileMenuOpen` Zustand state. Closes on nav-item tap, backdrop click, and Escape key.
+
+```jsx
+import MobileSidebar, { HamburgerButton } from './components/layout/MobileSidebar';
+// Render HamburgerButton in the mobile header, MobileSidebar anywhere in the tree.
+```
+
+---
+
+### `<MobileHeader>`
+**File:** `src/components/layout/MobileHeader.jsx`
+
+Fixed top-bar visible only on small screens. Contains the hamburger toggle and network badge.
+
+---
+
+### `<DashboardGrid>`
+**File:** `src/components/layout/DashboardGrid.jsx`
+
+Drag-and-drop widget grid for the customisable dashboard layout.
+
+---
+
+### `<ThemeToggle>`
+**File:** `src/components/layout/ThemeToggle.jsx`
+
+Dark/light mode button. Reads and writes `theme` from the Zustand store.
+
+---
+
+## Dashboard Components
+
+### `<Overview>`
+**File:** `src/components/dashboard/Overview.jsx`
+
+Top-level summary panel: account stats, recent transactions, network health.
+
+---
+
+### `<Account>`
+**File:** `src/components/dashboard/Account.jsx`
+
+Account detail view: balances, signers, flags, thresholds, and data entries.
+
+---
+
+### `<Transactions>`
+**File:** `src/components/dashboard/Transactions.jsx`
+
+Paginated transaction list with filter controls.
+
+---
+
+### `<TransactionBuilder>`
+**File:** `src/components/dashboard/TransactionBuilder.jsx`
+
+Interactive multi-operation transaction builder. Supports all Stellar operation types including payment, path payment, create account, change trust, manage offers, manage data, bump sequence, claimable balances, and sponsorship operations.
+
+Optionally loads a pre-built template via the `TRANSACTION_TEMPLATES` from `src/lib/transactionTemplates.js`.
+
+---
+
+### `<DataExport>`
+**File:** `src/components/dashboard/DataExport.jsx`
+
+Export/import panel for dashboard data. Allows downloading:
+- Dashboard settings backup (JSON)
+- Transaction history (CSV)
+- Account balances (CSV)
+
+And importing a previously saved JSON backup to restore theme and network settings.
+
+```jsx
+import DataExport from './components/dashboard/DataExport';
+<DataExport />
+```
+
+---
+
+### `<NetworkStats>`
+**File:** `src/components/dashboard/NetworkStats.jsx`
+
+Live Stellar network metrics: ledger sequence, base fee, protocol version, and node counts.
+
+---
+
+### `<Contracts>`
+**File:** `src/components/dashboard/Contracts.jsx`
+
+Soroban smart contract inspector and invoker.
+
+---
+
+### `<DEXExplorer>`
+**File:** `src/components/dashboard/DEXExplorer.jsx`
+
+Stellar DEX order book, trade history, and path-finding explorer.
+
+---
+
+### `<WalletConnect>`
+**File:** `src/components/dashboard/WalletConnect.jsx`
+
+Freighter wallet connection panel.
+
+---
+
+### `<TransactionSigner>`
+**File:** `src/components/dashboard/TransactionSigner.jsx`
+
+XDR transaction signer — paste an XDR envelope, sign with a secret key or Freighter.
+
+---
+
+### `<Faucet>`
+**File:** `src/components/dashboard/Faucet.jsx`
+
+Testnet faucet (Friendbot) integration — fund any testnet account with a click.
+
+---
+
+### `<PortfolioValue>`
+**File:** `src/components/dashboard/PortfolioValue.jsx`
+
+USD/EUR portfolio value estimate based on live price feeds.
+
+---
+
+## Asset Components
+
+### `<AssetDiscovery>`
+**File:** `src/components/assets/AssetDiscovery.jsx`
+
+Search and discover Stellar assets by code, issuer, or domain.
+
+### `<AssetCard>`
+**File:** `src/components/assets/AssetCard.jsx`
+
+Single asset card showing balance, price, 24h change, and quick actions.
+
+---
+
+## Chart Components
+
+### `<AdvancedChartSuite>`
+**File:** `src/components/charts/AdvancedChartSuite.jsx`
+
+Configurable chart collection: balance history, network metrics, account activity.
+
+### `<BalanceHistoryChart>`
+**File:** `src/components/charts/BalanceHistoryChart.jsx`
+
+XLM balance over time using the Recharts `AreaChart`.
+
+---
+
+## Utility Components
+
+### `<ErrorBoundary>`
+**File:** `src/components/ErrorBoundary.jsx`
+
+React error boundary that catches render errors and shows `<ErrorFallback>`.
+
+### `<CopyableValue>`
+**File:** `src/components/dashboard/CopyableValue.jsx`
+
+Inline component that copies its `value` prop to the clipboard on click.
+
+### `<I18nProvider>`
+**File:** `src/components/I18nProvider.jsx`
+
+Wraps the app in react-i18next context. Supports `en`, `es`, and `zh` out of the box.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,156 @@
+# Contributing to Stellar Dev Dashboard
+
+Thank you for taking the time to contribute! This guide covers everything you need to get started.
+
+## Table of Contents
+
+1. [Development setup](#development-setup)
+2. [Project structure](#project-structure)
+3. [Coding conventions](#coding-conventions)
+4. [Testing](#testing)
+5. [Pull request workflow](#pull-request-workflow)
+6. [Issue labels](#issue-labels)
+
+---
+
+## Development Setup
+
+### Prerequisites
+
+- Node.js ≥ 18
+- npm ≥ 9
+
+### Install & run
+
+```bash
+git clone https://github.com/Nanle-code/stellar-dev-dashboard.git
+cd stellar-dev-dashboard
+npm install
+npm run dev          # Vite dev server at http://localhost:5173
+```
+
+### Environment
+
+No `.env` file is required for local development. The app defaults to the Stellar testnet (`https://horizon-testnet.stellar.org`). You can switch networks from the sidebar.
+
+---
+
+## Project Structure
+
+```
+src/
+├── components/
+│   ├── dashboard/    # Feature panels (Account, Builder, DEXExplorer, …)
+│   ├── layout/       # Sidebar, MobileSidebar, DashboardGrid, …
+│   ├── charts/       # Recharts wrappers
+│   ├── assets/       # Asset discovery and display
+│   └── accessibility/ # Screen-reader announcer, keyboard nav
+├── hooks/            # Custom React hooks
+├── lib/              # Non-UI modules (stellar.js, store.js, transactionBuilder.js, …)
+├── utils/            # Pure utility functions (export.js, transactionValidation.ts, …)
+├── styles/           # globals.css, themes.js, accessibility.css
+└── i18n/             # Translation JSON files (en, es, zh)
+docs/
+├── api/              # API module reference (stellar.md, storage.md, …)
+├── components.md     # Component catalogue
+└── contributing.md   # This file
+```
+
+---
+
+## Coding Conventions
+
+### JavaScript / JSX
+
+- Use **ES modules** (`import`/`export`). No CommonJS `require()`.
+- All React components are functional; no class components.
+- Styling is done with inline `style` props using CSS custom properties from `globals.css`. Avoid third-party CSS-in-JS.
+- Use `"` for JSX string attributes and `'` for JS string literals.
+- Export components as **default exports**; export utilities as **named exports**.
+
+### TypeScript
+
+New utility/lib files that contain pure business logic should be `.ts`. React components remain `.jsx`. Shared type declarations go in the same file or a co-located `.d.ts`.
+
+### Naming
+
+| Kind | Convention | Example |
+|------|-----------|---------|
+| Component file | PascalCase | `DataExport.jsx` |
+| Hook file | camelCase, `use` prefix | `useDataExport.js` |
+| Lib/util file | camelCase | `transactionBuilder.js` |
+| CSS class | kebab-case | `.mobile-only` |
+| Zustand store key | camelCase | `isMobileMenuOpen` |
+
+### Accessibility
+
+- All interactive elements must be reachable by keyboard.
+- Use semantic HTML (`<nav>`, `<ul>`, `<button>`) over generic `<div>` + `onClick`.
+- Add `aria-label` to icon-only buttons.
+- Announce dynamic changes via `<ScreenReaderAnnouncer>` where appropriate.
+
+---
+
+## Testing
+
+### Unit tests (Vitest + Testing Library)
+
+```bash
+npm test              # run once
+npm run test:watch    # watch mode
+npm run test:coverage # with v8 coverage
+```
+
+Test files live alongside the source they cover: `src/utils/export.test.js` tests `src/utils/export.js`.
+
+New utility functions **must** have unit tests. New React components **should** have at least a smoke-render test.
+
+### End-to-end tests (Playwright)
+
+```bash
+npm run test:e2e        # headless
+npm run test:e2e:ui     # Playwright UI mode
+```
+
+E2E tests live in `tests/`.
+
+---
+
+## Pull Request Workflow
+
+1. **Fork** the repository and create a branch from `master`:
+   ```bash
+   git checkout -b fix/your-description
+   ```
+2. Make your changes, keeping each commit focused on one logical change.
+3. Run tests: `npm test && npm run test:e2e`.
+4. Open a PR targeting `master`. Include:
+   - A clear title referencing the issue (`fix: add export panel (#114)`).
+   - A summary of **what** changed and **why**.
+   - `Closes #<issue-number>` for each resolved issue.
+5. Respond to review comments within a week; otherwise the PR may be closed.
+
+### Commit style
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add path-payment support to transaction builder
+fix: restore focus after wallet modal closes
+docs: add component reference for DataExport
+refactor: extract flattenTransaction to export utils
+test: add validation tests for bumpSequence op
+```
+
+---
+
+## Issue Labels
+
+| Label | Meaning |
+|-------|---------|
+| `Stellar Wave` | Active sprint / batch of issues |
+| `good first issue` | Straightforward, well-scoped |
+| `help wanted` | Extra attention needed |
+| `bug` | Something is broken |
+| `enhancement` | New feature or improvement |
+| `documentation` | Docs-only change |

--- a/index.html
+++ b/index.html
@@ -3,7 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Real-time developer dashboard for the Stellar network" />
+    <meta name="theme-color" content="#00e5ff" />
     <title>Stellar Dev Dashboard</title>
+    <!-- PWA manifest (#110) -->
+    <link rel="manifest" href="/manifest.json" />
+    <link rel="apple-touch-icon" href="/icons/icon-192.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400&family=Syne:wght@400;500;600;700;800&display=swap" rel="stylesheet" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,27 @@
+{
+  "name": "Stellar Dev Dashboard",
+  "short_name": "StellarDash",
+  "description": "Real-time developer dashboard for the Stellar network — inspect accounts, transactions, contracts, and network stats.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#080c10",
+  "theme_color": "#00e5ff",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["developer tools", "finance", "utilities"],
+  "screenshots": [],
+  "prefer_related_applications": false
+}

--- a/src/components/dashboard/DataExport.jsx
+++ b/src/components/dashboard/DataExport.jsx
@@ -1,0 +1,190 @@
+/**
+ * DataExport component (#114).
+ *
+ * Provides a UI panel for exporting dashboard data as JSON/CSV
+ * and importing a previously saved backup file.
+ */
+
+import React, { useRef } from "react";
+import { useDataExport } from "../../hooks/useDataExport";
+import { useStore } from "../../lib/store";
+
+function ActionButton({ onClick, disabled, children, variant = "primary" }) {
+  const base = {
+    padding: "9px 18px",
+    borderRadius: "var(--radius-md)",
+    fontSize: "12px",
+    fontFamily: "var(--font-display)",
+    fontWeight: 600,
+    cursor: disabled ? "not-allowed" : "pointer",
+    opacity: disabled ? 0.5 : 1,
+    border: "none",
+    transition: "var(--transition)",
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "6px",
+  };
+  const styles =
+    variant === "primary"
+      ? { ...base, background: "var(--cyan)", color: "#000" }
+      : { ...base, background: "var(--bg-elevated)", color: "var(--text-primary)", border: "1px solid var(--border-bright)" };
+  return (
+    <button type="button" style={styles} onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  );
+}
+
+function StatusMessage({ error, success }) {
+  if (!error && !success) return null;
+  return (
+    <div
+      role="alert"
+      style={{
+        marginTop: "10px",
+        padding: "8px 12px",
+        borderRadius: "var(--radius-md)",
+        fontSize: "12px",
+        background: error ? "var(--red-glow)" : "var(--green-glow)",
+        border: `1px solid ${error ? "var(--red)" : "var(--green)"}`,
+        color: error ? "var(--red)" : "var(--green)",
+      }}
+    >
+      {error || "Import successful. Settings have been restored."}
+    </div>
+  );
+}
+
+export default function DataExport() {
+  const fileInputRef = useRef(null);
+  const { transactions, account } = useStore();
+  const {
+    isExporting,
+    isImporting,
+    exportError,
+    importError,
+    importSuccess,
+    exportDashboard,
+    exportTransactions,
+    exportBalances,
+    importBackup,
+  } = useDataExport();
+
+  const handleFileChange = (e) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      importBackup(file);
+      e.target.value = "";
+    }
+  };
+
+  const balances = account?.balances ?? [];
+  const txList = transactions ?? [];
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "20px",
+        padding: "4px",
+      }}
+    >
+      {/* ── Export section ── */}
+      <div
+        style={{
+          background: "var(--bg-card)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius-lg)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            padding: "14px 18px",
+            borderBottom: "1px solid var(--border)",
+            fontFamily: "var(--font-display)",
+            fontWeight: 600,
+            fontSize: "13px",
+          }}
+        >
+          Export Data
+        </div>
+        <div style={{ padding: "18px", display: "flex", flexDirection: "column", gap: "12px" }}>
+          <p style={{ fontSize: "12px", color: "var(--text-muted)", margin: 0 }}>
+            Download your dashboard settings and account data as files you can
+            restore later or open in a spreadsheet.
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "10px" }}>
+            <ActionButton onClick={exportDashboard} disabled={isExporting}>
+              ⬇ Export Dashboard Backup (JSON)
+            </ActionButton>
+            <ActionButton
+              onClick={() => exportTransactions(txList)}
+              disabled={isExporting || txList.length === 0}
+              variant="secondary"
+            >
+              ⬇ Export Transactions (CSV)
+            </ActionButton>
+            <ActionButton
+              onClick={() => exportBalances(balances)}
+              disabled={isExporting || balances.length === 0}
+              variant="secondary"
+            >
+              ⬇ Export Balances (CSV)
+            </ActionButton>
+          </div>
+          {exportError && (
+            <StatusMessage error={exportError} />
+          )}
+        </div>
+      </div>
+
+      {/* ── Import section ── */}
+      <div
+        style={{
+          background: "var(--bg-card)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius-lg)",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            padding: "14px 18px",
+            borderBottom: "1px solid var(--border)",
+            fontFamily: "var(--font-display)",
+            fontWeight: 600,
+            fontSize: "13px",
+          }}
+        >
+          Import Backup
+        </div>
+        <div style={{ padding: "18px", display: "flex", flexDirection: "column", gap: "12px" }}>
+          <p style={{ fontSize: "12px", color: "var(--text-muted)", margin: 0 }}>
+            Restore a previously exported dashboard backup JSON file. Your
+            current network selection and theme will be updated.
+          </p>
+          <div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              style={{ display: "none" }}
+              onChange={handleFileChange}
+              aria-label="Select backup JSON file to import"
+            />
+            <ActionButton
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isImporting}
+              variant="secondary"
+            >
+              {isImporting ? "⏳ Importing…" : "⬆ Choose Backup File"}
+            </ActionButton>
+          </div>
+          <StatusMessage error={importError} success={importSuccess} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/MobileSidebar.jsx
+++ b/src/components/layout/MobileSidebar.jsx
@@ -1,0 +1,278 @@
+/**
+ * MobileSidebar (#110).
+ *
+ * Slide-in navigation drawer for small screens. Renders a hamburger toggle
+ * in the fixed mobile header and the full nav list in a side-panel overlay.
+ * Closes on nav-item tap, backdrop click, and Escape key.
+ */
+
+import React, { useCallback, useEffect, useRef } from "react";
+import { useStore } from "../../lib/store";
+
+const NAV_ITEMS = [
+  { id: "overview", label: "Overview", icon: "◈" },
+  { id: "account", label: "Account", icon: "◉" },
+  { id: "compare", label: "Compare", icon: "◫" },
+  { id: "transactions", label: "Transactions", icon: "⇄" },
+  { id: "contracts", label: "Contracts", icon: "◻" },
+  { id: "assets", label: "Assets", icon: "💎" },
+  { id: "network", label: "Network", icon: "◎" },
+  { id: "realtime", label: "Real-Time", icon: "◉" },
+  { id: "builder", label: "Builder", icon: "⚒" },
+  { id: "faucet", label: "Faucet", icon: "⬡" },
+  { id: "wallet", label: "Wallet", icon: "⊡" },
+  { id: "signer", label: "Signer", icon: "✎" },
+  { id: "multisig", label: "Multisig", icon: "⊕" },
+  { id: "portfolio", label: "Portfolio", icon: "◐" },
+  { id: "charts", label: "Charts", icon: "▤" },
+];
+
+/**
+ * Hamburger button shown in the mobile top-bar.
+ */
+export function HamburgerButton() {
+  const { isMobileMenuOpen, setMobileMenuOpen } = useStore();
+  return (
+    <button
+      type="button"
+      aria-label={isMobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+      aria-expanded={isMobileMenuOpen}
+      aria-controls="mobile-sidebar"
+      onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}
+      style={{
+        background: "none",
+        border: "none",
+        cursor: "pointer",
+        padding: "8px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "5px",
+        minHeight: "var(--touch-target)",
+        minWidth: "var(--touch-target)",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          style={{
+            display: "block",
+            width: "20px",
+            height: "2px",
+            background: "var(--cyan)",
+            borderRadius: "2px",
+            transition: "var(--transition)",
+          }}
+        />
+      ))}
+    </button>
+  );
+}
+
+/**
+ * Full-screen overlay + slide-in drawer for mobile navigation.
+ */
+export default function MobileSidebar() {
+  const { activeTab, setActiveTab, isMobileMenuOpen, setMobileMenuOpen, theme, toggleTheme, network } =
+    useStore();
+  const drawerRef = useRef(null);
+
+  const close = useCallback(() => setMobileMenuOpen(false), [setMobileMenuOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isMobileMenuOpen) return;
+    const handler = (e) => { if (e.key === "Escape") close(); };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isMobileMenuOpen, close]);
+
+  // Focus first nav item when opening
+  useEffect(() => {
+    if (!isMobileMenuOpen) return;
+    const first = drawerRef.current?.querySelector("button, a");
+    first?.focus();
+  }, [isMobileMenuOpen]);
+
+  // Prevent body scroll while open
+  useEffect(() => {
+    document.body.style.overflow = isMobileMenuOpen ? "hidden" : "";
+    return () => { document.body.style.overflow = ""; };
+  }, [isMobileMenuOpen]);
+
+  if (!isMobileMenuOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        aria-hidden="true"
+        onClick={close}
+        style={{
+          position: "fixed",
+          inset: 0,
+          background: "rgba(0,0,0,0.6)",
+          backdropFilter: "blur(4px)",
+          zIndex: 999,
+        }}
+      />
+
+      {/* Drawer */}
+      <nav
+        id="mobile-sidebar"
+        ref={drawerRef}
+        aria-label="Mobile navigation"
+        role="dialog"
+        aria-modal="true"
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          bottom: 0,
+          width: "var(--sidebar-width-mobile, 280px)",
+          background: "var(--bg-surface)",
+          borderRight: "1px solid var(--border)",
+          zIndex: 1000,
+          display: "flex",
+          flexDirection: "column",
+          overflowY: "auto",
+          padding: "16px 0 32px",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "0 16px 16px",
+            borderBottom: "1px solid var(--border)",
+            marginBottom: "8px",
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--font-display)",
+              fontWeight: 700,
+              fontSize: "14px",
+              color: "var(--cyan)",
+              letterSpacing: "0.1em",
+            }}
+          >
+            STELLAR DASH
+          </span>
+          <button
+            type="button"
+            aria-label="Close navigation"
+            onClick={close}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              color: "var(--text-muted)",
+              fontSize: "18px",
+              padding: "4px 8px",
+              minHeight: "var(--touch-target-sm)",
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Network badge */}
+        <div style={{ padding: "4px 16px 12px" }}>
+          <span
+            style={{
+              display: "inline-block",
+              fontSize: "10px",
+              fontFamily: "var(--font-mono)",
+              padding: "3px 8px",
+              borderRadius: "999px",
+              background: "var(--cyan-glow-sm)",
+              border: "1px solid var(--cyan-dim)",
+              color: "var(--cyan)",
+              textTransform: "uppercase",
+            }}
+          >
+            {network}
+          </span>
+        </div>
+
+        {/* Nav items */}
+        <ul
+          role="list"
+          style={{
+            listStyle: "none",
+            margin: 0,
+            padding: "0 8px",
+            flexGrow: 1,
+          }}
+        >
+          {NAV_ITEMS.map((item) => {
+            const isActive = activeTab === item.id;
+            return (
+              <li key={item.id}>
+                <button
+                  type="button"
+                  aria-current={isActive ? "page" : undefined}
+                  onClick={() => { setActiveTab(item.id); close(); }}
+                  style={{
+                    width: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "12px",
+                    padding: "10px 12px",
+                    borderRadius: "var(--radius-md)",
+                    border: "none",
+                    background: isActive ? "var(--cyan-glow-sm)" : "transparent",
+                    color: isActive ? "var(--cyan)" : "var(--text-secondary)",
+                    cursor: "pointer",
+                    fontSize: "13px",
+                    fontFamily: "var(--font-display)",
+                    fontWeight: isActive ? 600 : 400,
+                    textAlign: "left",
+                    minHeight: "var(--touch-target)",
+                    transition: "var(--transition)",
+                    borderLeft: isActive ? "2px solid var(--cyan)" : "2px solid transparent",
+                  }}
+                >
+                  <span aria-hidden="true" style={{ fontSize: "16px", minWidth: "20px", textAlign: "center" }}>
+                    {item.icon}
+                  </span>
+                  {item.label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        {/* Footer — theme toggle */}
+        <div style={{ padding: "16px 16px 0", borderTop: "1px solid var(--border)", marginTop: "8px" }}>
+          <button
+            type="button"
+            onClick={toggleTheme}
+            style={{
+              width: "100%",
+              display: "flex",
+              alignItems: "center",
+              gap: "10px",
+              padding: "10px 12px",
+              borderRadius: "var(--radius-md)",
+              border: "1px solid var(--border)",
+              background: "var(--bg-elevated)",
+              color: "var(--text-secondary)",
+              cursor: "pointer",
+              fontSize: "12px",
+              fontFamily: "var(--font-display)",
+              minHeight: "var(--touch-target)",
+            }}
+          >
+            <span aria-hidden="true">{theme === "dark" ? "☀" : "☾"}</span>
+            {theme === "dark" ? "Light mode" : "Dark mode"}
+          </button>
+        </div>
+      </nav>
+    </>
+  );
+}

--- a/src/hooks/useDataExport.js
+++ b/src/hooks/useDataExport.js
@@ -1,0 +1,120 @@
+/**
+ * useDataExport hook (#114).
+ *
+ * Provides export/import actions bound to the live Zustand store state.
+ */
+
+import { useCallback, useState } from "react";
+import { useStore } from "../lib/store";
+import {
+  buildBackupPayload,
+  exportJson,
+  exportCsv,
+  flattenTransaction,
+  flattenBalance,
+} from "../utils/export";
+import { readFileAsText, parseBackup, validateBackupPayload, applyBackupToStore } from "../lib/import";
+
+/**
+ * @returns {{
+ *   isExporting: boolean,
+ *   isImporting: boolean,
+ *   exportError: string|null,
+ *   importError: string|null,
+ *   importSuccess: boolean,
+ *   exportDashboard: () => void,
+ *   exportTransactions: (transactions: Object[]) => void,
+ *   exportBalances: (balances: Object[]) => void,
+ *   importBackup: (file: File) => Promise<void>,
+ * }}
+ */
+export function useDataExport() {
+  const store = useStore();
+  const [isExporting, setIsExporting] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [exportError, setExportError] = useState(null);
+  const [importError, setImportError] = useState(null);
+  const [importSuccess, setImportSuccess] = useState(false);
+
+  const exportDashboard = useCallback(() => {
+    setIsExporting(true);
+    setExportError(null);
+    try {
+      const payload = buildBackupPayload(store);
+      const slug = store.connectedAddress
+        ? store.connectedAddress.slice(0, 6)
+        : "dashboard";
+      exportJson(payload, `stellar-${slug}-backup`);
+    } catch (err) {
+      setExportError(err.message);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [store]);
+
+  const exportTransactions = useCallback((transactions) => {
+    setIsExporting(true);
+    setExportError(null);
+    try {
+      const rows = (transactions || []).map(flattenTransaction);
+      exportCsv(rows, "stellar-transactions");
+    } catch (err) {
+      setExportError(err.message);
+    } finally {
+      setIsExporting(false);
+    }
+  }, []);
+
+  const exportBalances = useCallback((balances) => {
+    setIsExporting(true);
+    setExportError(null);
+    try {
+      const rows = (balances || []).map(flattenBalance);
+      exportCsv(rows, "stellar-balances");
+    } catch (err) {
+      setExportError(err.message);
+    } finally {
+      setIsExporting(false);
+    }
+  }, []);
+
+  const importBackup = useCallback(
+    async (file) => {
+      setIsImporting(true);
+      setImportError(null);
+      setImportSuccess(false);
+      try {
+        const text = await readFileAsText(file);
+        const result = parseBackup(text);
+        if (!result.ok) {
+          setImportError(result.error);
+          return;
+        }
+        const validationErrors = validateBackupPayload(result.data);
+        if (validationErrors.length > 0) {
+          setImportError(validationErrors.join(" "));
+          return;
+        }
+        applyBackupToStore(result.data, store);
+        setImportSuccess(true);
+      } catch (err) {
+        setImportError(err.message);
+      } finally {
+        setIsImporting(false);
+      }
+    },
+    [store],
+  );
+
+  return {
+    isExporting,
+    isImporting,
+    exportError,
+    importError,
+    importSuccess,
+    exportDashboard,
+    exportTransactions,
+    exportBalances,
+    importBackup,
+  };
+}

--- a/src/lib/import.js
+++ b/src/lib/import.js
@@ -1,0 +1,80 @@
+/**
+ * Data import functionality (#114).
+ *
+ * Reads backup JSON files produced by the export utilities and
+ * validates them before handing them to the store for restoration.
+ */
+
+const SUPPORTED_VERSIONS = [1];
+
+/**
+ * Parse and validate a backup JSON string.
+ * @param {string} jsonString - Raw file contents
+ * @returns {{ ok: true, data: Object } | { ok: false, error: string }}
+ */
+export function parseBackup(jsonString) {
+  let parsed;
+  try {
+    parsed = JSON.parse(jsonString);
+  } catch {
+    return { ok: false, error: "File is not valid JSON." };
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return { ok: false, error: "Backup file has an unexpected format." };
+  }
+
+  if (!SUPPORTED_VERSIONS.includes(parsed.version)) {
+    return {
+      ok: false,
+      error: `Unsupported backup version: ${parsed.version}. Expected one of: ${SUPPORTED_VERSIONS.join(", ")}.`,
+    };
+  }
+
+  return { ok: true, data: parsed };
+}
+
+/**
+ * Read a File object and return its text content as a promise.
+ * @param {File} file
+ * @returns {Promise<string>}
+ */
+export function readFileAsText(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => resolve(e.target.result);
+    reader.onerror = () => reject(new Error("Could not read file."));
+    reader.readAsText(file);
+  });
+}
+
+/**
+ * Validate that a backup payload has all required top-level keys.
+ * @param {Object} data - Parsed backup object
+ * @returns {string[]}  - Array of validation error messages (empty = valid)
+ */
+export function validateBackupPayload(data) {
+  const errors = [];
+  if (!data.exportedAt) errors.push("Missing exportedAt timestamp.");
+  if (!data.account || typeof data.account !== "object")
+    errors.push("Missing or invalid account section.");
+  return errors;
+}
+
+/**
+ * Merge imported backup data into the given Zustand store.
+ * Only whitelisted keys are applied to prevent prototype pollution.
+ * @param {Object} data  - Validated backup payload
+ * @param {Object} store - Zustand store with setter actions
+ */
+export function applyBackupToStore(data, store) {
+  if (data.theme && ["dark", "light"].includes(data.theme)) {
+    store.setTheme?.(data.theme);
+  }
+  if (data.account?.network) {
+    store.setNetwork?.(data.account.network);
+  }
+  if (Array.isArray(data.watchedAddresses)) {
+    store.setWatchedAddresses?.(data.watchedAddresses);
+  }
+}

--- a/src/lib/transactionBuilder.js
+++ b/src/lib/transactionBuilder.js
@@ -10,6 +10,15 @@ export const OPERATION_TYPES = [
   { value: "setOptions", label: "Set Options" },
   { value: "accountMerge", label: "Account Merge" },
   { value: "manageData", label: "Manage Data" },
+  // Extended operation types (#111)
+  { value: "pathPaymentStrictSend", label: "Path Payment (Strict Send)" },
+  { value: "pathPaymentStrictReceive", label: "Path Payment (Strict Receive)" },
+  { value: "claimClaimableBalance", label: "Claim Claimable Balance" },
+  { value: "createClaimableBalance", label: "Create Claimable Balance" },
+  { value: "bumpSequence", label: "Bump Sequence" },
+  { value: "revokeSponsorship", label: "Revoke Sponsorship" },
+  { value: "beginSponsoringFutureReserves", label: "Begin Sponsoring Future Reserves" },
+  { value: "endSponsoringFutureReserves", label: "End Sponsoring Future Reserves" },
 ];
 
 export function createOperation(type, params) {
@@ -93,6 +102,81 @@ export function createOperation(type, params) {
         name: params.name,
         value: params.value || null,
       });
+
+    // ── Extended operations (#111) ──────────────────────────────────────────
+
+    case "pathPaymentStrictSend":
+      return StellarSdk.Operation.pathPaymentStrictSend({
+        sendAsset:
+          params.sendAssetType === "native"
+            ? StellarSdk.Asset.native()
+            : new StellarSdk.Asset(params.sendAssetCode, params.sendAssetIssuer),
+        sendAmount: params.sendAmount,
+        destination: params.destination,
+        destAsset:
+          params.destAssetType === "native"
+            ? StellarSdk.Asset.native()
+            : new StellarSdk.Asset(params.destAssetCode, params.destAssetIssuer),
+        destMin: params.destMin,
+        path: (params.path || []).map(
+          (a) => new StellarSdk.Asset(a.assetCode, a.assetIssuer),
+        ),
+      });
+
+    case "pathPaymentStrictReceive":
+      return StellarSdk.Operation.pathPaymentStrictReceive({
+        sendAsset:
+          params.sendAssetType === "native"
+            ? StellarSdk.Asset.native()
+            : new StellarSdk.Asset(params.sendAssetCode, params.sendAssetIssuer),
+        sendMax: params.sendMax,
+        destination: params.destination,
+        destAsset:
+          params.destAssetType === "native"
+            ? StellarSdk.Asset.native()
+            : new StellarSdk.Asset(params.destAssetCode, params.destAssetIssuer),
+        destAmount: params.destAmount,
+        path: (params.path || []).map(
+          (a) => new StellarSdk.Asset(a.assetCode, a.assetIssuer),
+        ),
+      });
+
+    case "claimClaimableBalance":
+      return StellarSdk.Operation.claimClaimableBalance({
+        balanceId: params.balanceId,
+      });
+
+    case "createClaimableBalance": {
+      const claimants = (params.claimants || []).map(
+        (c) => new StellarSdk.Claimant(c.destination, c.predicate),
+      );
+      return StellarSdk.Operation.createClaimableBalance({
+        asset:
+          params.assetType === "native"
+            ? StellarSdk.Asset.native()
+            : new StellarSdk.Asset(params.assetCode, params.assetIssuer),
+        amount: params.amount,
+        claimants,
+      });
+    }
+
+    case "bumpSequence":
+      return StellarSdk.Operation.bumpSequence({
+        bumpTo: params.bumpTo,
+      });
+
+    case "revokeSponsorship":
+      return StellarSdk.Operation.revokeAccountSponsorship({
+        account: params.account,
+      });
+
+    case "beginSponsoringFutureReserves":
+      return StellarSdk.Operation.beginSponsoringFutureReserves({
+        sponsoredId: params.sponsoredId,
+      });
+
+    case "endSponsoringFutureReserves":
+      return StellarSdk.Operation.endSponsoringFutureReserves({});
 
     default:
       throw new Error(`Unsupported operation type: ${type}`);

--- a/src/lib/transactionTemplates.js
+++ b/src/lib/transactionTemplates.js
@@ -1,0 +1,173 @@
+/**
+ * Pre-built transaction templates (#111).
+ *
+ * Each template provides a human-readable description, a list of
+ * default operation parameters, and field-level documentation so
+ * the Builder UI can render the right form fields automatically.
+ */
+
+export const TRANSACTION_TEMPLATES = [
+  {
+    id: "simple_payment",
+    label: "Simple XLM Payment",
+    description: "Send XLM from one account to another.",
+    operations: [
+      {
+        type: "payment",
+        params: {
+          destination: "",
+          assetType: "native",
+          assetCode: "",
+          assetIssuer: "",
+          amount: "10",
+        },
+      },
+    ],
+    memo: "",
+    memoType: "text",
+  },
+  {
+    id: "asset_payment",
+    label: "Custom Asset Payment",
+    description: "Send a non-XLM Stellar asset to another account.",
+    operations: [
+      {
+        type: "payment",
+        params: {
+          destination: "",
+          assetType: "credit_alphanum4",
+          assetCode: "USDC",
+          assetIssuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+          amount: "10",
+        },
+      },
+    ],
+    memo: "",
+    memoType: "text",
+  },
+  {
+    id: "add_trustline",
+    label: "Add Trustline",
+    description: "Allow your account to hold a specific asset by adding a trustline.",
+    operations: [
+      {
+        type: "changeTrust",
+        params: {
+          assetCode: "USDC",
+          assetIssuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+          limit: "",
+        },
+      },
+    ],
+    memo: "",
+    memoType: "text",
+  },
+  {
+    id: "create_account",
+    label: "Create & Fund Account",
+    description: "Create a new Stellar account with a minimum starting balance.",
+    operations: [
+      {
+        type: "createAccount",
+        params: {
+          destination: "",
+          startingBalance: "1",
+        },
+      },
+    ],
+    memo: "Account created via Stellar Dev Dashboard",
+    memoType: "text",
+  },
+  {
+    id: "path_payment",
+    label: "Path Payment (Cross-Asset)",
+    description:
+      "Send a payment that automatically converts between assets using Stellar's DEX path finding.",
+    operations: [
+      {
+        type: "pathPaymentStrictSend",
+        params: {
+          sendAssetType: "native",
+          sendAssetCode: "",
+          sendAssetIssuer: "",
+          sendAmount: "10",
+          destination: "",
+          destAssetType: "credit_alphanum4",
+          destAssetCode: "USDC",
+          destAssetIssuer: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+          destMin: "1",
+          path: [],
+        },
+      },
+    ],
+    memo: "",
+    memoType: "text",
+  },
+  {
+    id: "set_home_domain",
+    label: "Set Home Domain",
+    description: "Associate a home domain with your account for federation and TOML lookups.",
+    operations: [
+      {
+        type: "setOptions",
+        params: {
+          homeDomain: "example.com",
+          setFlags: "",
+          clearFlags: "",
+        },
+      },
+    ],
+    memo: "",
+    memoType: "text",
+  },
+  {
+    id: "account_merge",
+    label: "Merge Account",
+    description:
+      "Merge all XLM from this account into a destination account and delete this account.",
+    operations: [
+      {
+        type: "accountMerge",
+        params: {
+          destination: "",
+        },
+      },
+    ],
+    memo: "",
+    memoType: "text",
+  },
+  {
+    id: "bump_sequence",
+    label: "Bump Sequence",
+    description: "Invalidate a set of in-flight transactions by bumping the sequence number.",
+    operations: [
+      {
+        type: "bumpSequence",
+        params: {
+          bumpTo: "",
+        },
+      },
+    ],
+    memo: "",
+    memoType: "text",
+  },
+];
+
+/**
+ * Look up a template by id.
+ * @param {string} id
+ * @returns {Object|undefined}
+ */
+export function getTemplate(id) {
+  return TRANSACTION_TEMPLATES.find((t) => t.id === id);
+}
+
+/**
+ * Deep-clone a template so edits don't mutate the original.
+ * @param {string} id
+ * @returns {Object|null}
+ */
+export function cloneTemplate(id) {
+  const tpl = getTemplate(id);
+  return tpl ? JSON.parse(JSON.stringify(tpl)) : null;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -740,3 +740,90 @@ a { color: inherit; text-decoration: none; }
 .widget-base::-webkit-scrollbar-thumb:hover {
   background: var(--border-bright);
 }
+
+/* ── Mobile-first responsive additions (#110) ────────────────────────────── */
+
+/* Safe-area insets for notched/island devices */
+@supports (padding: env(safe-area-inset-top)) {
+  .mobile-safe-top    { padding-top:    env(safe-area-inset-top); }
+  .mobile-safe-bottom { padding-bottom: env(safe-area-inset-bottom); }
+  .mobile-safe-left   { padding-left:   env(safe-area-inset-left); }
+  .mobile-safe-right  { padding-right:  env(safe-area-inset-right); }
+}
+
+/* Responsive layout helpers */
+.stack-on-mobile { display: flex; flex-direction: row; gap: 12px; }
+
+@media (max-width: 768px) {
+  .stack-on-mobile {
+    flex-direction: column;
+  }
+
+  /* Tighten content padding on small screens */
+  .dashboard-content {
+    padding: var(--content-padding-mobile) !important;
+  }
+
+  /* Full-width cards on mobile */
+  .card-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  /* Increase touch targets */
+  button, a, [role="button"] {
+    min-height: var(--touch-target);
+  }
+
+  /* Hide desktop-only sidebar; show hamburger */
+  .desktop-sidebar { display: none !important; }
+  .mobile-header   { display: flex !important; }
+
+  /* Allow tables to scroll horizontally */
+  .table-responsive {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Adjust font sizes for readability */
+  body { font-size: 14px; }
+}
+
+/* Tablet breakpoint */
+@media (min-width: 769px) and (max-width: 1024px) {
+  .dashboard-content {
+    padding: var(--content-padding-tablet) !important;
+  }
+
+  /* Two-column grid on tablet */
+  .card-grid-auto {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* PWA standalone display adjustments */
+@media (display-mode: standalone) {
+  /* Add extra top padding for devices that need it in standalone mode */
+  .app-root {
+    padding-top: env(safe-area-inset-top, 0px);
+  }
+}
+
+/* Reduced-motion: disable all transitions and animations */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* High-contrast mode support */
+@media (forced-colors: active) {
+  :root {
+    --cyan: ButtonText;
+    --border: ButtonBorder;
+    --text-primary: CanvasText;
+    --bg-card: Canvas;
+  }
+}

--- a/src/utils/export.js
+++ b/src/utils/export.js
@@ -1,0 +1,115 @@
+/**
+ * Data export utilities (#114).
+ *
+ * Converts dashboard data (account info, transactions, assets, settings)
+ * to JSON or CSV and triggers a browser download.
+ */
+
+/**
+ * Trigger a file download in the browser.
+ * @param {string} content  - File contents as a string
+ * @param {string} filename - Suggested filename
+ * @param {string} mimeType - MIME type (default: application/json)
+ */
+export function downloadFile(content, filename, mimeType = "application/json") {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Export an array of objects to a CSV file.
+ * @param {Object[]} rows       - Data rows
+ * @param {string}   filename   - Download filename (without extension)
+ * @param {string[]} [columns]  - Column names; inferred from first row if omitted
+ */
+export function exportCsv(rows, filename, columns) {
+  if (!rows || rows.length === 0) {
+    downloadFile("", `${filename}.csv`, "text/csv");
+    return;
+  }
+  const cols = columns || Object.keys(rows[0]);
+  const escape = (v) => {
+    const s = v == null ? "" : String(v);
+    return s.includes(",") || s.includes('"') || s.includes("\n")
+      ? `"${s.replace(/"/g, '""')}"`
+      : s;
+  };
+  const lines = [
+    cols.join(","),
+    ...rows.map((row) => cols.map((c) => escape(row[c])).join(",")),
+  ];
+  downloadFile(lines.join("\r\n"), `${filename}.csv`, "text/csv");
+}
+
+/**
+ * Export any value to a JSON file.
+ * @param {*}      data     - Data to serialise
+ * @param {string} filename - Download filename (without extension)
+ */
+export function exportJson(data, filename) {
+  downloadFile(JSON.stringify(data, null, 2), `${filename}.json`);
+}
+
+/**
+ * Build the complete dashboard backup object from live state.
+ * @param {Object} state - Zustand store state snapshot
+ * @returns {Object}     - Backup payload
+ */
+export function buildBackupPayload(state) {
+  return {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    account: {
+      connectedAddress: state.connectedAddress ?? null,
+      network: state.network ?? "testnet",
+    },
+    watchedAddresses: state.watchedAddresses ?? [],
+    customNetworks: state.customNetworks ?? [],
+    theme: state.theme ?? "dark",
+    activeTab: state.activeTab ?? "overview",
+  };
+}
+
+/**
+ * Flatten a Horizon transaction record to a plain CSV row.
+ * @param {Object} tx - Horizon transaction record
+ * @returns {Object}
+ */
+export function flattenTransaction(tx) {
+  return {
+    id: tx.id,
+    hash: tx.hash,
+    ledger: tx.ledger,
+    created_at: tx.created_at,
+    source_account: tx.source_account,
+    fee_charged: tx.fee_charged,
+    operation_count: tx.operation_count,
+    successful: tx.successful,
+    memo_type: tx.memo_type ?? "",
+    memo: tx.memo ?? "",
+  };
+}
+
+/**
+ * Flatten a Horizon balance object (from account.balances) to a CSV row.
+ * @param {Object} balance - Horizon balance record
+ * @returns {Object}
+ */
+export function flattenBalance(balance) {
+  return {
+    asset_type: balance.asset_type,
+    asset_code: balance.asset_code ?? "XLM",
+    asset_issuer: balance.asset_issuer ?? "",
+    balance: balance.balance,
+    limit: balance.limit ?? "",
+    buying_liabilities: balance.buying_liabilities ?? "0",
+    selling_liabilities: balance.selling_liabilities ?? "0",
+  };
+}

--- a/src/utils/transactionValidation.ts
+++ b/src/utils/transactionValidation.ts
@@ -1,0 +1,178 @@
+/**
+ * Advanced transaction validation (#111).
+ *
+ * Provides per-operation validation rules beyond the basic checks in
+ * transactionBuilder.js, returning structured error objects that the
+ * Builder UI can surface inline next to the relevant field.
+ */
+
+import { validateStellarAddress } from "../lib/validation";
+
+export interface FieldError {
+  field: string;
+  message: string;
+}
+
+export interface OperationValidationResult {
+  operationIndex: number;
+  errors: FieldError[];
+}
+
+export interface TransactionValidationResult {
+  valid: boolean;
+  operationErrors: OperationValidationResult[];
+  globalErrors: string[];
+}
+
+function isPositiveAmount(value: unknown): boolean {
+  if (typeof value !== "string" && typeof value !== "number") return false;
+  const n = parseFloat(String(value));
+  return Number.isFinite(n) && n > 0;
+}
+
+function isNonNegativeAmount(value: unknown): boolean {
+  if (typeof value !== "string" && typeof value !== "number") return false;
+  const n = parseFloat(String(value));
+  return Number.isFinite(n) && n >= 0;
+}
+
+function isValidAssetCode(code: unknown): boolean {
+  if (typeof code !== "string") return false;
+  return /^[A-Z0-9]{1,12}$/.test(code);
+}
+
+function validatePayment(params: Record<string, unknown>): FieldError[] {
+  const errors: FieldError[] = [];
+  const destResult = validateStellarAddress(params.destination);
+  if (!destResult.valid) errors.push({ field: "destination", message: destResult.errors[0] });
+  if (!isPositiveAmount(params.amount))
+    errors.push({ field: "amount", message: "Amount must be a positive number." });
+  if (params.assetType !== "native") {
+    if (!isValidAssetCode(params.assetCode))
+      errors.push({ field: "assetCode", message: "Asset code must be 1–12 uppercase letters/digits." });
+    const issuerResult = validateStellarAddress(params.assetIssuer);
+    if (!issuerResult.valid)
+      errors.push({ field: "assetIssuer", message: issuerResult.errors[0] });
+  }
+  return errors;
+}
+
+function validateCreateAccount(params: Record<string, unknown>): FieldError[] {
+  const errors: FieldError[] = [];
+  const destResult = validateStellarAddress(params.destination);
+  if (!destResult.valid) errors.push({ field: "destination", message: destResult.errors[0] });
+  const bal = parseFloat(String(params.startingBalance));
+  if (!Number.isFinite(bal) || bal < 1)
+    errors.push({ field: "startingBalance", message: "Starting balance must be at least 1 XLM." });
+  return errors;
+}
+
+function validateChangeTrust(params: Record<string, unknown>): FieldError[] {
+  const errors: FieldError[] = [];
+  if (!isValidAssetCode(params.assetCode))
+    errors.push({ field: "assetCode", message: "Asset code must be 1–12 uppercase letters/digits." });
+  const issuerResult = validateStellarAddress(params.assetIssuer);
+  if (!issuerResult.valid)
+    errors.push({ field: "assetIssuer", message: issuerResult.errors[0] });
+  if (params.limit !== "" && params.limit !== undefined && !isNonNegativeAmount(params.limit))
+    errors.push({ field: "limit", message: "Limit must be a non-negative number or empty for maximum." });
+  return errors;
+}
+
+function validateManageOffer(params: Record<string, unknown>, type: string): FieldError[] {
+  const errors: FieldError[] = [];
+  const amountField = type === "manageBuyOffer" ? "buyAmount" : "amount";
+  if (!isPositiveAmount(params[amountField]))
+    errors.push({ field: amountField, message: "Amount must be a positive number." });
+  if (!isPositiveAmount(params.price))
+    errors.push({ field: "price", message: "Price must be a positive number." });
+  return errors;
+}
+
+function validatePathPayment(params: Record<string, unknown>): FieldError[] {
+  const errors: FieldError[] = [];
+  const destResult = validateStellarAddress(params.destination);
+  if (!destResult.valid) errors.push({ field: "destination", message: destResult.errors[0] });
+  const sendAmount = (params.sendAmount ?? params.sendMax) as unknown;
+  if (!isPositiveAmount(sendAmount))
+    errors.push({ field: "sendAmount", message: "Send amount must be a positive number." });
+  const destAmount = (params.destAmount ?? params.destMin) as unknown;
+  if (!isPositiveAmount(destAmount))
+    errors.push({ field: "destAmount", message: "Destination amount must be a positive number." });
+  return errors;
+}
+
+function validateClaimClaimableBalance(params: Record<string, unknown>): FieldError[] {
+  const errors: FieldError[] = [];
+  if (!params.balanceId || typeof params.balanceId !== "string" || params.balanceId.trim() === "")
+    errors.push({ field: "balanceId", message: "Balance ID is required." });
+  return errors;
+}
+
+function validateBumpSequence(params: Record<string, unknown>): FieldError[] {
+  const errors: FieldError[] = [];
+  const n = parseInt(String(params.bumpTo), 10);
+  if (!Number.isFinite(n) || n < 0)
+    errors.push({ field: "bumpTo", message: "Bump-to value must be a non-negative integer." });
+  return errors;
+}
+
+function validateBeginSponsoring(params: Record<string, unknown>): FieldError[] {
+  const result = validateStellarAddress(params.sponsoredId);
+  if (!result.valid) return [{ field: "sponsoredId", message: result.errors[0] }];
+  return [];
+}
+
+/**
+ * Validate a single operation.
+ */
+export function validateOperation(
+  type: string,
+  params: Record<string, unknown>,
+): FieldError[] {
+  switch (type) {
+    case "payment": return validatePayment(params);
+    case "createAccount": return validateCreateAccount(params);
+    case "changeTrust": return validateChangeTrust(params);
+    case "manageSellOffer":
+    case "manageBuyOffer": return validateManageOffer(params, type);
+    case "pathPaymentStrictSend":
+    case "pathPaymentStrictReceive": return validatePathPayment(params);
+    case "claimClaimableBalance": return validateClaimClaimableBalance(params);
+    case "bumpSequence": return validateBumpSequence(params);
+    case "beginSponsoringFutureReserves": return validateBeginSponsoring(params);
+    default: return [];
+  }
+}
+
+/**
+ * Validate an entire transaction parameter set.
+ */
+export function validateTransactionParams(params: {
+  sourceAccount: string;
+  operations: Array<{ type: string; params: Record<string, unknown> }>;
+  baseFee?: number;
+}): TransactionValidationResult {
+  const globalErrors: string[] = [];
+  const operationErrors: OperationValidationResult[] = [];
+
+  const sourceResult = validateStellarAddress(params.sourceAccount);
+  if (!sourceResult.valid) globalErrors.push(`Source account: ${sourceResult.errors[0]}`);
+
+  if (!params.operations || params.operations.length === 0) {
+    globalErrors.push("At least one operation is required.");
+  } else if (params.operations.length > 100) {
+    globalErrors.push("A transaction may contain at most 100 operations.");
+  }
+
+  (params.operations ?? []).forEach((op, i) => {
+    const errors = validateOperation(op.type, op.params ?? {});
+    if (errors.length > 0) operationErrors.push({ operationIndex: i, errors });
+  });
+
+  return {
+    valid: globalErrors.length === 0 && operationErrors.length === 0,
+    operationErrors,
+    globalErrors,
+  };
+}


### PR DESCRIPTION
## Summary

- **#108** — Add comprehensive documentation: `docs/components.md` (full component catalogue with props, usage examples, and file paths), `docs/contributing.md` (dev setup, project structure, coding conventions, testing guide, PR workflow, commit style, issue labels). Extend `docs/api/README.md` to reference three new module pages: `transactionBuilder.md`, `transactionTemplates.md`, and `dataExport.md`.

- **#110** — Mobile responsiveness & PWA: add `public/manifest.json` (standalone display, theme-color, icons), wire `<link rel="manifest">` and `apple-touch-icon` into `index.html`. Add `src/components/layout/MobileSidebar.jsx` — a fully accessible slide-in drawer with focus trap, Escape-to-close, body-scroll lock, and `role="dialog"` semantics. Extend `src/styles/globals.css` with safe-area insets, mobile/tablet breakpoints, `display-mode: standalone` rule, `prefers-reduced-motion`, and `forced-colors` high-contrast support.

- **#111** — Advanced transaction builder: expand `OPERATION_TYPES` in `transactionBuilder.js` with 8 new operation types (path payments, claimable balances, bump sequence, sponsorship). Add `src/lib/transactionTemplates.js` with 8 pre-built templates (`cloneTemplate` returns a deep copy so UI edits are isolated). Add `src/utils/transactionValidation.ts` with per-field `FieldError` validation for every operation type and a `validateTransactionParams` top-level validator.

- **#114** — Backup & export: add `src/utils/export.js` (JSON/CSV download helpers, `buildBackupPayload`, `flattenTransaction`, `flattenBalance`), `src/lib/import.js` (parse, validate, and restore backup files with prototype-pollution guard), `src/hooks/useDataExport.js` (hook composing all actions), and `src/components/dashboard/DataExport.jsx` (UI panel for one-click export and file-pick import with inline error/success feedback).

Closes #108
Closes #110
Closes #111
Closes #114