### PR TITLE
feat(security): add comprehensive security audit trail

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,11 +29,13 @@ import ExplorerEmbed from "./components/dashboard/ExplorerEmbed";
 import RealTimeLedger from "./components/dashboard/RealTimeLedger";
 import { AssetDiscovery } from "./components/assets";
 import { MultisigManager } from "./components/multisig";
+import AuditLog from "./components/dashboard/AuditLog";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { useStore } from "./lib/store";
 import { useTranslation } from "./hooks/useTranslation";
 import { useResponsive } from "./hooks/useResponsive";
 import { initializeErrorReporting, addBreadcrumb } from "./lib/errorReporting";
+import { installSecurityEventListeners, trackSecurityEvent, SecurityEventType } from "./lib/securityEvents";
 import { TourLauncher } from "./components/tutorial";
 
 const ChartsTab = () => {
@@ -81,6 +83,7 @@ const TABS = {
   charts: ChartsTab,
   assets: AssetDiscovery,
   multisig: MultisigManager,
+  audit: AuditLog,
 };
 
 function DashboardLayout() {
@@ -102,6 +105,7 @@ function DashboardLayout() {
     });
 
     addBreadcrumb('Application initialized', 'info', { theme, isMobile });
+    installSecurityEventListeners();
   }, [theme, isMobile]);
 
   // Close mobile menu when resizing to desktop
@@ -140,6 +144,10 @@ function DashboardLayout() {
   // Track tab changes
   useEffect(() => {
     addBreadcrumb(`Navigated to ${activeTab} tab`, 'navigation', { activeTab });
+    trackSecurityEvent(SecurityEventType.CONFIG_CHANGED, {
+      target: 'activeTab',
+      metadata: { activeTab },
+    });
   }, [activeTab]);
 
   const ActiveComponent = TABS[activeTab] || Overview;

--- a/src/components/dashboard/AuditLog.jsx
+++ b/src/components/dashboard/AuditLog.jsx
@@ -1,0 +1,388 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Shield,
+  AlertTriangle,
+  CheckCircle,
+  Download,
+  Trash2,
+  Search,
+  RefreshCw,
+} from 'lucide-react';
+import {
+  AuditCategory,
+  AuditSeverity,
+  exportAuditCsv,
+  exportAuditJson,
+  clearAuditLog,
+  verifyAuditChain,
+} from '../../utils/audit.js';
+import {
+  useAuditLog,
+  useAuditStats,
+  useSecurityMonitor,
+} from '../../hooks/useAudit.js';
+
+const SEVERITY_COLORS = {
+  [AuditSeverity.INFO]:     'var(--cyan)',
+  [AuditSeverity.LOW]:      'var(--text-secondary)',
+  [AuditSeverity.MEDIUM]:   'var(--yellow)',
+  [AuditSeverity.HIGH]:     'var(--orange)',
+  [AuditSeverity.CRITICAL]: 'var(--red)',
+};
+
+const OUTCOME_COLORS = {
+  success: 'var(--green)',
+  failure: 'var(--red)',
+  denied:  'var(--orange)',
+};
+
+export default function AuditLog() {
+  const [category, setCategory] = useState('');
+  const [severity, setSeverity] = useState('');
+  const [search, setSearch] = useState('');
+  const [integrity, setIntegrity] = useState(null);
+
+  const filters = useMemo(
+    () => ({
+      category: category || undefined,
+      severity: severity || undefined,
+      search: search || undefined,
+      limit: 500,
+    }),
+    [category, severity, search],
+  );
+
+  const { entries, refresh } = useAuditLog(filters);
+  const stats = useAuditStats();
+  const { alerts, clear: clearAlerts } = useSecurityMonitor();
+
+  const downloadFile = (filename, mime, content) => {
+    const blob = new Blob([content], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleExport = (format) => {
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    if (format === 'json') {
+      downloadFile(`audit-${stamp}.json`, 'application/json', exportAuditJson(entries));
+    } else {
+      downloadFile(`audit-${stamp}.csv`, 'text/csv', exportAuditCsv(entries));
+    }
+  };
+
+  const handleVerify = async () => {
+    setIntegrity({ checking: true });
+    const result = await verifyAuditChain();
+    setIntegrity(result);
+  };
+
+  const handleClear = () => {
+    if (confirm('Clear all audit entries? This action is not reversible.')) {
+      clearAuditLog();
+      refresh();
+    }
+  };
+
+  return (
+    <div className="animate-in" style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '12px' }}>
+        <div>
+          <div style={{ fontFamily: 'var(--font-display)', fontSize: '22px', fontWeight: 700, display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <Shield size={22} style={{ color: 'var(--cyan)' }} />
+            Audit Trail
+          </div>
+          <div style={{ fontSize: '13px', color: 'var(--text-muted)', marginTop: '4px' }}>
+            Tamper-evident security &amp; compliance log
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+          <ToolbarButton onClick={refresh} icon={<RefreshCw size={14} />} label="Refresh" />
+          <ToolbarButton onClick={handleVerify} icon={<CheckCircle size={14} />} label="Verify Chain" />
+          <ToolbarButton onClick={() => handleExport('json')} icon={<Download size={14} />} label="Export JSON" />
+          <ToolbarButton onClick={() => handleExport('csv')} icon={<Download size={14} />} label="Export CSV" />
+          <ToolbarButton onClick={handleClear} icon={<Trash2 size={14} />} label="Clear" danger />
+        </div>
+      </div>
+
+      {/* Integrity status */}
+      {integrity && !integrity.checking && (
+        <div
+          style={{
+            padding: '12px 16px',
+            borderRadius: 'var(--radius-md)',
+            background: integrity.valid ? 'rgba(34,197,94,0.08)' : 'rgba(239,68,68,0.08)',
+            border: `1px solid ${integrity.valid ? 'var(--green)' : 'var(--red)'}`,
+            color: integrity.valid ? 'var(--green)' : 'var(--red)',
+            fontSize: '13px',
+            fontFamily: 'var(--font-mono)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+          }}
+        >
+          {integrity.valid ? <CheckCircle size={16} /> : <AlertTriangle size={16} />}
+          {integrity.valid
+            ? `Chain valid (${stats.total} entries)`
+            : `Chain broken at index ${integrity.brokenAt}: ${integrity.reason}`}
+        </div>
+      )}
+
+      {/* Live alerts */}
+      {alerts.length > 0 && (
+        <div
+          style={{
+            background: 'rgba(239,68,68,0.05)',
+            border: '1px solid var(--red)',
+            borderRadius: 'var(--radius-lg)',
+            padding: '16px 20px',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+            <div style={{ fontWeight: 700, color: 'var(--red)', display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <AlertTriangle size={16} />
+              Live Security Alerts ({alerts.length})
+            </div>
+            <button onClick={clearAlerts} style={smallButtonStyle}>Dismiss</button>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', fontFamily: 'var(--font-mono)' }}>
+            {alerts.map((a, i) => (
+              <div key={i} style={{ color: 'var(--text-primary)' }}>
+                <span style={{ color: 'var(--red)', fontWeight: 700 }}>[{a.kind}]</span>{' '}
+                actor=<code>{a.actor ?? a.action}</code> count={a.count}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Stat cards */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '12px' }}>
+        <StatCard label="Total" value={stats.total} color="var(--cyan)" />
+        <StatCard label="Critical" value={stats.bySeverity[AuditSeverity.CRITICAL] ?? 0} color="var(--red)" />
+        <StatCard label="High" value={stats.bySeverity[AuditSeverity.HIGH] ?? 0} color="var(--orange)" />
+        <StatCard label="Medium" value={stats.bySeverity[AuditSeverity.MEDIUM] ?? 0} color="var(--yellow)" />
+        <StatCard label="Failures" value={stats.byOutcome.failure ?? 0} color="var(--red)" />
+        <StatCard label="Denied" value={stats.byOutcome.denied ?? 0} color="var(--orange)" />
+      </div>
+
+      {/* Filters */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+          gap: '12px',
+          padding: '16px',
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-lg)',
+        }}
+      >
+        <div style={{ position: 'relative' }}>
+          <Search
+            size={14}
+            style={{ position: 'absolute', left: '10px', top: '50%', transform: 'translateY(-50%)', color: 'var(--text-muted)' }}
+          />
+          <input
+            type="text"
+            placeholder="Search action / actor / metadata"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            style={{ ...inputStyle, paddingLeft: '32px' }}
+          />
+        </div>
+        <select value={category} onChange={(e) => setCategory(e.target.value)} style={inputStyle}>
+          <option value="">All categories</option>
+          {Object.values(AuditCategory).map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+        <select value={severity} onChange={(e) => setSeverity(e.target.value)} style={inputStyle}>
+          <option value="">All severities</option>
+          {Object.values(AuditSeverity).map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Table */}
+      <div
+        style={{
+          background: 'var(--bg-card)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-lg)',
+          overflow: 'hidden',
+        }}
+      >
+        {entries.length === 0 ? (
+          <div style={{ padding: '48px', textAlign: 'center', color: 'var(--text-muted)' }}>
+            No audit entries match the current filters.
+          </div>
+        ) : (
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px', fontFamily: 'var(--font-mono)' }}>
+              <thead>
+                <tr style={{ background: 'var(--bg-elevated)', textAlign: 'left' }}>
+                  <th style={cellStyle}>Time</th>
+                  <th style={cellStyle}>Severity</th>
+                  <th style={cellStyle}>Category</th>
+                  <th style={cellStyle}>Action</th>
+                  <th style={cellStyle}>Actor</th>
+                  <th style={cellStyle}>Outcome</th>
+                  <th style={cellStyle}>Details</th>
+                </tr>
+              </thead>
+              <tbody>
+                {entries.map((e) => (
+                  <AuditRow key={e.id} entry={e} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AuditRow({ entry }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <tr
+        onClick={() => setOpen((o) => !o)}
+        style={{ cursor: 'pointer', borderTop: '1px solid var(--border)' }}
+      >
+        <td style={cellStyle}>{new Date(entry.timestamp).toLocaleTimeString()}</td>
+        <td style={cellStyle}>
+          <span
+            style={{
+              padding: '2px 8px',
+              borderRadius: '999px',
+              fontSize: '10px',
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              color: SEVERITY_COLORS[entry.severity],
+              border: `1px solid ${SEVERITY_COLORS[entry.severity]}`,
+            }}
+          >
+            {entry.severity}
+          </span>
+        </td>
+        <td style={cellStyle}>{entry.category}</td>
+        <td style={{ ...cellStyle, color: 'var(--text-primary)' }}>{entry.action}</td>
+        <td style={cellStyle}>{truncate(entry.actor) ?? '—'}</td>
+        <td style={{ ...cellStyle, color: OUTCOME_COLORS[entry.outcome] ?? 'var(--text-muted)' }}>
+          {entry.outcome}
+        </td>
+        <td style={{ ...cellStyle, color: 'var(--text-muted)' }}>{open ? '▾' : '▸'}</td>
+      </tr>
+      {open && (
+        <tr style={{ background: 'var(--bg-elevated)' }}>
+          <td colSpan={7} style={{ padding: '12px 16px' }}>
+            <pre
+              style={{
+                margin: 0,
+                fontSize: '11px',
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-all',
+                color: 'var(--text-secondary)',
+              }}
+            >
+              {JSON.stringify(
+                {
+                  id: entry.id,
+                  target: entry.target,
+                  metadata: entry.metadata,
+                  sessionId: entry.sessionId,
+                  hash: entry.hash,
+                  prevHash: entry.prevHash,
+                },
+                null,
+                2,
+              )}
+            </pre>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function StatCard({ label, value, color }) {
+  return (
+    <div
+      style={{
+        background: 'var(--bg-card)',
+        border: '1px solid var(--border)',
+        borderRadius: 'var(--radius-lg)',
+        padding: '16px',
+      }}
+    >
+      <div style={{ fontSize: '11px', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+        {label}
+      </div>
+      <div style={{ fontSize: '24px', fontWeight: 700, color, marginTop: '4px' }}>{value}</div>
+    </div>
+  );
+}
+
+function ToolbarButton({ onClick, icon, label, danger }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '8px 12px',
+        background: danger ? 'rgba(239,68,68,0.08)' : 'var(--bg-card)',
+        border: `1px solid ${danger ? 'var(--red)' : 'var(--border)'}`,
+        borderRadius: 'var(--radius-md)',
+        color: danger ? 'var(--red)' : 'var(--text-primary)',
+        fontSize: '12px',
+        fontFamily: 'var(--font-mono)',
+        cursor: 'pointer',
+        transition: 'var(--transition)',
+      }}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function truncate(s, n = 16) {
+  if (!s || typeof s !== 'string') return s;
+  return s.length > n ? `${s.slice(0, 6)}…${s.slice(-6)}` : s;
+}
+
+const cellStyle = { padding: '10px 12px', verticalAlign: 'top' };
+
+const inputStyle = {
+  width: '100%',
+  padding: '8px 12px',
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-md)',
+  color: 'var(--text-primary)',
+  fontSize: '12px',
+  fontFamily: 'var(--font-mono)',
+  outline: 'none',
+};
+
+const smallButtonStyle = {
+  background: 'transparent',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--text-secondary)',
+  fontSize: '11px',
+  padding: '4px 10px',
+  cursor: 'pointer',
+};

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -19,6 +19,7 @@ const NAV_ITEMS = [
   { id: 'multisig', label: 'Multisig', icon: '⊕' },
   { id: 'portfolio', label: 'Portfolio', icon: '◐' },
   { id: 'charts', label: 'Charts', icon: '▤' },
+  { id: 'audit', label: 'Audit', icon: '⊟' },
 ]
 
 export default function Sidebar({ isMobile = false }) {

--- a/src/hooks/useAudit.js
+++ b/src/hooks/useAudit.js
@@ -1,0 +1,123 @@
+/**
+ * Audit Hooks (#118)
+ *
+ * - useAuditLog: subscribe to the audit ring buffer with filters
+ * - useAuditAction: stable callback that records a fixed action type
+ * - useSecurityMonitor: live alerts from securityEvents
+ * - useAuditStats: aggregated counts for dashboards
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  getAuditEntries,
+  getAuditStats,
+  recordAudit,
+  subscribeAudit,
+} from '../utils/audit.js';
+import {
+  trackSecurityEvent,
+  subscribeSecurityAlerts,
+} from '../lib/securityEvents.js';
+
+/**
+ * Subscribe to audit entries with optional filters.
+ * Re-renders whenever a matching new entry is recorded.
+ *
+ * @param {object} [filters]  Same shape as getAuditEntries
+ * @param {{ pollMs?: number }} [opts]
+ */
+export function useAuditLog(filters = {}, opts = {}) {
+  const { pollMs = 0 } = opts;
+  // Stabilise filter object across renders
+  const filterKey = JSON.stringify(filters);
+  const stableFilters = useMemo(() => filters, [filterKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const [entries, setEntries] = useState(() => getAuditEntries(stableFilters));
+
+  const refresh = useCallback(() => {
+    setEntries(getAuditEntries(stableFilters));
+  }, [stableFilters]);
+
+  useEffect(() => {
+    refresh();
+    const unsub = subscribeAudit((entry) => {
+      // Cheap pre-filter: only refresh if the new entry could match
+      if (stableFilters.category && entry.category !== stableFilters.category) return;
+      if (stableFilters.severity && entry.severity !== stableFilters.severity) return;
+      refresh();
+    });
+
+    let interval;
+    if (pollMs > 0) interval = setInterval(refresh, pollMs);
+
+    return () => {
+      unsub();
+      if (interval) clearInterval(interval);
+    };
+  }, [refresh, stableFilters, pollMs]);
+
+  return { entries, refresh };
+}
+
+/**
+ * Returns a stable callback that records an audit entry with a preset action.
+ * Useful for buttons or event handlers that always log the same action.
+ *
+ * @example
+ *   const logExport = useAuditAction('data.export', { category: 'export' });
+ *   <button onClick={() => logExport({ metadata: { format: 'csv' } })}>Export</button>
+ */
+export function useAuditAction(action, defaults = {}) {
+  return useCallback(
+    (overrides = {}) =>
+      recordAudit({ action, ...defaults, ...overrides }),
+    [action, JSON.stringify(defaults)], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+}
+
+/**
+ * Returns a stable callback for tracking security events.
+ *
+ * @example
+ *   const trackLoginFail = useSecurityEvent(SecurityEventType.AUTH_LOGIN_FAILED);
+ *   trackLoginFail({ actor: address, metadata: { reason: 'bad-sig' } });
+ */
+export function useSecurityEvent(eventType, defaults = {}) {
+  return useCallback(
+    (overrides = {}) => trackSecurityEvent(eventType, { ...defaults, ...overrides }),
+    [eventType, JSON.stringify(defaults)], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+}
+
+/**
+ * Subscribe to live security alerts (anomaly detector output).
+ * Returns the latest N alerts in chronological order (newest first).
+ */
+export function useSecurityMonitor(maxAlerts = 20) {
+  const [alerts, setAlerts] = useState([]);
+
+  useEffect(() => {
+    const unsub = subscribeSecurityAlerts((alert) => {
+      setAlerts((prev) => [{ ...alert, at: Date.now() }, ...prev].slice(0, maxAlerts));
+    });
+    return unsub;
+  }, [maxAlerts]);
+
+  const clear = useCallback(() => setAlerts([]), []);
+
+  return { alerts, clear };
+}
+
+/**
+ * Aggregated audit stats for dashboards. Refreshes on every new entry.
+ */
+export function useAuditStats() {
+  const [stats, setStats] = useState(() => getAuditStats());
+
+  useEffect(() => {
+    const unsub = subscribeAudit(() => setStats(getAuditStats()));
+    return unsub;
+  }, []);
+
+  return stats;
+}

--- a/src/lib/securityEvents.js
+++ b/src/lib/securityEvents.js
@@ -1,0 +1,234 @@
+/**
+ * Security Event Tracking (#118)
+ *
+ * High-level helpers that record security-significant events into the
+ * audit trail and run lightweight anomaly detection (failed-auth bursts,
+ * rate-limit exhaustion, unusual transaction values).
+ */
+
+import {
+  recordAudit,
+  AuditCategory,
+  AuditSeverity,
+  subscribeAudit,
+} from '../utils/audit.js';
+
+// ─── Canonical security event types ──────────────────────────────────────────
+
+export const SecurityEventType = Object.freeze({
+  // Authentication
+  AUTH_LOGIN_SUCCESS:      'auth.login.success',
+  AUTH_LOGIN_FAILED:       'auth.login.failed',
+  AUTH_LOGOUT:             'auth.logout',
+  AUTH_SESSION_EXPIRED:    'auth.session.expired',
+
+  // Wallet
+  WALLET_CONNECTED:        'wallet.connected',
+  WALLET_DISCONNECTED:     'wallet.disconnected',
+  WALLET_SIGN_REQUEST:     'wallet.sign.request',
+  WALLET_SIGN_REJECTED:    'wallet.sign.rejected',
+  WALLET_KEY_EXPORTED:     'wallet.key.exported',
+
+  // Transactions
+  TX_SUBMITTED:            'tx.submitted',
+  TX_FAILED:               'tx.failed',
+  TX_HIGH_VALUE:           'tx.high_value',
+  TX_SUSPICIOUS:           'tx.suspicious',
+
+  // Network / config
+  NETWORK_SWITCHED:        'network.switched',
+  CONFIG_CHANGED:          'config.changed',
+
+  // Defensive
+  RATE_LIMIT_HIT:          'security.rate_limit_hit',
+  CSP_VIOLATION:           'security.csp_violation',
+  XSS_ATTEMPT:             'security.xss_attempt',
+  PERMISSION_DENIED:       'security.permission_denied',
+  INTEGRITY_VIOLATION:     'security.integrity_violation',
+});
+
+// Severity mapping for each event type
+const SEVERITY_MAP = {
+  [SecurityEventType.AUTH_LOGIN_SUCCESS]:    AuditSeverity.INFO,
+  [SecurityEventType.AUTH_LOGIN_FAILED]:     AuditSeverity.MEDIUM,
+  [SecurityEventType.AUTH_LOGOUT]:           AuditSeverity.INFO,
+  [SecurityEventType.AUTH_SESSION_EXPIRED]:  AuditSeverity.LOW,
+
+  [SecurityEventType.WALLET_CONNECTED]:      AuditSeverity.INFO,
+  [SecurityEventType.WALLET_DISCONNECTED]:   AuditSeverity.INFO,
+  [SecurityEventType.WALLET_SIGN_REQUEST]:   AuditSeverity.LOW,
+  [SecurityEventType.WALLET_SIGN_REJECTED]:  AuditSeverity.LOW,
+  [SecurityEventType.WALLET_KEY_EXPORTED]:   AuditSeverity.HIGH,
+
+  [SecurityEventType.TX_SUBMITTED]:          AuditSeverity.INFO,
+  [SecurityEventType.TX_FAILED]:             AuditSeverity.LOW,
+  [SecurityEventType.TX_HIGH_VALUE]:         AuditSeverity.MEDIUM,
+  [SecurityEventType.TX_SUSPICIOUS]:         AuditSeverity.HIGH,
+
+  [SecurityEventType.NETWORK_SWITCHED]:      AuditSeverity.LOW,
+  [SecurityEventType.CONFIG_CHANGED]:        AuditSeverity.LOW,
+
+  [SecurityEventType.RATE_LIMIT_HIT]:        AuditSeverity.MEDIUM,
+  [SecurityEventType.CSP_VIOLATION]:         AuditSeverity.HIGH,
+  [SecurityEventType.XSS_ATTEMPT]:           AuditSeverity.CRITICAL,
+  [SecurityEventType.PERMISSION_DENIED]:     AuditSeverity.MEDIUM,
+  [SecurityEventType.INTEGRITY_VIOLATION]:   AuditSeverity.CRITICAL,
+};
+
+const CATEGORY_MAP = {
+  'auth':     AuditCategory.AUTH,
+  'wallet':   AuditCategory.WALLET,
+  'tx':       AuditCategory.TRANSACTION,
+  'network':  AuditCategory.NETWORK,
+  'config':   AuditCategory.CONFIG,
+  'security': AuditCategory.SECURITY,
+};
+
+function categoryFor(eventType) {
+  const prefix = eventType.split('.')[0];
+  return CATEGORY_MAP[prefix] ?? AuditCategory.SYSTEM;
+}
+
+// ─── Anomaly detection state ─────────────────────────────────────────────────
+
+const _failedAuthByActor = new Map();         // actor -> timestamps
+const _ratelimitHitsByAction = new Map();     // action -> timestamps
+const FAILED_AUTH_WINDOW_MS = 5 * 60_000;
+const FAILED_AUTH_THRESHOLD = 5;
+const RATE_LIMIT_WINDOW_MS = 10 * 60_000;
+const RATE_LIMIT_THRESHOLD = 10;
+
+const _alertSubscribers = new Set();
+
+export function subscribeSecurityAlerts(handler) {
+  _alertSubscribers.add(handler);
+  return () => _alertSubscribers.delete(handler);
+}
+
+function emitAlert(alert) {
+  for (const fn of _alertSubscribers) {
+    try { fn(alert); } catch { /* swallow */ }
+  }
+}
+
+function pruneOlderThan(arr, cutoff) {
+  return arr.filter((t) => t >= cutoff);
+}
+
+function checkAnomalies(eventType, payload) {
+  const now = Date.now();
+
+  if (eventType === SecurityEventType.AUTH_LOGIN_FAILED) {
+    const actor = payload.actor || 'anonymous';
+    const list = pruneOlderThan(
+      _failedAuthByActor.get(actor) ?? [],
+      now - FAILED_AUTH_WINDOW_MS,
+    );
+    list.push(now);
+    _failedAuthByActor.set(actor, list);
+    if (list.length >= FAILED_AUTH_THRESHOLD) {
+      const alert = {
+        kind: 'brute_force_suspected',
+        actor,
+        count: list.length,
+        windowMs: FAILED_AUTH_WINDOW_MS,
+      };
+      emitAlert(alert);
+      recordAudit({
+        action: 'security.alert.brute_force_suspected',
+        category: AuditCategory.SECURITY,
+        severity: AuditSeverity.CRITICAL,
+        actor,
+        outcome: 'denied',
+        metadata: alert,
+      });
+    }
+  }
+
+  if (eventType === SecurityEventType.RATE_LIMIT_HIT) {
+    const action = payload.metadata?.action || 'unknown';
+    const list = pruneOlderThan(
+      _ratelimitHitsByAction.get(action) ?? [],
+      now - RATE_LIMIT_WINDOW_MS,
+    );
+    list.push(now);
+    _ratelimitHitsByAction.set(action, list);
+    if (list.length >= RATE_LIMIT_THRESHOLD) {
+      const alert = {
+        kind: 'rate_limit_storm',
+        action,
+        count: list.length,
+        windowMs: RATE_LIMIT_WINDOW_MS,
+      };
+      emitAlert(alert);
+      recordAudit({
+        action: 'security.alert.rate_limit_storm',
+        category: AuditCategory.SECURITY,
+        severity: AuditSeverity.HIGH,
+        outcome: 'denied',
+        metadata: alert,
+      });
+    }
+  }
+}
+
+// ─── Main entry point ────────────────────────────────────────────────────────
+
+/**
+ * Record a security-significant event.
+ *
+ * @param {string} eventType  one of SecurityEventType
+ * @param {{
+ *   actor?: string,
+ *   target?: string,
+ *   outcome?: 'success'|'failure'|'denied',
+ *   metadata?: Record<string, unknown>,
+ *   severityOverride?: string,
+ * }} [opts]
+ * @returns {Promise<object>}
+ */
+export function trackSecurityEvent(eventType, opts = {}) {
+  const severity = opts.severityOverride ?? SEVERITY_MAP[eventType] ?? AuditSeverity.INFO;
+  const category = categoryFor(eventType);
+
+  const promise = recordAudit({
+    action: eventType,
+    category,
+    severity,
+    actor: opts.actor ?? null,
+    target: opts.target ?? null,
+    outcome: opts.outcome ?? 'success',
+    metadata: opts.metadata ?? {},
+  });
+
+  // Side-effect: anomaly detection
+  checkAnomalies(eventType, opts);
+
+  return promise;
+}
+
+// ─── Built-in CSP / global error listeners ──────────────────────────────────
+
+let _listenersInstalled = false;
+
+export function installSecurityEventListeners() {
+  if (_listenersInstalled || typeof window === 'undefined') return;
+  _listenersInstalled = true;
+
+  document.addEventListener('securitypolicyviolation', (e) => {
+    trackSecurityEvent(SecurityEventType.CSP_VIOLATION, {
+      target: e.violatedDirective,
+      outcome: 'denied',
+      metadata: {
+        blockedURI: e.blockedURI,
+        violatedDirective: e.violatedDirective,
+        sourceFile: e.sourceFile,
+        lineNumber: e.lineNumber,
+      },
+    });
+  });
+}
+
+// ─── Convenience re-exports for the rest of the app ─────────────────────────
+
+export { subscribeAudit, AuditSeverity, AuditCategory };

--- a/src/utils/audit.js
+++ b/src/utils/audit.js
@@ -1,0 +1,298 @@
+/**
+ * Audit Trail Utilities (#118)
+ *
+ * Provides:
+ *  - Tamper-evident audit log records (each entry hash-chained to its predecessor)
+ *  - In-memory ring buffer for fast reads + IndexedDB persistence
+ *  - Severity levels and category enums
+ *  - PII / secret redaction before persistence
+ *  - Export helpers (JSON / CSV) for compliance review
+ *  - Subscription API for real-time audit viewers
+ */
+
+import { getStoredValue, setStoredValue } from '../lib/storage.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const AuditSeverity = Object.freeze({
+  INFO: 'info',
+  LOW: 'low',
+  MEDIUM: 'medium',
+  HIGH: 'high',
+  CRITICAL: 'critical',
+});
+
+export const AuditCategory = Object.freeze({
+  AUTH: 'auth',
+  WALLET: 'wallet',
+  TRANSACTION: 'transaction',
+  CONTRACT: 'contract',
+  NETWORK: 'network',
+  CONFIG: 'config',
+  DATA_ACCESS: 'data_access',
+  EXPORT: 'export',
+  SECURITY: 'security',
+  ADMIN: 'admin',
+  SYSTEM: 'system',
+});
+
+const STORAGE_KEY = 'audit-log';
+const MAX_RING_SIZE = 1000;
+
+// ─── State ────────────────────────────────────────────────────────────────────
+
+const _ring = [];
+let _lastHash = '0';
+let _sessionId = `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+let _hydrated = false;
+const _subscribers = new Set();
+
+// ─── Hashing (browser SubtleCrypto with fallback) ─────────────────────────────
+
+async function hashEntry(payload) {
+  const str = JSON.stringify(payload);
+  if (typeof crypto !== 'undefined' && crypto.subtle) {
+    const data = new TextEncoder().encode(str);
+    const buf = await crypto.subtle.digest('SHA-256', data);
+    return Array.from(new Uint8Array(buf))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  // Fallback: lightweight non-crypto hash (still deterministic & chained)
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+// ─── Redaction ────────────────────────────────────────────────────────────────
+
+const SECRET_KEY_PATTERN = /\bS[A-Z2-7]{55}\b/g;
+const SENSITIVE_FIELD_NAMES = new Set([
+  'secret', 'secretKey', 'privateKey', 'seed', 'mnemonic',
+  'password', 'passphrase', 'token', 'apiKey', 'authorization',
+]);
+
+export function redactSensitive(value) {
+  if (value == null) return value;
+  if (typeof value === 'string') {
+    return value.replace(SECRET_KEY_PATTERN, '[REDACTED_SECRET_KEY]');
+  }
+  if (Array.isArray(value)) return value.map(redactSensitive);
+  if (typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (SENSITIVE_FIELD_NAMES.has(k)) {
+        out[k] = '[REDACTED]';
+      } else {
+        out[k] = redactSensitive(v);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+// ─── Hydration / persistence ─────────────────────────────────────────────────
+
+async function hydrate() {
+  if (_hydrated || typeof window === 'undefined') return;
+  _hydrated = true;
+  try {
+    const stored = await getStoredValue(STORAGE_KEY);
+    if (Array.isArray(stored) && stored.length) {
+      _ring.push(...stored.slice(-MAX_RING_SIZE));
+      _lastHash = _ring[_ring.length - 1]?.hash ?? '0';
+    }
+  } catch {
+    // Storage unavailable — operate in-memory only
+  }
+}
+
+async function persist() {
+  if (typeof window === 'undefined') return;
+  try {
+    await setStoredValue(STORAGE_KEY, _ring);
+  } catch {
+    // Best-effort persistence
+  }
+}
+
+// Kick off hydration on module load
+hydrate();
+
+// ─── Subscriptions ───────────────────────────────────────────────────────────
+
+export function subscribeAudit(handler) {
+  _subscribers.add(handler);
+  return () => _subscribers.delete(handler);
+}
+
+function notify(entry) {
+  for (const fn of _subscribers) {
+    try { fn(entry); } catch { /* swallow subscriber errors */ }
+  }
+}
+
+// ─── Recording ───────────────────────────────────────────────────────────────
+
+let _seq = 0;
+
+export async function recordAudit({
+  action,
+  category = AuditCategory.SYSTEM,
+  severity = AuditSeverity.INFO,
+  actor = null,
+  target = null,
+  outcome = 'success',
+  metadata = {},
+} = {}) {
+  if (!action || typeof action !== 'string') {
+    throw new Error('audit.record requires a string action');
+  }
+  await hydrate();
+
+  const base = {
+    id: `audit-${Date.now()}-${(++_seq).toString(36)}`,
+    timestamp: new Date().toISOString(),
+    action,
+    category,
+    severity,
+    actor,
+    target,
+    outcome,
+    metadata: redactSensitive(metadata),
+    sessionId: _sessionId,
+    url: typeof window !== 'undefined' ? window.location.href : null,
+    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : null,
+    prevHash: _lastHash,
+  };
+
+  const hash = await hashEntry(base);
+  const entry = { ...base, hash };
+
+  _ring.push(entry);
+  if (_ring.length > MAX_RING_SIZE) _ring.shift();
+  _lastHash = hash;
+
+  // Mirror critical events to the console for live debugging
+  if (severity === AuditSeverity.CRITICAL || severity === AuditSeverity.HIGH) {
+    // eslint-disable-next-line no-console
+    console.warn(`[audit:${severity}] ${action}`, metadata);
+  }
+
+  notify(entry);
+  // Fire-and-forget persistence so callers don't await disk I/O
+  persist();
+  return entry;
+}
+
+// ─── Query API ───────────────────────────────────────────────────────────────
+
+export function getAuditEntries({
+  category,
+  severity,
+  actor,
+  search,
+  since,
+  until,
+  limit = 200,
+} = {}) {
+  let entries = _ring.slice();
+
+  if (category) entries = entries.filter((e) => e.category === category);
+  if (severity) entries = entries.filter((e) => e.severity === severity);
+  if (actor) entries = entries.filter((e) => e.actor === actor);
+
+  if (since) {
+    const t = +new Date(since);
+    entries = entries.filter((e) => +new Date(e.timestamp) >= t);
+  }
+  if (until) {
+    const t = +new Date(until);
+    entries = entries.filter((e) => +new Date(e.timestamp) <= t);
+  }
+
+  if (search) {
+    const needle = search.toLowerCase();
+    entries = entries.filter((e) => {
+      const haystack = `${e.action} ${e.actor ?? ''} ${e.target ?? ''} ${JSON.stringify(e.metadata)}`.toLowerCase();
+      return haystack.includes(needle);
+    });
+  }
+
+  // Most recent first
+  return entries.reverse().slice(0, limit);
+}
+
+export function getAuditStats() {
+  const stats = {
+    total: _ring.length,
+    bySeverity: {},
+    byCategory: {},
+    byOutcome: { success: 0, failure: 0, denied: 0 },
+  };
+  for (const e of _ring) {
+    stats.bySeverity[e.severity] = (stats.bySeverity[e.severity] ?? 0) + 1;
+    stats.byCategory[e.category] = (stats.byCategory[e.category] ?? 0) + 1;
+    stats.byOutcome[e.outcome] = (stats.byOutcome[e.outcome] ?? 0) + 1;
+  }
+  return stats;
+}
+
+// ─── Integrity verification ───────────────────────────────────────────────────
+
+export async function verifyAuditChain() {
+  let prevHash = '0';
+  for (let i = 0; i < _ring.length; i++) {
+    const entry = _ring[i];
+    if (entry.prevHash !== prevHash) {
+      return { valid: false, brokenAt: i, reason: 'prevHash mismatch' };
+    }
+    const { hash, ...rest } = entry;
+    const expected = await hashEntry(rest);
+    if (expected !== hash) {
+      return { valid: false, brokenAt: i, reason: 'hash mismatch' };
+    }
+    prevHash = hash;
+  }
+  return { valid: true, brokenAt: -1 };
+}
+
+// ─── Export helpers ───────────────────────────────────────────────────────────
+
+export function exportAuditJson(entries = _ring.slice()) {
+  return JSON.stringify(entries, null, 2);
+}
+
+export function exportAuditCsv(entries = _ring.slice()) {
+  const headers = [
+    'id', 'timestamp', 'severity', 'category', 'action',
+    'actor', 'target', 'outcome', 'sessionId', 'hash',
+  ];
+  const escape = (v) => {
+    if (v == null) return '';
+    const s = typeof v === 'string' ? v : JSON.stringify(v);
+    return `"${s.replace(/"/g, '""')}"`;
+  };
+  const rows = entries.map((e) => headers.map((h) => escape(e[h])).join(','));
+  return [headers.join(','), ...rows].join('\n');
+}
+
+// ─── Test / admin helpers ────────────────────────────────────────────────────
+
+export function clearAuditLog() {
+  _ring.length = 0;
+  _lastHash = '0';
+  _seq = 0;
+  persist();
+}
+
+export function getSessionId() {
+  return _sessionId;
+}
+
+export function setSessionId(id) {
+  _sessionId = id;
+}


### PR DESCRIPTION
Introduce a tamper-evident audit log with hash-chained entries, security event tracking, anomaly detection, and a viewer UI for compliance review.

- src/utils/audit.js: hash-chained ring buffer (SHA-256 with chaining of prevHash -> hash), severity/category enums, PII redaction, IndexedDB persistence, JSON/CSV export, integrity verification
- src/lib/securityEvents.js: typed security event helpers, severity map, brute-force / rate-limit anomaly detection, CSP-violation listener
- src/hooks/useAudit.js: useAuditLog (filtered, live), useAuditAction, useSecurityEvent, useSecurityMonitor, useAuditStats
- src/components/dashboard/AuditLog.jsx: filterable viewer with severity badges, expandable rows, live alerts panel, integrity check, exports
- App.jsx + Sidebar.jsx: register audit tab and install CSP listeners

Closes #118 