### PR TITLE
feat(charts): add interactivity, exports, and real-time updates

### DIFF
--- a/src/components/charts/AccountActivityChart.jsx
+++ b/src/components/charts/AccountActivityChart.jsx
@@ -1,17 +1,29 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import { useStore } from '../../lib/store'
 import { TOOLTIP_STYLE, AXIS_TICK_STYLE, CHART_COLORS } from '../../lib/chartUtils'
+import {
+  exportChartDataAsCsv,
+  exportPng,
+  exportSvg,
+  downloadJson,
+  safeFilename,
+  buildColorMap,
+} from '../../utils/chartUtils'
 import Card from '../dashboard/Card'
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
   ResponsiveContainer, PieChart, Pie, Cell, Legend,
 } from 'recharts'
 import { format } from 'date-fns'
+import { Download } from 'lucide-react'
 
 const PIE_COLORS = [CHART_COLORS.cyan, CHART_COLORS.amber, CHART_COLORS.green, CHART_COLORS.red, '#8884d8', '#82ca9d']
 
 export default function AccountActivityChart() {
   const { transactions, operations, txLoading, opsLoading } = useStore()
+  const [exportOpen, setExportOpen] = useState(false)
+  const txChartRef = useRef(null)
+  const opsChartRef = useRef(null)
 
   // Group transactions by day
   const txByDay = useMemo(() => {
@@ -34,9 +46,7 @@ export default function AccountActivityChart() {
 
     const grouped = {}
     for (const op of operations) {
-      const type = op.type_i !== undefined
-        ? op.type
-        : 'unknown'
+      const type = op.type_i !== undefined ? op.type : 'unknown'
       const label = type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
       if (!grouped[label]) grouped[label] = { name: label, count: 0 }
       grouped[label].count++
@@ -45,10 +55,66 @@ export default function AccountActivityChart() {
     return Object.values(grouped).sort((a, b) => b.count - a.count).slice(0, 6)
   }, [operations])
 
+  const colorMap = useMemo(() => buildColorMap(opsByType.map((o) => o.name), PIE_COLORS), [opsByType])
+
   const loading = txLoading || opsLoading
 
+  const closeMenu = () => setExportOpen(false)
+
+  const exportCsvCombined = () => {
+    const rows = [
+      ...txByDay.map((row) => ({ section: 'tx_by_day', ...row })),
+      ...opsByType.map((row) => ({ section: 'ops_by_type', ...row })),
+    ]
+    exportChartDataAsCsv(rows, safeFilename('account-activity', 'csv'))
+    closeMenu()
+  }
+
+  const exportJsonCombined = () => {
+    downloadJson({ txByDay, opsByType }, 'account-activity')
+    closeMenu()
+  }
+
+  const exportTxPng = async () => {
+    await exportPng(txChartRef.current, 'tx-by-day', { background: '#0f1820', scale: 2 })
+    closeMenu()
+  }
+
+  const exportOpsPng = async () => {
+    await exportPng(opsChartRef.current, 'ops-by-type', { background: '#0f1820', scale: 2 })
+    closeMenu()
+  }
+
+  const exportTxSvg = () => { exportSvg(txChartRef.current, 'tx-by-day'); closeMenu() }
+  const exportOpsSvg = () => { exportSvg(opsChartRef.current, 'ops-by-type'); closeMenu() }
+
+  const hasAny = txByDay.length > 0 || opsByType.length > 0
+
   return (
-    <Card title="Account Activity" subtitle="Transaction & operation breakdown">
+    <Card
+      title="Account Activity"
+      subtitle="Transaction & operation breakdown"
+      action={
+        hasAny && (
+          <div style={{ position: 'relative' }}>
+            <button onClick={() => setExportOpen((o) => !o)} title="Export" style={iconBtn}>
+              <Download size={13} /> Export
+            </button>
+            {exportOpen && (
+              <div style={dropdownStyle} onMouseLeave={closeMenu}>
+                <DropdownItem onClick={exportCsvCombined}>Export CSV</DropdownItem>
+                <DropdownItem onClick={exportJsonCombined}>Export JSON</DropdownItem>
+                <Sep />
+                <DropdownItem onClick={exportTxPng} disabled={txByDay.length === 0}>PNG · Tx by Day</DropdownItem>
+                <DropdownItem onClick={exportTxSvg} disabled={txByDay.length === 0}>SVG · Tx by Day</DropdownItem>
+                <DropdownItem onClick={exportOpsPng} disabled={opsByType.length === 0}>PNG · Ops by Type</DropdownItem>
+                <DropdownItem onClick={exportOpsSvg} disabled={opsByType.length === 0}>SVG · Ops by Type</DropdownItem>
+              </div>
+            )}
+          </div>
+        )
+      }
+    >
       {loading ? (
         <div style={{ padding: '48px', display: 'flex', justifyContent: 'center' }}>
           <div className="spinner" />
@@ -62,10 +128,8 @@ export default function AccountActivityChart() {
           {/* Transactions by day */}
           {txByDay.length > 0 && (
             <div>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', letterSpacing: '0.8px', marginBottom: '10px', textTransform: 'uppercase' }}>
-                Transactions by Day
-              </div>
-              <div style={{ height: '200px' }}>
+              <div style={sectionLabel}>Transactions by Day</div>
+              <div ref={txChartRef} style={{ height: '200px' }}>
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={txByDay}>
                     <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
@@ -84,10 +148,8 @@ export default function AccountActivityChart() {
           {/* Operation types pie chart */}
           {opsByType.length > 0 && (
             <div>
-              <div style={{ fontSize: '11px', color: 'var(--text-muted)', letterSpacing: '0.8px', marginBottom: '10px', textTransform: 'uppercase' }}>
-                Operation Types
-              </div>
-              <div style={{ height: '240px' }}>
+              <div style={sectionLabel}>Operation Types</div>
+              <div ref={opsChartRef} style={{ height: '240px' }}>
                 <ResponsiveContainer width="100%" height="100%">
                   <PieChart>
                     <Pie
@@ -100,8 +162,8 @@ export default function AccountActivityChart() {
                       label={({ name, percent }) => `${name} (${(percent * 100).toFixed(0)}%)`}
                       labelLine={{ stroke: 'var(--text-muted)' }}
                     >
-                      {opsByType.map((_, index) => (
-                        <Cell key={`cell-${index}`} fill={PIE_COLORS[index % PIE_COLORS.length]} />
+                      {opsByType.map((entry) => (
+                        <Cell key={`cell-${entry.name}`} fill={colorMap[entry.name]} />
                       ))}
                     </Pie>
                     <Tooltip contentStyle={TOOLTIP_STYLE} />
@@ -115,4 +177,70 @@ export default function AccountActivityChart() {
       )}
     </Card>
   )
+}
+
+const sectionLabel = {
+  fontSize: '11px',
+  color: 'var(--text-muted)',
+  letterSpacing: '0.8px',
+  marginBottom: '10px',
+  textTransform: 'uppercase',
+}
+
+const iconBtn = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  height: 26,
+  padding: '0 10px',
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--text-secondary)',
+  fontSize: '11px',
+  cursor: 'pointer',
+  fontFamily: 'var(--font-mono)',
+}
+
+const dropdownStyle = {
+  position: 'absolute',
+  top: '32px',
+  right: 0,
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-md)',
+  boxShadow: '0 6px 24px rgba(0,0,0,0.35)',
+  minWidth: 200,
+  padding: '4px',
+  zIndex: 50,
+}
+
+function DropdownItem({ children, onClick, disabled }) {
+  return (
+    <button
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      style={{
+        display: 'block',
+        width: '100%',
+        textAlign: 'left',
+        background: 'transparent',
+        border: 'none',
+        color: disabled ? 'var(--text-muted)' : 'var(--text-primary)',
+        fontSize: '12px',
+        padding: '8px 12px',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        borderRadius: 'var(--radius-sm)',
+        opacity: disabled ? 0.5 : 1,
+      }}
+      onMouseEnter={(e) => !disabled && (e.currentTarget.style.background = 'var(--bg-hover)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+    >
+      {children}
+    </button>
+  )
+}
+
+function Sep() {
+  return <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }} />
 }

--- a/src/components/charts/BalanceHistoryChart.jsx
+++ b/src/components/charts/BalanceHistoryChart.jsx
@@ -1,19 +1,36 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useStore } from '../../lib/store'
 import { formatXLMValue, TOOLTIP_STYLE, AXIS_TICK_STYLE, CHART_COLORS } from '../../lib/chartUtils'
-import { formatXLM } from '../../lib/stellar'
+import { fetchAccount, formatXLM } from '../../lib/stellar'
+import { sparklinePath, throttle } from '../../utils/chartUtils'
 import Card from '../dashboard/Card'
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
   ResponsiveContainer, Cell,
 } from 'recharts'
+import { Pause, Play, RefreshCw } from 'lucide-react'
+
+const BAR_COLORS = [CHART_COLORS.cyan, CHART_COLORS.amber, CHART_COLORS.green, CHART_COLORS.red, '#8884d8', '#82ca9d']
+const POLL_OPTIONS = [
+  { value: 0,     label: 'Off' },
+  { value: 5000,  label: '5s' },
+  { value: 15000, label: '15s' },
+  { value: 30000, label: '30s' },
+  { value: 60000, label: '60s' },
+]
+const HISTORY_LIMIT = 30
 
 export default function BalanceHistoryChart() {
-  const { accountData } = useStore()
+  const { accountData, connectedAddress, network, setAccountData } = useStore()
+  const [pollMs, setPollMs] = useState(15000)
+  const [tickAt, setTickAt] = useState(null)
+  const [pulse, setPulse] = useState(false)
+  // Track per-asset balance over time so we can render a sparkline trend.
+  const historyRef = useRef(new Map())
+  const [historySnapshot, setHistorySnapshot] = useState(0) // version counter
 
   const balanceData = useMemo(() => {
     if (!accountData?.balances) return []
-
     return accountData.balances.map((b) => {
       const code = b.asset_type === 'native' ? 'XLM' : (b.asset_code || b.asset_type)
       return {
@@ -23,6 +40,44 @@ export default function BalanceHistoryChart() {
       }
     }).sort((a, b) => b.balance - a.balance)
   }, [accountData])
+
+  // Append the current balance snapshot to per-asset history (capped).
+  useEffect(() => {
+    if (balanceData.length === 0) return
+    const map = historyRef.current
+    for (const item of balanceData) {
+      const arr = map.get(item.asset) ?? []
+      const next = [...arr, item.balance]
+      if (next.length > HISTORY_LIMIT) next.shift()
+      map.set(item.asset, next)
+    }
+    setHistorySnapshot((n) => n + 1)
+  }, [balanceData])
+
+  // Real-time polling: re-fetch the account on the chosen interval and pulse
+  // the indicator on each update. Throttled so rapid clicks don't spam Horizon.
+  const refresh = useMemo(
+    () =>
+      throttle(async () => {
+        if (!connectedAddress) return
+        try {
+          const fresh = await fetchAccount(connectedAddress, network, 'balance-chart')
+          setAccountData(fresh)
+          setTickAt(Date.now())
+          setPulse(true)
+          setTimeout(() => setPulse(false), 600)
+        } catch {
+          // Silent: keep showing the last known balances
+        }
+      }, 1500),
+    [connectedAddress, network, setAccountData],
+  )
+
+  useEffect(() => {
+    if (!pollMs || !connectedAddress) return undefined
+    const id = setInterval(refresh, pollMs)
+    return () => clearInterval(id)
+  }, [pollMs, refresh, connectedAddress])
 
   if (!accountData) {
     return (
@@ -44,10 +99,39 @@ export default function BalanceHistoryChart() {
     )
   }
 
-  const barColors = [CHART_COLORS.cyan, CHART_COLORS.amber, CHART_COLORS.green, CHART_COLORS.red, '#8884d8', '#82ca9d']
-
   return (
-    <Card title="Balance Overview" subtitle="Current asset balances">
+    <Card
+      title="Balance Overview"
+      subtitle="Current asset balances"
+      action={
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <LiveBadge pulse={pulse} active={pollMs > 0} updatedAt={tickAt} />
+
+          <select
+            value={pollMs}
+            onChange={(e) => setPollMs(Number(e.target.value))}
+            title="Auto-refresh interval"
+            style={selectStyle}
+          >
+            {POLL_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+
+          <button
+            onClick={() => setPollMs((p) => (p > 0 ? 0 : 15000))}
+            title={pollMs > 0 ? 'Pause auto-refresh' : 'Resume auto-refresh'}
+            style={iconBtn}
+          >
+            {pollMs > 0 ? <Pause size={13} /> : <Play size={13} />}
+          </button>
+
+          <button onClick={refresh} title="Refresh now" style={iconBtn}>
+            <RefreshCw size={13} />
+          </button>
+        </div>
+      }
+    >
       <div style={{ padding: '18px', display: 'flex', flexDirection: 'column', gap: '16px' }}>
         {/* Bar chart */}
         <div style={{ height: Math.max(200, balanceData.length * 40) }}>
@@ -65,50 +149,129 @@ export default function BalanceHistoryChart() {
               />
               <Bar dataKey="balance" name="Balance" radius={[0, 4, 4, 0]}>
                 {balanceData.map((_, index) => (
-                  <Cell key={`cell-${index}`} fill={barColors[index % barColors.length]} />
+                  <Cell key={`cell-${index}`} fill={BAR_COLORS[index % BAR_COLORS.length]} />
                 ))}
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </div>
 
-        {/* Summary table */}
+        {/* Summary table with live trend sparkline */}
         <div>
           <div style={{
-            display: 'grid', gridTemplateColumns: '1fr 1fr 1fr',
+            display: 'grid', gridTemplateColumns: '1fr 1fr 90px 1fr',
             padding: '8px 12px', fontSize: '10px', color: 'var(--text-muted)',
             textTransform: 'uppercase', letterSpacing: '1px',
             borderBottom: '1px solid var(--border)',
           }}>
             <span>Asset</span>
             <span style={{ textAlign: 'right' }}>Balance</span>
+            <span style={{ textAlign: 'center' }}>Trend</span>
             <span style={{ textAlign: 'right' }}>Trust Limit</span>
           </div>
-          {balanceData.map((item, i) => (
-            <div
-              key={item.asset + i}
-              style={{
-                display: 'grid', gridTemplateColumns: '1fr 1fr 1fr',
-                padding: '10px 12px', fontSize: '12px',
-                borderBottom: i < balanceData.length - 1 ? '1px solid var(--border)' : 'none',
-                transition: 'var(--transition)',
-              }}
-              onMouseEnter={(e) => e.currentTarget.style.background = 'var(--bg-hover)'}
-              onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
-            >
-              <span style={{ color: barColors[i % barColors.length], fontWeight: 600 }}>
-                {item.asset}
-              </span>
-              <span style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
-                {item.balance.toLocaleString(undefined, { maximumFractionDigits: 4 })}
-              </span>
-              <span style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', color: 'var(--text-muted)' }}>
-                {item.limit !== null ? formatXLM(item.limit) : '∞'}
-              </span>
-            </div>
-          ))}
+          {balanceData.map((item, i) => {
+            const series = historyRef.current.get(item.asset) || []
+            const color = BAR_COLORS[i % BAR_COLORS.length]
+            const delta = series.length > 1 ? series[series.length - 1] - series[0] : 0
+            return (
+              <div
+                key={item.asset + i}
+                data-history-snapshot={historySnapshot}
+                style={{
+                  display: 'grid', gridTemplateColumns: '1fr 1fr 90px 1fr',
+                  padding: '10px 12px', fontSize: '12px',
+                  borderBottom: i < balanceData.length - 1 ? '1px solid var(--border)' : 'none',
+                  transition: 'var(--transition)',
+                  alignItems: 'center',
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.background = 'var(--bg-hover)'}
+                onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+              >
+                <span style={{ color, fontWeight: 600 }}>{item.asset}</span>
+                <span style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
+                  {item.balance.toLocaleString(undefined, { maximumFractionDigits: 4 })}
+                </span>
+                <span style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                  <Sparkline values={series} color={delta >= 0 ? CHART_COLORS.green : CHART_COLORS.red} />
+                </span>
+                <span style={{ textAlign: 'right', fontFamily: 'var(--font-mono)', color: 'var(--text-muted)' }}>
+                  {item.limit !== null ? formatXLM(item.limit) : '∞'}
+                </span>
+              </div>
+            )
+          })}
         </div>
       </div>
     </Card>
   )
+}
+
+function Sparkline({ values, color }) {
+  const { d, width, height } = sparklinePath(values, { width: 80, height: 18 })
+  if (!d) {
+    return <span style={{ color: 'var(--text-muted)', fontSize: 11 }}>—</span>
+  }
+  return (
+    <svg width={width} height={height} aria-label="balance trend" role="img">
+      <path d={d} fill="none" stroke={color} strokeWidth={1.5} />
+    </svg>
+  )
+}
+
+function LiveBadge({ pulse, active, updatedAt }) {
+  return (
+    <div
+      title={updatedAt ? `Updated ${new Date(updatedAt).toLocaleTimeString()}` : 'Awaiting first update'}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '4px 10px',
+        background: active ? 'rgba(0, 230, 118, 0.08)' : 'var(--bg-elevated)',
+        border: `1px solid ${active ? CHART_COLORS.green : 'var(--border)'}`,
+        borderRadius: 999,
+        fontSize: 10,
+        color: active ? CHART_COLORS.green : 'var(--text-muted)',
+        fontFamily: 'var(--font-mono)',
+        textTransform: 'uppercase',
+        letterSpacing: 1,
+      }}
+    >
+      <span
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: '50%',
+          background: active ? CHART_COLORS.green : 'var(--text-muted)',
+          boxShadow: pulse ? `0 0 0 4px ${CHART_COLORS.green}33` : 'none',
+          transition: 'box-shadow 600ms ease-out',
+        }}
+      />
+      {active ? 'Live' : 'Paused'}
+    </div>
+  )
+}
+
+const iconBtn = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 26,
+  height: 26,
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--text-secondary)',
+  cursor: 'pointer',
+}
+
+const selectStyle = {
+  height: 26,
+  padding: '0 6px',
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--text-primary)',
+  fontSize: 11,
+  fontFamily: 'var(--font-mono)',
 }

--- a/src/components/charts/NetworkMetricsChart.jsx
+++ b/src/components/charts/NetworkMetricsChart.jsx
@@ -1,18 +1,33 @@
-import React, { useEffect, useState, useMemo } from 'react'
+import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react'
 import { useStore } from '../../lib/store'
 import { getServer } from '../../lib/stellar'
 import { formatCompactNumber, TOOLTIP_STYLE, AXIS_TICK_STYLE, CHART_COLORS } from '../../lib/chartUtils'
+import { exportPng, exportSvg, downloadJson, exportChartDataAsCsv, safeFilename } from '../../utils/chartUtils'
 import Card from '../dashboard/Card'
 import {
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip,
-  ResponsiveContainer, BarChart, Bar, Legend,
+  ResponsiveContainer, BarChart, Bar, Legend, Brush,
 } from 'recharts'
 import { format } from 'date-fns'
+import { RefreshCw, Download, Eye, EyeOff } from 'lucide-react'
+
+const SERIES = [
+  { id: 'txCount',  label: 'Successful', color: CHART_COLORS.green },
+  { id: 'failedTx', label: 'Failed',     color: CHART_COLORS.red },
+  { id: 'opCount',  label: 'Operations', color: CHART_COLORS.cyan },
+]
 
 export default function NetworkMetricsChart() {
   const { network } = useStore()
   const [ledgerData, setLedgerData] = useState([])
   const [loading, setLoading] = useState(false)
+  const [refreshTick, setRefreshTick] = useState(0)
+  const [hidden, setHidden] = useState(() => new Set())
+  const [selected, setSelected] = useState(null)
+  const [exportOpen, setExportOpen] = useState(false)
+
+  const txChartRef = useRef(null)
+  const opsChartRef = useRef(null)
 
   useEffect(() => {
     let cancelled = false
@@ -35,16 +50,82 @@ export default function NetworkMetricsChart() {
       .finally(() => { if (!cancelled) setLoading(false) })
 
     return () => { cancelled = true }
-  }, [network])
+  }, [network, refreshTick])
 
   const maxTx = useMemo(() => {
     if (ledgerData.length === 0) return 10
     return Math.max(...ledgerData.map((d) => d.txCount + d.failedTx), 10)
   }, [ledgerData])
 
+  const isHidden = (id) => hidden.has(id)
+  const toggleSeries = useCallback((id) => {
+    setHidden((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id); else next.add(id)
+      return next
+    })
+  }, [])
+
+  const handleExportCsv = () => {
+    exportChartDataAsCsv(ledgerData, safeFilename('network-metrics', 'csv'))
+    setExportOpen(false)
+  }
+  const handleExportJson = () => {
+    downloadJson(ledgerData, 'network-metrics')
+    setExportOpen(false)
+  }
+  const handleExportPng = async (which) => {
+    const ref = which === 'tx' ? txChartRef : opsChartRef
+    await exportPng(ref.current, `network-${which}`, { background: '#0f1820', scale: 2 })
+    setExportOpen(false)
+  }
+  const handleExportSvg = (which) => {
+    const ref = which === 'tx' ? txChartRef : opsChartRef
+    exportSvg(ref.current, `network-${which}`)
+    setExportOpen(false)
+  }
+
   return (
-    <Card title="Network Metrics" subtitle="Transactions & operations per ledger">
-      {loading ? (
+    <Card
+      title="Network Metrics"
+      subtitle="Transactions & operations per ledger"
+      action={
+        <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+          {SERIES.map((s) => (
+            <button
+              key={s.id}
+              onClick={() => toggleSeries(s.id)}
+              title={`${isHidden(s.id) ? 'Show' : 'Hide'} ${s.label}`}
+              style={toggleStyle(s.color, isHidden(s.id))}
+            >
+              {isHidden(s.id) ? <EyeOff size={11} /> : <Eye size={11} />}
+              {s.label}
+            </button>
+          ))}
+
+          <button onClick={() => setRefreshTick((n) => n + 1)} title="Refresh" style={iconBtn}>
+            <RefreshCw size={13} className={loading ? 'spinner-icon' : ''} />
+          </button>
+
+          <div style={{ position: 'relative' }}>
+            <button onClick={() => setExportOpen((o) => !o)} title="Export" style={iconBtn}>
+              <Download size={13} />
+            </button>
+            {exportOpen && (
+              <div style={dropdownStyle} onMouseLeave={() => setExportOpen(false)}>
+                <DropdownItem onClick={handleExportCsv}>Export CSV</DropdownItem>
+                <DropdownItem onClick={handleExportJson}>Export JSON</DropdownItem>
+                <DropdownItem onClick={() => handleExportPng('tx')}>PNG · Transactions</DropdownItem>
+                <DropdownItem onClick={() => handleExportPng('ops')}>PNG · Operations</DropdownItem>
+                <DropdownItem onClick={() => handleExportSvg('tx')}>SVG · Transactions</DropdownItem>
+                <DropdownItem onClick={() => handleExportSvg('ops')}>SVG · Operations</DropdownItem>
+              </div>
+            )}
+          </div>
+        </div>
+      }
+    >
+      {loading && ledgerData.length === 0 ? (
         <div style={{ padding: '48px', display: 'flex', justifyContent: 'center' }}>
           <div className="spinner" />
         </div>
@@ -54,49 +135,180 @@ export default function NetworkMetricsChart() {
         </div>
       ) : (
         <div style={{ padding: '18px', display: 'flex', flexDirection: 'column', gap: '20px' }}>
-          {/* Tx count area chart */}
+          {/* Tx count bar chart with brush */}
           <div>
-            <div style={{ fontSize: '11px', color: 'var(--text-muted)', letterSpacing: '0.8px', marginBottom: '10px', textTransform: 'uppercase' }}>
-              Transactions per Ledger
-            </div>
-            <div style={{ height: '200px' }}>
+            <div style={sectionLabel}>Transactions per Ledger</div>
+            <div ref={txChartRef} style={{ height: '240px' }}>
               <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={ledgerData}>
+                <BarChart
+                  data={ledgerData}
+                  onClick={(e) => e?.activePayload?.[0] && setSelected(e.activePayload[0].payload)}
+                >
                   <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
                   <XAxis dataKey="label" tick={AXIS_TICK_STYLE} interval="preserveStartEnd" />
                   <YAxis tick={AXIS_TICK_STYLE} domain={[0, maxTx]} tickFormatter={formatCompactNumber} />
                   <Tooltip contentStyle={TOOLTIP_STYLE} />
                   <Legend wrapperStyle={{ fontSize: '11px' }} />
-                  <Bar dataKey="txCount" name="Successful" fill={CHART_COLORS.green} radius={[2, 2, 0, 0]} />
-                  <Bar dataKey="failedTx" name="Failed" fill={CHART_COLORS.red} radius={[2, 2, 0, 0]} />
+                  {!isHidden('txCount') && (
+                    <Bar dataKey="txCount" name="Successful" fill={CHART_COLORS.green} radius={[2, 2, 0, 0]} />
+                  )}
+                  {!isHidden('failedTx') && (
+                    <Bar dataKey="failedTx" name="Failed" fill={CHART_COLORS.red} radius={[2, 2, 0, 0]} />
+                  )}
+                  <Brush
+                    dataKey="label"
+                    height={20}
+                    stroke={CHART_COLORS.cyan}
+                    travellerWidth={8}
+                    fill="rgba(0, 229, 255, 0.05)"
+                  />
                 </BarChart>
               </ResponsiveContainer>
             </div>
           </div>
 
           {/* Operations area chart */}
-          <div>
-            <div style={{ fontSize: '11px', color: 'var(--text-muted)', letterSpacing: '0.8px', marginBottom: '10px', textTransform: 'uppercase' }}>
-              Operations per Ledger
+          {!isHidden('opCount') && (
+            <div>
+              <div style={sectionLabel}>Operations per Ledger</div>
+              <div ref={opsChartRef} style={{ height: '220px' }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart
+                    data={ledgerData}
+                    onClick={(e) => e?.activePayload?.[0] && setSelected(e.activePayload[0].payload)}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                    <XAxis dataKey="label" tick={AXIS_TICK_STYLE} interval="preserveStartEnd" />
+                    <YAxis tick={AXIS_TICK_STYLE} tickFormatter={formatCompactNumber} />
+                    <Tooltip contentStyle={TOOLTIP_STYLE} />
+                    <Area
+                      type="monotone" dataKey="opCount" name="Operations"
+                      stroke={CHART_COLORS.cyan} fill={CHART_COLORS.cyan}
+                      fillOpacity={0.15} strokeWidth={2}
+                    />
+                    <Brush
+                      dataKey="label"
+                      height={20}
+                      stroke={CHART_COLORS.cyan}
+                      travellerWidth={8}
+                      fill="rgba(0, 229, 255, 0.05)"
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
             </div>
-            <div style={{ height: '200px' }}>
-              <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={ledgerData}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
-                  <XAxis dataKey="label" tick={AXIS_TICK_STYLE} interval="preserveStartEnd" />
-                  <YAxis tick={AXIS_TICK_STYLE} tickFormatter={formatCompactNumber} />
-                  <Tooltip contentStyle={TOOLTIP_STYLE} />
-                  <Area
-                    type="monotone" dataKey="opCount" name="Operations"
-                    stroke={CHART_COLORS.cyan} fill={CHART_COLORS.cyan}
-                    fillOpacity={0.15} strokeWidth={2}
-                  />
-                </AreaChart>
-              </ResponsiveContainer>
+          )}
+
+          {/* Pinned-selection details */}
+          {selected && (
+            <div style={pinnedStyle}>
+              <div style={{ fontSize: '11px', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+                Pinned Ledger #{selected.sequence}
+              </div>
+              <div style={{ display: 'flex', gap: '18px', marginTop: '6px', fontSize: '12px', flexWrap: 'wrap' }}>
+                <span>Closed: <strong>{selected.label}</strong></span>
+                <span style={{ color: CHART_COLORS.green }}>Success: {selected.txCount}</span>
+                <span style={{ color: CHART_COLORS.red }}>Failed: {selected.failedTx}</span>
+                <span style={{ color: CHART_COLORS.cyan }}>Ops: {selected.opCount}</span>
+                <button onClick={() => setSelected(null)} style={clearBtn}>clear</button>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       )}
     </Card>
   )
+}
+
+const sectionLabel = {
+  fontSize: '11px',
+  color: 'var(--text-muted)',
+  letterSpacing: '0.8px',
+  marginBottom: '10px',
+  textTransform: 'uppercase',
+}
+
+const iconBtn = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 26,
+  height: 26,
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--text-secondary)',
+  cursor: 'pointer',
+}
+
+const dropdownStyle = {
+  position: 'absolute',
+  top: '32px',
+  right: 0,
+  background: 'var(--bg-card)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-md)',
+  boxShadow: '0 6px 24px rgba(0,0,0,0.35)',
+  minWidth: 180,
+  padding: '4px',
+  zIndex: 50,
+}
+
+function DropdownItem({ children, onClick }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: 'block',
+        width: '100%',
+        textAlign: 'left',
+        background: 'transparent',
+        border: 'none',
+        color: 'var(--text-primary)',
+        fontSize: '12px',
+        padding: '8px 12px',
+        cursor: 'pointer',
+        borderRadius: 'var(--radius-sm)',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--bg-hover)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+    >
+      {children}
+    </button>
+  )
+}
+
+function toggleStyle(color, isOff) {
+  return {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 4,
+    height: 26,
+    padding: '0 8px',
+    background: isOff ? 'transparent' : `${color}1a`,
+    border: `1px solid ${isOff ? 'var(--border)' : color}`,
+    borderRadius: 'var(--radius-sm)',
+    color: isOff ? 'var(--text-muted)' : color,
+    fontSize: '11px',
+    cursor: 'pointer',
+    fontFamily: 'var(--font-mono)',
+  }
+}
+
+const pinnedStyle = {
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--cyan-dim)',
+  borderRadius: 'var(--radius-md)',
+  padding: '10px 14px',
+}
+
+const clearBtn = {
+  marginLeft: 'auto',
+  background: 'transparent',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)',
+  color: 'var(--text-muted)',
+  fontSize: '11px',
+  padding: '2px 8px',
+  cursor: 'pointer',
 }

--- a/src/utils/chartUtils.js
+++ b/src/utils/chartUtils.js
@@ -1,0 +1,346 @@
+/**
+ * Advanced chart utilities (#109)
+ *
+ * Complements src/lib/chartUtils.js (which holds the basic formatters and
+ * theme constants). This module adds:
+ *
+ *  - PNG / SVG export of any DOM-rendered chart
+ *  - JSON / CSV / PNG download helpers with safe filenames
+ *  - Largest-Triangle-Three-Buckets (LTTB) downsampling for big series
+ *  - Percentile / quantile helpers
+ *  - Sparkline SVG path generator
+ *  - Throttle / debounce for live-update streams
+ *  - Color-scale generator for categorical series
+ */
+
+// ─── Filenames ───────────────────────────────────────────────────────────────
+
+/**
+ * Build a safe, timestamped filename.
+ * @example safeFilename('balances', 'csv') -> "balances-2025-01-30T11-22-09.csv"
+ */
+export function safeFilename(prefix, ext) {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const safePrefix = String(prefix || 'chart').replace(/[^a-z0-9_-]+/gi, '-').toLowerCase();
+  return `${safePrefix}-${stamp}.${ext}`;
+}
+
+// ─── Generic file download ───────────────────────────────────────────────────
+
+function triggerDownload(blob, filename) {
+  if (typeof document === 'undefined') return false;
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+  return true;
+}
+
+/**
+ * Download arbitrary string content as a text file.
+ */
+export function downloadText(content, filename, mime = 'text/plain') {
+  const blob = new Blob([content], { type: `${mime};charset=utf-8;` });
+  return triggerDownload(blob, filename);
+}
+
+/**
+ * Download an array as JSON.
+ */
+export function downloadJson(rows, prefix = 'chart') {
+  const json = JSON.stringify(rows, null, 2);
+  return downloadText(json, safeFilename(prefix, 'json'), 'application/json');
+}
+
+// ─── SVG / PNG export ────────────────────────────────────────────────────────
+
+/**
+ * Locate the first <svg> rendered inside a container (Recharts mounts an SVG
+ * inside a wrapping div). Returns null if not found.
+ */
+function findSvg(container) {
+  if (!container) return null;
+  return container.querySelector('svg');
+}
+
+/**
+ * Serialize an in-page <svg> to a standalone XML string.
+ * Inlines the computed font-family so the export looks identical.
+ */
+export function svgToString(svgEl) {
+  if (!svgEl) return '';
+  const cloned = svgEl.cloneNode(true);
+  cloned.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  cloned.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+
+  // Inline minimal styles so colours don't disappear when CSS variables
+  // aren't resolvable in the standalone file.
+  if (typeof window !== 'undefined') {
+    const computed = window.getComputedStyle(svgEl);
+    cloned.setAttribute('style', `font-family: ${computed.fontFamily};`);
+  }
+
+  return new XMLSerializer().serializeToString(cloned);
+}
+
+/**
+ * Export an in-page SVG as a downloaded .svg file.
+ */
+export function exportSvg(container, prefix = 'chart') {
+  const svg = findSvg(container);
+  if (!svg) return false;
+  const xml = svgToString(svg);
+  return downloadText(`<?xml version="1.0" standalone="no"?>\n${xml}`, safeFilename(prefix, 'svg'), 'image/svg+xml');
+}
+
+/**
+ * Export an in-page SVG to a PNG via canvas.
+ * Returns a Promise resolving to true on success.
+ *
+ * @param {HTMLElement} container - element containing the <svg>
+ * @param {string} prefix - filename prefix
+ * @param {{ scale?: number, background?: string }} [opts]
+ */
+export async function exportPng(container, prefix = 'chart', opts = {}) {
+  if (typeof document === 'undefined') return false;
+  const svg = findSvg(container);
+  if (!svg) return false;
+
+  const { scale = 2, background = '#0f1820' } = opts;
+  const rect = svg.getBoundingClientRect();
+  const width = Math.max(1, Math.round(rect.width));
+  const height = Math.max(1, Math.round(rect.height));
+
+  const xml = svgToString(svg);
+  const svgBlob = new Blob([xml], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(svgBlob);
+
+  try {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.src = url;
+    await new Promise((resolve, reject) => {
+      img.onload = resolve;
+      img.onerror = () => reject(new Error('Failed to rasterise SVG'));
+    });
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width * scale;
+    canvas.height = height * scale;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return false;
+
+    if (background) {
+      ctx.fillStyle = background;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+    const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
+    if (!blob) return false;
+    return triggerDownload(blob, safeFilename(prefix, 'png'));
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+// ─── Downsampling (LTTB) ─────────────────────────────────────────────────────
+
+/**
+ * Largest-Triangle-Three-Buckets downsampling.
+ * Reduces a series to `threshold` points while preserving visual peaks.
+ *
+ * @param {Array<{x:number, y:number}>} data
+ * @param {number} threshold
+ */
+export function downsampleLTTB(data, threshold) {
+  if (!Array.isArray(data) || threshold >= data.length || threshold <= 2) {
+    return data;
+  }
+
+  const sampled = [];
+  const bucketSize = (data.length - 2) / (threshold - 2);
+
+  let a = 0;
+  sampled.push(data[a]);
+
+  for (let i = 0; i < threshold - 2; i++) {
+    const start = Math.floor((i + 1) * bucketSize) + 1;
+    const end = Math.min(Math.floor((i + 2) * bucketSize) + 1, data.length);
+
+    let avgX = 0;
+    let avgY = 0;
+    const range = end - start;
+    for (let j = start; j < end; j++) {
+      avgX += data[j].x;
+      avgY += data[j].y;
+    }
+    avgX /= range || 1;
+    avgY /= range || 1;
+
+    const rangeStart = Math.floor(i * bucketSize) + 1;
+    const rangeEnd = Math.floor((i + 1) * bucketSize) + 1;
+
+    let maxArea = -1;
+    let nextA = rangeStart;
+    const pointAX = data[a].x;
+    const pointAY = data[a].y;
+
+    for (let j = rangeStart; j < rangeEnd; j++) {
+      const area = Math.abs(
+        (pointAX - avgX) * (data[j].y - pointAY) -
+        (pointAX - data[j].x) * (avgY - pointAY),
+      ) * 0.5;
+
+      if (area > maxArea) {
+        maxArea = area;
+        nextA = j;
+      }
+    }
+
+    sampled.push(data[nextA]);
+    a = nextA;
+  }
+
+  sampled.push(data[data.length - 1]);
+  return sampled;
+}
+
+// ─── Statistics ──────────────────────────────────────────────────────────────
+
+/**
+ * Calculate a percentile from numeric values.
+ * @param {number[]} values
+ * @param {number} p  0..100
+ */
+export function percentile(values, p) {
+  if (!Array.isArray(values) || values.length === 0) return null;
+  const sorted = values.filter((v) => Number.isFinite(v)).sort((a, b) => a - b);
+  if (sorted.length === 0) return null;
+  const rank = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo);
+}
+
+/** Convenience: quartiles + extents. */
+export function fiveNumberSummary(values) {
+  return {
+    min: percentile(values, 0),
+    q1: percentile(values, 25),
+    median: percentile(values, 50),
+    q3: percentile(values, 75),
+    max: percentile(values, 100),
+  };
+}
+
+// ─── Sparkline ───────────────────────────────────────────────────────────────
+
+/**
+ * Build an SVG `d` attribute for a sparkline path.
+ * Returns an object with `d`, `width`, `height`.
+ */
+export function sparklinePath(values, { width = 80, height = 20, padding = 1 } = {}) {
+  if (!Array.isArray(values) || values.length < 2) {
+    return { d: '', width, height };
+  }
+  const numeric = values.map((v) => Number(v)).filter(Number.isFinite);
+  if (numeric.length < 2) return { d: '', width, height };
+
+  const min = Math.min(...numeric);
+  const max = Math.max(...numeric);
+  const range = max - min || 1;
+
+  const stepX = (width - padding * 2) / (numeric.length - 1);
+  const points = numeric.map((v, i) => {
+    const x = padding + i * stepX;
+    const y = padding + (height - padding * 2) * (1 - (v - min) / range);
+    return [x, y];
+  });
+
+  const d = points.reduce(
+    (acc, [x, y], idx) => acc + `${idx === 0 ? 'M' : 'L'}${x.toFixed(2)},${y.toFixed(2)} `,
+    '',
+  ).trim();
+
+  return { d, width, height };
+}
+
+// ─── Throttle / debounce ────────────────────────────────────────────────────
+
+/**
+ * Throttle: call at most once per `ms` interval. Trailing call is honoured.
+ */
+export function throttle(fn, ms = 250) {
+  let lastCall = 0;
+  let trailingTimer = null;
+  let trailingArgs = null;
+
+  return function throttled(...args) {
+    const now = Date.now();
+    const elapsed = now - lastCall;
+
+    if (elapsed >= ms) {
+      lastCall = now;
+      fn.apply(this, args);
+    } else {
+      trailingArgs = args;
+      if (!trailingTimer) {
+        trailingTimer = setTimeout(() => {
+          lastCall = Date.now();
+          trailingTimer = null;
+          fn.apply(this, trailingArgs);
+        }, ms - elapsed);
+      }
+    }
+  };
+}
+
+/**
+ * Debounce: call once after `ms` of inactivity.
+ */
+export function debounce(fn, ms = 250) {
+  let timer = null;
+  return function debounced(...args) {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => fn.apply(this, args), ms);
+  };
+}
+
+// ─── Color scale ─────────────────────────────────────────────────────────────
+
+const DEFAULT_SCALE = [
+  '#00e5ff', '#ffb300', '#00e676', '#ff1744',
+  '#8884d8', '#82ca9d', '#ffc658', '#a4de6c',
+  '#d0ed57', '#ff7300', '#387908', '#7c43bd',
+];
+
+/**
+ * Get a colour from the categorical scale by index, looping if necessary.
+ */
+export function colorForIndex(index, scale = DEFAULT_SCALE) {
+  if (!Array.isArray(scale) || scale.length === 0) return '#000000';
+  const i = ((index % scale.length) + scale.length) % scale.length;
+  return scale[i];
+}
+
+/**
+ * Build a deterministic colour map for a list of category names.
+ */
+export function buildColorMap(categories, scale = DEFAULT_SCALE) {
+  const map = {};
+  if (!Array.isArray(categories)) return map;
+  categories.forEach((name, idx) => {
+    map[name] = colorForIndex(idx, scale);
+  });
+  return map;
+}
+
+// ─── Re-exports of CSV builder (for one-stop import) ─────────────────────────
+
+export { buildCsv, exportChartDataAsCsv } from '../lib/chartUtils.js';


### PR DESCRIPTION
- src/utils/chartUtils.js: PNG/SVG export from in-page Recharts SVG, JSON download, LTTB downsampling, percentile/quantile helpers, sparkline SVG path generator, throttle/debounce, deterministic color-scale builder
- NetworkMetricsChart: add Recharts Brush for zoom, per-series show/hide toggles, click-to-pin ledger details panel, refresh button, export menu (CSV/JSON/PNG/SVG)
- AccountActivityChart: add export menu (combined CSV/JSON; PNG/SVG per chart) using buildColorMap for stable category colours
- BalanceHistoryChart: add live polling (off/5s/15s/30s/60s) with pause/resume, throttled fetchAccount refresh, pulse Live badge with last-updated tooltip, per-asset balance trend sparkline column

Closes #109 