### PR TITLE
feat: add secure custom Horizon auth headers

### DIFF
--- a/src/components/dashboard/Settings.jsx
+++ b/src/components/dashboard/Settings.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from "react";
 import { useSettings } from "../../hooks/useSettings";
 import { useStore } from "../../lib/store";
 import { getEnvironmentConfig } from "../../lib/config";
+import { getCustomNetworkAuthHeaders, updateCustomNetworkConfig } from "../../lib/stellar";
 
 function FieldLabel({ children }) {
   return (
@@ -12,6 +13,8 @@ function FieldLabel({ children }) {
 }
 
 export default function Settings() {
+  const initialCustomHeaders = getCustomNetworkAuthHeaders();
+  const initialHeaderName = Object.keys(initialCustomHeaders)[0] || "Authorization";
   const { network, setNetwork, theme, toggleTheme } = useStore();
   const {
     profiles,
@@ -26,12 +29,22 @@ export default function Settings() {
 
   const [profileName, setProfileName] = useState("");
   const [draftConfig, setDraftConfig] = useState(() => activeProfile.config);
+  const [customHeaderName, setCustomHeaderName] = useState(initialHeaderName);
+  const [customHeaderValue, setCustomHeaderValue] = useState(initialCustomHeaders[initialHeaderName] || "");
   const baseline = useMemo(() => getEnvironmentConfig(), []);
 
   function handleSaveProfile() {
     const name = profileName.trim() || activeProfileName;
     saveProfile(name, draftConfig);
     setProfileName("");
+  }
+
+  function updateCustomHeader(name, value) {
+    setCustomHeaderName(name);
+    setCustomHeaderValue(value);
+    updateCustomNetworkConfig({
+      headers: name.trim() && value.trim() ? { [name.trim()]: value.trim() } : {},
+    });
   }
 
   return (
@@ -204,6 +217,43 @@ export default function Settings() {
           >
             Save Profile
           </button>
+        </div>
+      </div>
+
+      <div style={{ background: "var(--bg-card)", border: "1px solid var(--border)", borderRadius: "var(--radius-lg)", padding: "14px", display: "flex", flexDirection: "column", gap: "12px" }}>
+        <FieldLabel>Custom Horizon Authentication</FieldLabel>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: "10px" }}>
+          <label style={{ display: "flex", flexDirection: "column", gap: "6px", fontSize: "12px", color: "var(--text-secondary)" }}>
+            Header Name
+            <input
+              value={customHeaderName}
+              onChange={(event) => updateCustomHeader(event.target.value, customHeaderValue)}
+              placeholder="Authorization"
+              style={{
+                padding: "8px",
+                borderRadius: "var(--radius-sm)",
+                border: "1px solid var(--border)",
+                background: "var(--bg-elevated)",
+                color: "var(--text-primary)",
+              }}
+            />
+          </label>
+          <label style={{ display: "flex", flexDirection: "column", gap: "6px", fontSize: "12px", color: "var(--text-secondary)" }}>
+            Header Value
+            <input
+              type="password"
+              value={customHeaderValue}
+              onChange={(event) => updateCustomHeader(customHeaderName, event.target.value)}
+              placeholder="Bearer ..."
+              style={{
+                padding: "8px",
+                borderRadius: "var(--radius-sm)",
+                border: "1px solid var(--border)",
+                background: "var(--bg-elevated)",
+                color: "var(--text-primary)",
+              }}
+            />
+          </label>
         </div>
       </div>
     </div>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useStore } from '../../lib/store'
 import CopyableValue from '../dashboard/CopyableValue'
-import { NETWORKS, updateCustomNetworkConfig } from '../../lib/stellar'
+import { NETWORKS, getCustomNetworkAuthHeaders, updateCustomNetworkConfig } from '../../lib/stellar'
 
 const NAV_ITEMS = [
   { id: 'overview', label: 'Overview', icon: '◈' },
@@ -30,6 +30,10 @@ const NAV_ITEMS = [
 ]
 
 export default function Sidebar({ isMobile = false }) {
+  const initialCustomHeaders = getCustomNetworkAuthHeaders()
+  const initialHeaderName = Object.keys(initialCustomHeaders)[0] || 'Authorization'
+  const [customHeaderName, setCustomHeaderName] = useState(initialHeaderName)
+  const [customHeaderValue, setCustomHeaderValue] = useState(initialCustomHeaders[initialHeaderName] || '')
   const { 
     activeTab, 
     setActiveTab, 
@@ -74,6 +78,14 @@ export default function Sidebar({ isMobile = false }) {
     borderRadius: 'var(--radius-sm)',
     color: 'var(--text-primary)',
     outline: 'none',
+  }
+
+  const updateCustomHeader = (name, value) => {
+    setCustomHeaderName(name)
+    setCustomHeaderValue(value)
+    updateCustomNetworkConfig({
+      headers: name.trim() && value.trim() ? { [name.trim()]: value.trim() } : {},
+    })
   }
 
   return (
@@ -190,6 +202,19 @@ export default function Sidebar({ isMobile = false }) {
                 defaultValue={NETWORKS.custom.passphrase}
                 style={customInputStyle}
                 onChange={(e) => updateCustomNetworkConfig({ passphrase: e.target.value.trim() })}
+              />
+              <input
+                placeholder="Auth Header Name"
+                value={customHeaderName}
+                style={customInputStyle}
+                onChange={(e) => updateCustomHeader(e.target.value, customHeaderValue)}
+              />
+              <input
+                placeholder="Auth Header Value (session only)"
+                type="password"
+                value={customHeaderValue}
+                style={customInputStyle}
+                onChange={(e) => updateCustomHeader(customHeaderName, e.target.value)}
               />
             </div>
           )}

--- a/src/lib/auditTrail.js
+++ b/src/lib/auditTrail.js
@@ -186,24 +186,14 @@ class AuditTrail {
     const metadata = {
       error: error.message,
       stack: error.stack,
-      context
+      context: this.sanitizeData(context)
     };
     
     this.logEvent('ERROR', error.message, metadata, 'error');
   }
 
   sanitizeParams(params) {
-    // Remove sensitive data like private keys, passwords, etc.
-    const sanitized = { ...params };
-    const sensitiveKeys = ['secret', 'privateKey', 'password', 'token'];
-    
-    sensitiveKeys.forEach(key => {
-      if (sanitized[key]) {
-        sanitized[key] = '[REDACTED]';
-      }
-    });
-    
-    return sanitized;
+    return this.sanitizeData(params);
   }
 
   sanitizeData(data) {
@@ -213,7 +203,8 @@ class AuditTrail {
     const sanitized = JSON.parse(JSON.stringify(data));
     const sensitivePaths = [
       'secretKey', 'privateKey', 'seed', 'password', 'token',
-      'signerKey', 'signingKey'
+      'signerKey', 'signingKey', 'secret', 'authorization',
+      'apiKey', 'api-key', 'x-api-key', 'headers'
     ];
     
     const redactSensitive = (obj) => {

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -23,6 +23,7 @@ export interface NetworkConfig {
   sorobanUrl?: string
   passphrase: string
   faucetUrl?: string
+  headers?: Record<string, string>
 }
 
 export const NETWORKS: Record<NetworkName, NetworkConfig> = {
@@ -57,10 +58,79 @@ export const NETWORKS: Record<NetworkName, NetworkConfig> = {
     horizonUrl: '',
     sorobanUrl: '',
     passphrase: '',
+    headers: {},
   },
 }
 
 const COINGECKO_XLM_PRICE_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd'
+const CUSTOM_NETWORK_HEADERS_KEY = 'stellar-custom-network-headers'
+
+function getSessionStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  return window.sessionStorage || null
+}
+
+function normalizeHeaders(headers: Record<string, string> = {}): Record<string, string> {
+  return Object.entries(headers).reduce<Record<string, string>>((acc, [name, value]) => {
+    const trimmedName = String(name || '').trim()
+    const trimmedValue = String(value || '').trim()
+    if (trimmedName && trimmedValue) {
+      acc[trimmedName] = trimmedValue
+    }
+    return acc
+  }, {})
+}
+
+export function getCustomNetworkAuthHeaders(): Record<string, string> {
+  const storage = getSessionStorage()
+  if (!storage) return NETWORKS.custom.headers || {}
+
+  try {
+    const raw = storage.getItem(CUSTOM_NETWORK_HEADERS_KEY)
+    const headers = raw ? normalizeHeaders(JSON.parse(raw)) : {}
+    NETWORKS.custom.headers = headers
+    return headers
+  } catch {
+    return NETWORKS.custom.headers || {}
+  }
+}
+
+function saveCustomNetworkAuthHeaders(headers: Record<string, string>) {
+  const normalized = normalizeHeaders(headers)
+  NETWORKS.custom.headers = normalized
+
+  const storage = getSessionStorage()
+  if (!storage) return
+
+  if (Object.keys(normalized).length) {
+    storage.setItem(CUSTOM_NETWORK_HEADERS_KEY, JSON.stringify(normalized))
+  } else {
+    storage.removeItem(CUSTOM_NETWORK_HEADERS_KEY)
+  }
+}
+
+function getNetworkHeaders(network: NetworkName): Record<string, string> {
+  if (network === 'custom') return getCustomNetworkAuthHeaders()
+  return NETWORKS[network].headers || {}
+}
+
+function withNetworkHeaders(options: RequestInit = {}, network: NetworkName): RequestInit {
+  const headers = getNetworkHeaders(network)
+  if (!Object.keys(headers).length) return options
+
+  return {
+    ...options,
+    headers: {
+      ...(options.headers as Record<string, string> | undefined),
+      ...headers,
+    },
+  }
+}
+
+function getServerOptions(network: NetworkName) {
+  const headers = getNetworkHeaders(network)
+  return Object.keys(headers).length ? { headers } : undefined
+}
 
 // ─── Rate Limited Fetch Wrapper ───────────────────────────────────────────────
 
@@ -113,12 +183,17 @@ export function getNetworkDetails(network: NetworkName): NetworkConfig {
 }
 
 export function updateCustomNetworkConfig(config: Partial<NetworkConfig>) {
-  Object.assign(NETWORKS.custom, config)
+  const { headers, ...networkConfig } = config
+  Object.assign(NETWORKS.custom, networkConfig)
+  if (headers) saveCustomNetworkAuthHeaders(headers)
 }
 
 export function getServer(network: NetworkName = 'testnet'): StellarSdk.Horizon.Server {
   const config = NETWORKS[network]
-  return new StellarSdk.Horizon.Server(config.horizonUrl || NETWORKS.testnet.horizonUrl)
+  return new StellarSdk.Horizon.Server(
+    config.horizonUrl || NETWORKS.testnet.horizonUrl,
+    getServerOptions(network),
+  )
 }
 
 export function getSorobanServer(network: NetworkName = 'testnet'): StellarSdk.SorobanRpc.Server {
@@ -126,7 +201,10 @@ export function getSorobanServer(network: NetworkName = 'testnet'): StellarSdk.S
   if (network === 'custom' && !config.sorobanUrl) {
     throw new Error('Custom Soroban RPC URL not configured')
   }
-  return new StellarSdk.SorobanRpc.Server(config.sorobanUrl || NETWORKS.testnet.sorobanUrl!)
+  return new StellarSdk.SorobanRpc.Server(
+    config.sorobanUrl || NETWORKS.testnet.sorobanUrl!,
+    getServerOptions(network),
+  )
 }
 
 // ─── Account ──────────────────────────────────────────────────────────────────
@@ -419,7 +497,10 @@ export async function fetchAssetPrice(
     buying_asset_type: 'native',
   })
 
-  const response = await fetch(`${NETWORKS[network].horizonUrl}/order_book?${params.toString()}`)
+  const response = await fetch(
+    `${NETWORKS[network].horizonUrl}/order_book?${params.toString()}`,
+    withNetworkHeaders({}, network),
+  )
 
   if (!response.ok) {
     throw new Error(`Order book request failed: ${response.status}`)
@@ -1714,7 +1795,7 @@ export async function fetchPaymentPaths(
     url = `${horizonUrl}/paths/strict-receive?${assetParams(destAsset, 'destination')}&destination_amount=${amount}&source_assets=${encodeURIComponent(assetString(sourceAsset))}`
   }
 
-  const res = await fetch(url)
+  const res = await fetch(url, withNetworkHeaders({}, network))
   if (!res.ok) throw new Error(`Horizon error: ${res.status}`)
   const data = await res.json() as { _embedded?: { records: PaymentPathRecord[] } }
   return data._embedded?.records ?? []
@@ -1746,6 +1827,7 @@ export default {
   NETWORKS,
   getNetworkDetails,
   updateCustomNetworkConfig,
+  getCustomNetworkAuthHeaders,
   getServer,
   getSorobanServer,
   fetchAccount,

--- a/src/lib/tests/auditTrail.test.js
+++ b/src/lib/tests/auditTrail.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { AuditTrail } from '../auditTrail';
+
+describe('AuditTrail redaction', () => {
+  it('redacts request headers and API keys from API call metadata', () => {
+    const auditTrail = new AuditTrail();
+
+    auditTrail.logAPICall(
+      'https://horizon.example.test/accounts',
+      'GET',
+      {
+        headers: {
+          Authorization: 'Bearer secret-horizon-token',
+          'X-Api-Key': 'secret-api-key',
+        },
+      },
+      { status: 200 },
+    );
+
+    const [event] = auditTrail.getAPIActivity();
+
+    expect(event.metadata.params.headers).toBe('[REDACTED]');
+    expect(JSON.stringify(event.metadata)).not.toContain('secret-horizon-token');
+    expect(JSON.stringify(event.metadata)).not.toContain('secret-api-key');
+  });
+
+  it('redacts sensitive request context from error metadata', () => {
+    const auditTrail = new AuditTrail();
+
+    auditTrail.logError(new Error('request failed'), {
+      options: {
+        headers: {
+          Authorization: 'Bearer secret-horizon-token',
+        },
+      },
+    });
+
+    const [event] = auditTrail.getErrors();
+
+    expect(event.metadata.context.options.headers).toBe('[REDACTED]');
+    expect(JSON.stringify(event.metadata)).not.toContain('secret-horizon-token');
+  });
+});

--- a/src/lib/tests/stellar.test.ts
+++ b/src/lib/tests/stellar.test.ts
@@ -7,18 +7,29 @@
  * config lookup).
  */
 
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, it, expect } from 'vitest';
 import * as StellarSdk from '@stellar/stellar-sdk';
 
 import {
   NETWORKS,
   OPERATION_LABELS,
   formatXLM,
+  getCustomNetworkAuthHeaders,
   getNetworkDetails,
   getOperationLabel,
   shortAddress,
   updateCustomNetworkConfig,
 } from '../stellar';
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  updateCustomNetworkConfig({
+    horizonUrl: '',
+    sorobanUrl: '',
+    passphrase: '',
+    headers: {},
+  });
+});
 
 describe('NETWORKS', () => {
   it('exposes mainnet, testnet, futurenet, local, and custom configs', () => {
@@ -54,6 +65,26 @@ describe('updateCustomNetworkConfig', () => {
     updateCustomNetworkConfig({ horizonUrl: 'http://example.invalid/horizon' });
     expect(NETWORKS.custom.horizonUrl).toBe('http://example.invalid/horizon');
     expect(NETWORKS.testnet).toEqual(before);
+  });
+
+  it('stores custom auth headers in session storage only', () => {
+    updateCustomNetworkConfig({
+      headers: { Authorization: 'Bearer secret-horizon-token' },
+    });
+
+    expect(getCustomNetworkAuthHeaders()).toEqual({
+      Authorization: 'Bearer secret-horizon-token',
+    });
+    expect(window.sessionStorage.getItem('stellar-custom-network-headers')).toContain('secret-horizon-token');
+    expect(window.localStorage.getItem('stellar-custom-network-headers')).toBeNull();
+  });
+
+  it('removes blank custom auth headers', () => {
+    updateCustomNetworkConfig({ headers: { Authorization: 'Bearer secret-horizon-token' } });
+    updateCustomNetworkConfig({ headers: { Authorization: '' } });
+
+    expect(getCustomNetworkAuthHeaders()).toEqual({});
+    expect(window.sessionStorage.getItem('stellar-custom-network-headers')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Fixes #201

Summary:
- Adds session-scoped custom Horizon/Soroban auth headers for the custom network configuration.
- Passes those headers into Stellar SDK Horizon/Soroban servers and direct custom-network Horizon fetches.
- Adds custom auth header fields to the sidebar custom network block and Settings page.
- Redacts request headers and API key material from audit trail API/error metadata.

Validation:
- `npm test -- --run src/lib/tests/stellar.test.ts src/lib/tests/auditTrail.test.js` passed: 2 files, 17 tests.
- `git diff --cached --check` passed before commit.
- `npx tsc --noEmit -p tsconfig.json` is not currently clean on upstream; it fails on pre-existing syntax errors in `src/hooks/useSearch.js`. A focused one-file type command also reports existing type issues in `src/lib/stellar.ts` and related JS imports, but did not flag the new SDK header option.

Notes:
- `npm ci` requires `--legacy-peer-deps` because the repo currently has a peer conflict between `typescript@6.0.3` and packages expecting TypeScript `^5`.
- Payment details intentionally omitted from public GitHub text.