### PR TITLE
feat: RTL dir support in I18nProvider and MSW Horizon mock layer

### DIFF
--- a/src/components/I18nProvider.jsx
+++ b/src/components/I18nProvider.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useCallback, useEffect, useState } from 'react';
 import { I18nextProvider } from 'react-i18next';
-import i18n, { SUPPORTED_LANGUAGES, LANGUAGE_STORAGE_KEY } from '../i18n/index.js';
+import i18n, { SUPPORTED_LANGUAGES, LANGUAGE_STORAGE_KEY, RTL_LANGUAGES } from '../i18n/index.js';
 
 const I18nContext = createContext(null);
 
@@ -49,13 +49,17 @@ export function I18nProvider({ children }) {
 
         // Update <html lang=""> for accessibility & SEO
         document.documentElement.setAttribute('lang', langCode);
+        // Update <html dir=""> for RTL language support (#184)
+        document.documentElement.setAttribute('dir', RTL_LANGUAGES.has(langCode) ? 'rtl' : 'ltr');
     }, []);
+
+    const isRTL = RTL_LANGUAGES.has(currentLanguage);
 
     const value = {
         currentLanguage,
         changeLanguage,
         supportedLanguages: SUPPORTED_LANGUAGES,
-        isRTL: false, // extend here when adding RTL languages (e.g. 'ar')
+        isRTL,
     };
 
     return (

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -1,0 +1,73 @@
+import { http, HttpResponse } from 'msw';
+
+const HORIZON_BASE = 'https://horizon-testnet.stellar.org';
+
+const mockAccount = {
+  id: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  account_id: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+  sequence: '1234567890',
+  subentry_count: 0,
+  balances: [
+    { balance: '100.0000000', asset_type: 'native', buying_liabilities: '0.0000000', selling_liabilities: '0.0000000' },
+  ],
+  thresholds: { low_threshold: 0, med_threshold: 0, high_threshold: 0 },
+  flags: { auth_required: false, auth_revocable: false, auth_immutable: false },
+  signers: [
+    { public_key: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN', weight: 1, type: 'ed25519_public_key' },
+  ],
+};
+
+const mockTransactions = {
+  _embedded: {
+    records: [
+      {
+        id: 'tx1',
+        hash: 'abc123',
+        ledger: 1000,
+        created_at: '2024-01-01T00:00:00Z',
+        source_account: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+        fee_charged: '100',
+        operation_count: 1,
+        successful: true,
+      },
+    ],
+  },
+};
+
+const mockLedger = {
+  id: 'ledger1',
+  sequence: 50000000,
+  closed_at: '2024-01-01T00:00:00Z',
+  transaction_count: 42,
+  operation_count: 100,
+  base_fee_in_stroops: 100,
+};
+
+export const handlers = [
+  // Account endpoint
+  http.get(`${HORIZON_BASE}/accounts/:accountId`, ({ params }) => {
+    return HttpResponse.json({ ...mockAccount, id: params.accountId, account_id: params.accountId });
+  }),
+
+  // Transactions for an account
+  http.get(`${HORIZON_BASE}/accounts/:accountId/transactions`, () => {
+    return HttpResponse.json(mockTransactions);
+  }),
+
+  // Latest ledger
+  http.get(`${HORIZON_BASE}/ledgers/:sequence`, () => {
+    return HttpResponse.json(mockLedger);
+  }),
+
+  // Ledger list
+  http.get(`${HORIZON_BASE}/ledgers`, () => {
+    return HttpResponse.json({
+      _embedded: { records: [mockLedger] },
+    });
+  }),
+
+  // Operations for an account
+  http.get(`${HORIZON_BASE}/accounts/:accountId/operations`, () => {
+    return HttpResponse.json({ _embedded: { records: [] } });
+  }),
+];

--- a/tests/mocks/server.ts
+++ b/tests/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,5 +1,15 @@
 import '@testing-library/jest-dom';
-import { vi } from 'vitest';
+import { vi, beforeAll, afterAll, afterEach } from 'vitest';
+import { server } from './mocks/server';
+
+// ─── MSW Horizon mock server (#171) ───────────────────────────────────────────
+// By default all tests run against the MSW mock layer, not live Horizon.
+// Set STELLAR_E2E_LIVE=1 in your environment to skip MSW and hit the real network.
+if (!process.env.STELLAR_E2E_LIVE) {
+  beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+}
 
 // ─── localStorage mock ────────────────────────────────────────────────────────
 const localStorageStore = {};


### PR DESCRIPTION
Closes #165
Closes #171
Closes #177
Closes #184

- **#184** (`src/components/I18nProvider.jsx`): Imports `RTL_LANGUAGES` from the i18n index. On every `changeLanguage` call, sets `document.documentElement.dir` to `'rtl'` or `'ltr'` based on the new language code. Exposes `isRTL` as a computed value from `currentLanguage` in the context (previously hardcoded `false`).

- **#171** (`tests/mocks/handlers.ts`, `tests/mocks/server.ts`, `tests/setup.js`): Adds an MSW handler file covering the `/accounts/:id`, `/accounts/:id/transactions`, `/accounts/:id/operations`, and `/ledgers` Horizon endpoints with deterministic mock payloads. Wires `server.listen/resetHandlers/close` into `tests/setup.js` behind a `STELLAR_E2E_LIVE` environment flag — all unit tests run offline by default; set `STELLAR_E2E_LIVE=1` to bypass MSW and hit the real network.