### PR TITLE
feat(perf): bundle size budget and visualizer (#173)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,111 @@ jobs:
           name: dist
           path: dist/
           retention-days: 7
+
+  # ── Bundle size budget ────────────────────────────────────────────────────
+  # Fails the PR if the gzipped main entry chunk exceeds BUDGET_KB.
+  # Add the label "skip-bundle-check" to the PR to bypass (e.g. intentional
+  # large dependency bump that will be addressed in a follow-up).
+  bundle-size:
+    name: Bundle Size Budget
+    runs-on: ubuntu-latest
+    needs: [lint, type-check, test]
+    env:
+      # Gzip budget for the main entry chunk in kilobytes.
+      BUDGET_KB: 500
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Measure gzipped bundle size
+        id: measure
+        run: |
+          # Find the main entry JS chunk (assets/index-*.js or assets/main-*.js)
+          MAIN_CHUNK=$(ls dist/assets/index-*.js dist/assets/main-*.js 2>/dev/null | head -n 1)
+          if [ -z "$MAIN_CHUNK" ]; then
+            echo "::error::Could not locate main entry chunk in dist/assets/"
+            exit 1
+          fi
+          GZIP_BYTES=$(gzip -c "$MAIN_CHUNK" | wc -c)
+          GZIP_KB=$(( GZIP_BYTES / 1024 ))
+          echo "main_chunk=$MAIN_CHUNK"   >> "$GITHUB_OUTPUT"
+          echo "gzip_kb=$GZIP_KB"         >> "$GITHUB_OUTPUT"
+          echo "budget_kb=$BUDGET_KB"     >> "$GITHUB_OUTPUT"
+          echo "### Bundle Size Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Main chunk | \`$MAIN_CHUNK\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Gzipped size | **${GZIP_KB} KB** |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Budget | ${BUDGET_KB} KB |" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$GZIP_KB" -gt "$BUDGET_KB" ]; then
+            echo "| Status | ❌ Over budget by $(( GZIP_KB - BUDGET_KB )) KB |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| Status | ✅ Within budget ($(( BUDGET_KB - GZIP_KB )) KB headroom) |" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Enforce budget (skippable via label)
+        # Skip enforcement when the PR carries the override label.
+        if: >
+          !contains(
+            github.event.pull_request.labels.*.name,
+            'skip-bundle-check'
+          )
+        run: |
+          GZIP_KB=${{ steps.measure.outputs.gzip_kb }}
+          BUDGET_KB=${{ steps.measure.outputs.budget_kb }}
+          if [ "$GZIP_KB" -gt "$BUDGET_KB" ]; then
+            echo "::error::Main bundle is ${GZIP_KB} KB gzipped — exceeds the ${BUDGET_KB} KB budget."
+            echo "::error::To bypass, add the 'skip-bundle-check' label to this PR and document the reason."
+            exit 1
+          fi
+          echo "✅ Main bundle is ${GZIP_KB} KB gzipped (budget: ${BUDGET_KB} KB)."
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  # ── On-demand bundle visualizer ───────────────────────────────────────────
+  # Triggered manually (workflow_dispatch) or when the PR has the label
+  # "generate-bundle-report". Uploads dist/stats.html as a CI artifact.
+  analyze:
+    name: Bundle Visualizer
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      contains(
+        github.event.pull_request.labels.*.name,
+        'generate-bundle-report'
+      )
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build with visualizer
+        run: npm run build:analyze
+        env:
+          ANALYZE: '1'
+
+      - name: Upload stats.html
+        uses: actions/upload-artifact@v7
+        with:
+          name: bundle-stats
+          path: dist/stats.html
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -263,6 +263,42 @@ The network switcher in the sidebar calls `setNetwork()` which resets all accoun
 
 ---
 
+## Bundle Size & Performance
+
+### Size budget
+
+The CI `bundle-size` job enforces a **500 KB gzipped** limit on the main entry chunk. A PR that exceeds this threshold will fail. To bypass intentionally (e.g. a large dependency bump that will be addressed in a follow-up), add the `skip-bundle-check` label to the PR and document the reason in the PR description.
+
+### Chunk strategy
+
+Vite splits the output into stable, cacheable chunks so that a UI-only change does not bust the Stellar SDK cache:
+
+| Chunk | Contents | Why separate |
+|---|---|---|
+| `stellar-sdk` | `@stellar/stellar-sdk` | Largest dep; changes rarely |
+| `react-vendor` | `react`, `react-dom`, `react-router-dom` | Stable; long cache TTL |
+| `ui-vendor` | `recharts`, `lucide-react` | Changes with design work |
+| `i18n` | `i18next`, `react-i18next`, `i18next-browser-languagedetector` | Only needed after first render |
+| `index` (entry) | Application code | Changes on every commit |
+
+### Bundle visualizer
+
+Generate an interactive treemap of the bundle at any time:
+
+```bash
+# Linux / macOS
+npm run build:analyze   # builds with ANALYZE=1, writes dist/stats.html
+open dist/stats.html    # open in browser
+
+# Windows (PowerShell)
+$env:ANALYZE=1; npm run build; Remove-Item Env:ANALYZE
+# then open dist/stats.html in your browser
+```
+
+In CI, add the `generate-bundle-report` label to a PR (or trigger the workflow manually via **Actions → CI → Run workflow**) to upload `dist/stats.html` as a downloadable artifact retained for 30 days.
+
+---
+
 ## TypeScript Migration
 
 The project is mid-migration from JavaScript to TypeScript. The Vite config sets `.ts` to resolve before `.js`, so imports of `stellar` and `store` automatically use the typed versions. `tsconfig.json` covers `src/lib/**/*.ts` with strict mode enabled. `allowJs: true` and `checkJs: false` let the remaining `.jsx` components import from the typed lib files without errors.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:analyze": "ANALYZE=1 vite build",
     "preview": "vite preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -70,6 +71,7 @@
     "lint-staged": "^17.0.5",
     "msw": "^2.14.3",
     "prettier": "^3.3.3",
+    "rollup-plugin-visualizer": "^5.12.0",
     "storybook": "^8.5.0",
     "typescript": "^6.0.3",
     "vite": "^5.4.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,15 +1,20 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 export default defineConfig({
   plugins: [
     react(),
-    // Bundle analysis plugin (optional, install rollup-plugin-visualizer to enable)
-    // process.env.ANALYZE && visualizer({
-    //   open: false,
-    //   filename: 'dist/stats.html',
-    //   title: 'Bundle Analysis'
-    // }),
+    // Bundle analysis: run `ANALYZE=1 npm run build` to generate dist/stats.html
+    process.env.ANALYZE &&
+      visualizer({
+        open: false,
+        filename: 'dist/stats.html',
+        title: 'Stellar Dev Dashboard — Bundle Analysis',
+        gzipSize: true,
+        brotliSize: true,
+        template: 'treemap', // 'treemap' | 'sunburst' | 'network'
+      }),
     // Security headers plugin (#106): injects HTTP security headers in dev server
     {
       name: 'security-headers',
@@ -57,11 +62,18 @@ export default defineConfig({
         chunkFileNames: 'assets/[name]-[hash].js',
         entryFileNames: 'assets/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash].[ext]',
-        // Manual chunks for common libraries
+        // Manual chunks — keep vendor code in stable, cacheable files.
+        // Chunk strategy:
+        //   stellar-sdk  — Stellar SDK + XDR (largest dep, changes rarely)
+        //   react-vendor — React core + router (stable, long cache TTL)
+        //   ui-vendor    — Recharts + Lucide icons (changes with design work)
+        //   i18n         — i18next runtime (only needed after first render)
+        // Everything else lands in the default index chunk.
         manualChunks: {
           'stellar-sdk': ['@stellar/stellar-sdk'],
           'react-vendor': ['react', 'react-dom', 'react-router-dom'],
           'ui-vendor': ['lucide-react', 'recharts'],
+          i18n: ['i18next', 'react-i18next', 'i18next-browser-languagedetector'],
         },
       },
     },


### PR DESCRIPTION
- Enable rollup-plugin-visualizer behind ANALYZE=1 env var
- Add build:analyze npm script for local use
- Expand manualChunks with i18n chunk and inline strategy comments
- Add CI bundle-size job enforcing 500KB gzipped main chunk budget
- Add skip-bundle-check label override for intentional exceptions
- Add on-demand analyze job uploading dist/stats.html artifact
- Document chunk strategy and bundle analysis in README
- Closes #173 