### PR TITLE
 feat: mobile-first navigation with hamburger drawer and bottom nav

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import './styles/responsive.css'
 
 import Sidebar from './components/layout/Sidebar'
 import MobileHeader from './components/layout/MobileHeader'
+import MobileSidebar from './components/layout/MobileSidebar'
 import ConnectPanel from './components/dashboard/ConnectPanel'
 import Overview from './components/dashboard/Overview'
 import Account from './components/dashboard/Account'
@@ -315,7 +316,7 @@ function DashboardLayout() {
         }}
       >
         {isMobile && <MobileHeader />}
-        <Sidebar isMobile={isMobile} />
+        {isMobile ? <MobileSidebar /> : <Sidebar />}
         <main style={getMainStyles()}>
           <KeyboardNavigation />
           <div style={{ marginBottom: '12px', display: 'flex', alignItems: 'center', gap: '8px' }}>

--- a/src/components/layout/MobileHeader.jsx
+++ b/src/components/layout/MobileHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useStore } from '../../lib/store'
 
 export default function MobileHeader() {
-  const { setMobileMenuOpen, theme, toggleTheme } = useStore()
+  const { isMobileMenuOpen, setMobileMenuOpen, theme, toggleTheme } = useStore()
 
   return (
     <header 
@@ -24,7 +24,11 @@ export default function MobileHeader() {
     >
       {/* Menu button */}
       <button
-        onClick={() => setMobileMenuOpen(true)}
+        type="button"
+        aria-label={isMobileMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+        aria-expanded={isMobileMenuOpen}
+        aria-controls="mobile-sidebar"
+        onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}
         className="touch-target"
         style={{
           background: 'transparent',

--- a/src/components/layout/MobileNavigation.jsx
+++ b/src/components/layout/MobileNavigation.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useStore } from '../../lib/store'
 
 // Mirrors the most-used tabs; full nav is in the sidebar (hamburger menu).
@@ -11,7 +12,8 @@ const QUICK_NAV = [
 ]
 
 export default function MobileNavigation() {
-  const { activeTab, setActiveTab } = useStore()
+  const navigate = useNavigate()
+  const { activeTab } = useStore()
 
   return (
     <nav
@@ -24,7 +26,7 @@ export default function MobileNavigation() {
         return (
           <button
             key={item.id}
-            onClick={() => setActiveTab(item.id)}
+            onClick={() => navigate(`/${item.id}`)}
             aria-label={item.label}
             aria-current={isActive ? 'page' : undefined}
             style={{

--- a/src/components/layout/MobileSidebar.jsx
+++ b/src/components/layout/MobileSidebar.jsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useCallback, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import { useStore } from "../../lib/store";
 
 const NAV_ITEMS = [
@@ -74,11 +75,17 @@ export function HamburgerButton() {
  * Full-screen overlay + slide-in drawer for mobile navigation.
  */
 export default function MobileSidebar() {
-  const { activeTab, setActiveTab, isMobileMenuOpen, setMobileMenuOpen, theme, toggleTheme, network } =
+  const navigate = useNavigate();
+  const { activeTab, isMobileMenuOpen, setMobileMenuOpen, theme, toggleTheme, network } =
     useStore();
   const drawerRef = useRef(null);
 
   const close = useCallback(() => setMobileMenuOpen(false), [setMobileMenuOpen]);
+
+  const handleNavClick = (tabId) => {
+    navigate(`/${tabId}`);
+    close();
+  };
 
   // Close on Escape
   useEffect(() => {
@@ -101,44 +108,24 @@ export default function MobileSidebar() {
     return () => { document.body.style.overflow = ""; };
   }, [isMobileMenuOpen]);
 
-  if (!isMobileMenuOpen) return null;
-
   return (
     <>
       {/* Backdrop */}
       <div
         aria-hidden="true"
         onClick={close}
-        style={{
-          position: "fixed",
-          inset: 0,
-          background: "rgba(0,0,0,0.6)",
-          backdropFilter: "blur(4px)",
-          zIndex: 999,
-        }}
+        className={`mobile-drawer-backdrop${isMobileMenuOpen ? " open" : ""}`}
       />
 
-      {/* Drawer */}
+      {/* Drawer — always in DOM so CSS transition plays on close too */}
       <nav
         id="mobile-sidebar"
         ref={drawerRef}
         aria-label="Mobile navigation"
         role="dialog"
         aria-modal="true"
-        style={{
-          position: "fixed",
-          top: 0,
-          left: 0,
-          bottom: 0,
-          width: "var(--sidebar-width-mobile, 280px)",
-          background: "var(--bg-surface)",
-          borderRight: "1px solid var(--border)",
-          zIndex: 1000,
-          display: "flex",
-          flexDirection: "column",
-          overflowY: "auto",
-          padding: "16px 0 32px",
-        }}
+        aria-hidden={!isMobileMenuOpen}
+        className={`mobile-drawer${isMobileMenuOpen ? " open" : ""}`}
       >
         {/* Header */}
         <div
@@ -216,7 +203,7 @@ export default function MobileSidebar() {
                 <button
                   type="button"
                   aria-current={isActive ? "page" : undefined}
-                  onClick={() => { setActiveTab(item.id); close(); }}
+                  onClick={() => handleNavClick(item.id)}
                   style={{
                     width: "100%",
                     display: "flex",

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -31,6 +31,59 @@
   transform: translateX(0);
 }
 
+/* ── Mobile drawer (slide-in) ────────────────────────────────────────────── */
+.mobile-drawer-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  z-index: 999;
+  opacity: 0;
+  transition: opacity 220ms ease;
+  pointer-events: none;
+}
+
+.mobile-drawer-backdrop.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.mobile-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: var(--sidebar-width-mobile, 280px);
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 16px 0 32px;
+  transform: translateX(-100%);
+  transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
+}
+
+.mobile-drawer.open {
+  transform: translateX(0);
+}
+
+@media (max-width: 768px) {
+  .mobile-drawer-backdrop {
+    display: block;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-drawer,
+  .mobile-drawer-backdrop {
+    transition: none;
+  }
+}
+
 /* ── Main content area ───────────────────────────────────────────────────── */
 .main-content {
   margin-left: var(--sidebar-width);


### PR DESCRIPTION
## Summary
  Replaces the desktop sidebar on mobile (<768px) with a purpose-built
  slide-out drawer + bottom navigation bar.
  
  ## Changes
  - **MobileHeader** — hamburger button now has correct `aria-label` (dynamic
    open/close text), `aria-expanded`, and `aria-controls="mobile-sidebar"`;
    toggles menu instead of only opening it
  - **MobileSidebar** — drawer is always in the DOM so the CSS slide-out
    animation plays on close; uses `navigate()` instead of `setActiveTab()`
    to keep the router in sync; closes on nav tap, backdrop click, and Escape
  - **MobileNavigation** — bottom bar uses `navigate()` instead of `setActiveTab()`
  - **responsive.css** — `.mobile-drawer` / `.mobile-drawer-backdrop` CSS
    transitions (220ms cubic-bezier ease-out), `will-change: transform`,
    `prefers-reduced-motion` override
  - **App.tsx** — renders `<MobileSidebar />` on mobile instead of
    `<Sidebar isMobile={true} />`
  
  ## Tested
  - Navigation works on screens < 768px
  - Menu closes after tapping a nav item
  - Escape key closes the drawer
  - Backdrop click closes the drawer
  - Body scroll locked while drawer is open
  - Smooth slide-in/out animation on open and close
  - Reduced-motion users get instant transitions
close #255 