### PR TITLE
Add alertsService for email/webhook/SMS notifications and refactor us…

### DIFF
--- a/src/hooks/useMonitoring.js
+++ b/src/hooks/useMonitoring.js
@@ -1,17 +1,4 @@
-import { sendEmail, sendWebhook, sendSMS } from "../lib/notificationChannels";
-
-// Helper to dispatch alerts via appropriate channels
-function dispatchAlert(alert) {
-  // Simple mapping: critical -> email, warning -> webhook, info -> SMS (optional)
-  if (alert.severity === "critical") {
-    // Example payload; in real use, fill appropriate fields
-    sendEmail({ to: "admin@example.com", subject: alert.title, body: alert.description });
-  } else if (alert.severity === "warning") {
-    sendWebhook({ url: "https://example.com/webhook", data: alert });
-  } else if (alert.severity === "info") {
-    sendSMS({ to: "+1234567890", message: `${alert.title}: ${alert.description}` });
-  }
-}
+import { dispatchAlert } from "../lib/alertsService";
 
 import {
   collectHealthSnapshot,

--- a/src/lib/alertsService.ts
+++ b/src/lib/alertsService.ts
@@ -1,0 +1,49 @@
+// src/lib/alertsService.ts
+// Service to dispatch alerts via configured channels.
+import { NOTIFICATION_CHANNEL, sendEmail, sendWebhook, sendSMS } from "./notificationChannels";
+
+export interface AlertPayload {
+  id: string;
+  severity: string;
+  title: string;
+  description: string;
+  channel: keyof typeof NOTIFICATION_CHANNEL;
+  // Additional optional fields per channel
+  email?: { to: string; subject: string; body: string };
+  webhook?: { url: string; data: any };
+  sms?: { to: string; message: string };
+}
+
+/**
+ * Dispatch a single alert using the appropriate provider.
+ * Returns true if the notification was sent successfully.
+ */
+export async function dispatchAlert(alert: AlertPayload): Promise<boolean> {
+  switch (alert.channel) {
+    case NOTIFICATION_CHANNEL.EMAIL:
+      if (alert.email) {
+        return await sendEmail(alert.email);
+      }
+      break;
+    case NOTIFICATION_CHANNEL.WEBHOOK:
+      if (alert.webhook) {
+        return await sendWebhook(alert.webhook);
+      }
+      break;
+    case NOTIFICATION_CHANNEL.SMS:
+      if (alert.sms) {
+        return await sendSMS(alert.sms);
+      }
+      break;
+    default:
+      console.warn("Unsupported notification channel", alert.channel);
+  }
+  return false;
+}
+
+/**
+ * Dispatch multiple alerts in parallel, returning an array of results.
+ */
+export async function dispatchAlerts(alerts: AlertPayload[]): Promise<boolean[]> {
+  return Promise.all(alerts.map(dispatchAlert));
+}


### PR DESCRIPTION
this pr closes #335  This PR introduces a dedicated alertsService that centralizes dispatch logic for email, webhook, and SMS channels.

New src/lib/alertsService.ts defines AlertPayload, dispatchAlert, and dispatchAlerts.
useMonitoring hook now imports dispatchAlert from the service, simplifying alert handling and keeping routing logic separate from UI hooks.
All changes are scoped to the new feature/custom-alerts branch, which is set as upstream.