### PR TITLE
Add custom analytics report builder

### DIFF
--- a/src/components/dashboard/Analytics.tsx
+++ b/src/components/dashboard/Analytics.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useAnalytics } from "../../hooks/useAnalytics";
 import AnalyticsChart from "../charts/AnalyticsChart";
 import { StatCard } from "./Card";
+import CustomReports from "./CustomReports";
 import type { AlertEntry } from "./types";
 
 function RiskItem({ signal }: { signal: AlertEntry }) {
@@ -49,6 +50,8 @@ export default function Analytics() {
       </div>
 
       <AnalyticsChart data={analytics.activity || []} />
+
+      <CustomReports analytics={analytics} />
 
       <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: "12px" }}>
         <StatCard label="Latest Ledger" value={network.latestLedgerSequence || "—"} />

--- a/src/components/dashboard/CustomReports.tsx
+++ b/src/components/dashboard/CustomReports.tsx
@@ -1,0 +1,335 @@
+import React, { useMemo, useState } from "react";
+import {
+  BarChart3,
+  CalendarClock,
+  Download,
+  FileJson,
+  FileText,
+  Gauge,
+  Mail,
+  Save,
+  Table2,
+  Webhook,
+} from "lucide-react";
+import {
+  buildDeliveryPlan,
+  buildHorizonQuery,
+  createPdfReportPayload,
+  createReportSchedule,
+  exportReportAsCsv,
+  exportReportAsJson,
+  getNextRunPreview,
+  getReportTemplate,
+  REPORT_COMPONENT_PALETTE,
+  REPORT_TEMPLATES,
+  transformReportData,
+  type ReportComponentDefinition,
+  type ReportResource,
+} from "../../lib/customReports";
+
+interface CustomReportsProps {
+  analytics: any;
+}
+
+const fieldStyle: React.CSSProperties = {
+  width: "100%",
+  minHeight: "36px",
+  borderRadius: "var(--radius-md)",
+  border: "1px solid var(--border)",
+  background: "var(--bg-elevated)",
+  color: "var(--text-primary)",
+  padding: "8px 10px",
+  fontSize: "12px",
+};
+
+const buttonStyle: React.CSSProperties = {
+  borderRadius: "var(--radius-md)",
+  border: "1px solid var(--border)",
+  background: "var(--bg-elevated)",
+  color: "var(--text-primary)",
+  padding: "8px 10px",
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "6px",
+  fontSize: "12px",
+  cursor: "pointer",
+};
+
+function downloadText(filename: string, content: string, type: string) {
+  const blob = new Blob([content], { type });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function componentIcon(type: ReportComponentDefinition["type"]) {
+  if (type === "chart") return <BarChart3 size={14} />;
+  if (type === "table") return <Table2 size={14} />;
+  return <Gauge size={14} />;
+}
+
+export default function CustomReports({ analytics }: CustomReportsProps) {
+  const [templateId, setTemplateId] = useState(REPORT_TEMPLATES[0].id);
+  const [resource, setResource] = useState<ReportResource>("transactions");
+  const [accountId, setAccountId] = useState("");
+  const [limit, setLimit] = useState(50);
+  const [cron, setCron] = useState("0 9 * * 1");
+  const [email, setEmail] = useState("");
+  const [webhookUrl, setWebhookUrl] = useState("");
+  const [components, setComponents] = useState(REPORT_TEMPLATES[0].components);
+
+  const template = getReportTemplate(templateId);
+  const reportData = useMemo(() => transformReportData(template.id, analytics || {}), [analytics, template.id]);
+  const query = useMemo(
+    () =>
+      buildHorizonQuery({
+        resource,
+        accountId: accountId || undefined,
+        limit,
+        filters: { include_failed: resource === "transactions" ? "true" : undefined },
+      }),
+    [accountId, limit, resource],
+  );
+  const schedule = useMemo(() => {
+    try {
+      return createReportSchedule({
+        id: `${template.id}-weekly`,
+        reportId: template.id,
+        cron,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        enabled: true,
+        channels: webhookUrl ? ["email", "webhook"] : ["email"],
+        recipients: email ? [email] : [],
+        webhookUrl: webhookUrl || undefined,
+      });
+    } catch {
+      return null;
+    }
+  }, [cron, email, template.id, webhookUrl]);
+  const deliveryPlan = schedule ? buildDeliveryPlan(schedule, template, reportData) : [];
+
+  const handleTemplateChange = (nextTemplateId: string) => {
+    const nextTemplate = getReportTemplate(nextTemplateId);
+    setTemplateId(nextTemplate.id);
+    setResource(nextTemplate.resource);
+    setComponents(nextTemplate.components);
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const droppedId = event.dataTransfer.getData("application/report-component");
+    const dropped = REPORT_COMPONENT_PALETTE.find((component) => component.id === droppedId);
+    if (!dropped) return;
+    setComponents((current) => [
+      ...current,
+      { ...dropped, id: `${dropped.id}-${Date.now()}`, label: `Custom ${dropped.label}` },
+    ]);
+  };
+
+  const exportJson = () => {
+    downloadText(`${template.id}.json`, exportReportAsJson(template, reportData), "application/json");
+  };
+
+  const exportCsv = () => {
+    downloadText(`${template.id}.csv`, exportReportAsCsv(reportData), "text/csv");
+  };
+
+  const exportPdf = () => {
+    const payload = createPdfReportPayload(template, reportData);
+    downloadText(payload.filename, payload.html, payload.contentType);
+  };
+
+  return (
+    <div
+      style={{
+        background: "var(--bg-card)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-lg)",
+        padding: "16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "14px",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "12px", flexWrap: "wrap" }}>
+        <div>
+          <div style={{ fontFamily: "var(--font-display)", fontSize: "15px", fontWeight: 700 }}>
+            Custom Reports
+          </div>
+          <div style={{ color: "var(--text-muted)", fontSize: "12px", marginTop: "3px" }}>
+            Build reusable Stellar analytics reports with exports and scheduled delivery.
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+          <button type="button" style={buttonStyle} onClick={exportCsv} title="Export CSV">
+            <Download size={14} /> CSV
+          </button>
+          <button type="button" style={buttonStyle} onClick={exportPdf} title="Export PDF-ready report">
+            <FileText size={14} /> PDF
+          </button>
+          <button type="button" style={buttonStyle} onClick={exportJson} title="Export JSON">
+            <FileJson size={14} /> JSON
+          </button>
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: "14px" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          <label style={{ display: "flex", flexDirection: "column", gap: "6px", fontSize: "12px", color: "var(--text-muted)" }}>
+            Template
+            <select value={templateId} onChange={(event) => handleTemplateChange(event.target.value)} style={fieldStyle}>
+              {REPORT_TEMPLATES.map((reportTemplate) => (
+                <option key={reportTemplate.id} value={reportTemplate.id}>
+                  {reportTemplate.name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 90px", gap: "8px" }}>
+            <label style={{ display: "flex", flexDirection: "column", gap: "6px", fontSize: "12px", color: "var(--text-muted)" }}>
+              Horizon resource
+              <select value={resource} onChange={(event) => setResource(event.target.value as ReportResource)} style={fieldStyle}>
+                <option value="accounts">Accounts</option>
+                <option value="transactions">Transactions</option>
+                <option value="operations">Operations</option>
+                <option value="payments">Payments</option>
+                <option value="ledgers">Ledgers</option>
+              </select>
+            </label>
+            <label style={{ display: "flex", flexDirection: "column", gap: "6px", fontSize: "12px", color: "var(--text-muted)" }}>
+              Limit
+              <input type="number" min={1} max={200} value={limit} onChange={(event) => setLimit(Number(event.target.value))} style={fieldStyle} />
+            </label>
+          </div>
+
+          <label style={{ display: "flex", flexDirection: "column", gap: "6px", fontSize: "12px", color: "var(--text-muted)" }}>
+            Account filter
+            <input value={accountId} onChange={(event) => setAccountId(event.target.value)} placeholder="G..." style={fieldStyle} />
+          </label>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+            <div style={{ fontSize: "12px", color: "var(--text-muted)" }}>Component palette</div>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: "8px" }}>
+              {REPORT_COMPONENT_PALETTE.map((component) => (
+                <button
+                  key={component.id}
+                  type="button"
+                  draggable
+                  onDragStart={(event) => event.dataTransfer.setData("application/report-component", component.id)}
+                  onClick={() => setComponents((current) => [...current, { ...component, id: `${component.id}-${Date.now()}` }])}
+                  style={buttonStyle}
+                  title={`Add ${component.label}`}
+                >
+                  {componentIcon(component.type)}
+                  {component.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div
+            style={{
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius-md)",
+              padding: "10px",
+              background: "var(--bg-elevated)",
+              color: "var(--text-muted)",
+              fontSize: "11px",
+              wordBreak: "break-all",
+            }}
+          >
+            {query.url}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+          <div
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={handleDrop}
+            style={{
+              border: "1px dashed var(--border)",
+              borderRadius: "var(--radius-lg)",
+              padding: "12px",
+              minHeight: "155px",
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+              gap: "8px",
+            }}
+          >
+            {components.map((component, index) => (
+              <div
+                key={component.id}
+                style={{
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius-md)",
+                  background: "var(--bg-elevated)",
+                  padding: "10px",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: "8px",
+                }}
+              >
+                <span style={{ display: "inline-flex", alignItems: "center", gap: "7px", fontSize: "12px" }}>
+                  {componentIcon(component.type)}
+                  {component.label}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setComponents((current) => current.filter((_, itemIndex) => itemIndex !== index))}
+                  style={{ ...buttonStyle, padding: "5px 7px" }}
+                  title={`Remove ${component.label}`}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: "8px" }}>
+            {reportData.metrics.map((metric) => (
+              <div key={metric.label} style={{ background: "var(--bg-elevated)", border: "1px solid var(--border)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                <div style={{ color: "var(--text-muted)", fontSize: "11px" }}>{metric.label}</div>
+                <div style={{ fontFamily: "var(--font-display)", fontWeight: 700, marginTop: "6px" }}>{metric.value}</div>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px" }}>
+            <label style={{ display: "flex", flexDirection: "column", gap: "6px", fontSize: "12px", color: "var(--text-muted)" }}>
+              Cron
+              <input value={cron} onChange={(event) => setCron(event.target.value)} style={fieldStyle} />
+            </label>
+            <label style={{ display: "flex", flexDirection: "column", gap: "6px", fontSize: "12px", color: "var(--text-muted)" }}>
+              Email
+              <input value={email} onChange={(event) => setEmail(event.target.value)} placeholder="ops@example.com" style={fieldStyle} />
+            </label>
+          </div>
+          <label style={{ display: "flex", flexDirection: "column", gap: "6px", fontSize: "12px", color: "var(--text-muted)" }}>
+            Webhook
+            <input value={webhookUrl} onChange={(event) => setWebhookUrl(event.target.value)} placeholder="https://example.com/report-hook" style={fieldStyle} />
+          </label>
+
+          <div style={{ display: "flex", gap: "8px", flexWrap: "wrap", color: "var(--text-muted)", fontSize: "12px" }}>
+            <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
+              <CalendarClock size={14} /> Next run: {schedule?.nextRunAt || getNextRunPreview("0 9 * * 1")}
+            </span>
+            <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
+              <Mail size={14} /> {deliveryPlan.find((item) => item.channel === "email")?.attachments.length || 3} attachments
+            </span>
+            <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
+              <Webhook size={14} /> {webhookUrl ? "Webhook ready" : "Webhook optional"}
+            </span>
+            <span style={{ display: "inline-flex", alignItems: "center", gap: "6px" }}>
+              <Save size={14} /> Cached report preview
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/customReports.test.ts
+++ b/src/lib/__tests__/customReports.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildDeliveryPlan,
+  buildHorizonQuery,
+  createPdfReportPayload,
+  createReportCache,
+  createReportSchedule,
+  exportReportAsCsv,
+  exportReportAsJson,
+  getNextRunPreview,
+  REPORT_TEMPLATES,
+  transformReportData,
+} from "../customReports";
+
+const analytics = {
+  account: {
+    xlmBalance: 128.5,
+    trustlineCount: 3,
+    totalAssets: 4,
+  },
+  transactions: {
+    successRate: 0.875,
+    opTypeCounts: {
+      payment: 5,
+      manage_sell_offer: 2,
+    },
+  },
+  network: {
+    latestLedgerSequence: 123456,
+    baseFee: 100,
+  },
+  activity: [
+    { date: "2026-06-23", transactions: 4, fees: 400 },
+    { date: "2026-06-24", transactions: 2, fees: 200 },
+  ],
+  risks: [{ id: "master-single-point", label: "Single signer", active: true }],
+};
+
+describe("custom reports", () => {
+  it("ships the required Stellar report templates", () => {
+    expect(REPORT_TEMPLATES.map((template) => template.id)).toEqual([
+      "account-activity",
+      "portfolio-performance",
+      "transaction-analysis",
+      "network-health",
+    ]);
+    expect(REPORT_TEMPLATES.every((template) => template.components.length >= 3)).toBe(true);
+  });
+
+  it("builds account-scoped Horizon queries with filters", () => {
+    const query = buildHorizonQuery({
+      resource: "transactions",
+      network: "public",
+      accountId: "GABC",
+      limit: 500,
+      filters: { include_failed: true },
+    });
+
+    expect(query.endpoint).toBe("/accounts/GABC/transactions");
+    expect(query.params.limit).toBe("200");
+    expect(query.url).toContain("https://horizon.stellar.org/accounts/GABC/transactions");
+    expect(query.url).toContain("include_failed=true");
+  });
+
+  it("transforms analytics snapshots into report metrics, charts, and rows", () => {
+    const data = transformReportData("transaction-analysis", analytics);
+
+    expect(data.metrics).toContainEqual({ label: "Success Rate", value: "87.5%" });
+    expect(data.chartData).toHaveLength(2);
+    expect(data.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "payment", value: 5 }),
+        expect.objectContaining({ id: "manage_sell_offer", value: 2 }),
+      ]),
+    );
+  });
+
+  it("caches report data until the ttl expires", () => {
+    vi.useFakeTimers();
+    const cache = createReportCache(1000);
+
+    cache.set("activity", { rows: 1 });
+    expect(cache.get("activity")).toEqual({ rows: 1 });
+
+    vi.advanceTimersByTime(1001);
+    expect(cache.get("activity")).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("exports JSON, CSV, and PDF-ready report payloads", () => {
+    const template = REPORT_TEMPLATES[0];
+    const data = transformReportData(template.id, analytics);
+
+    expect(JSON.parse(exportReportAsJson(template, data)).template.id).toBe(template.id);
+    expect(exportReportAsCsv(data)).toContain("section,label,value");
+    const pdf = createPdfReportPayload(template, data);
+    expect(pdf.filename).toBe("account-activity.pdf.html");
+    expect(pdf.html).toContain("<h1>Account Activity</h1>");
+    expect(pdf.chartData).toEqual(data.chartData);
+  });
+
+  it("validates schedules and builds email and webhook deliveries", () => {
+    const schedule = createReportSchedule({
+      id: "weekly-activity",
+      reportId: "account-activity",
+      cron: "0 9 * * 1",
+      timezone: "UTC",
+      enabled: true,
+      channels: ["email", "webhook"],
+      recipients: ["ops@example.com"],
+      webhookUrl: "https://example.com/reports",
+    });
+    const data = transformReportData("account-activity", analytics);
+    const plan = buildDeliveryPlan(schedule, REPORT_TEMPLATES[0], data);
+
+    expect(schedule.nextRunAt).toEqual(getNextRunPreview("0 9 * * 1"));
+    expect(plan).toHaveLength(2);
+    expect(plan[0].attachments.map((attachment) => attachment.contentType)).toEqual([
+      "application/json",
+      "text/csv",
+      "text/html",
+    ]);
+  });
+});

--- a/src/lib/customReports.ts
+++ b/src/lib/customReports.ts
@@ -1,0 +1,386 @@
+export type ReportComponentType = "metric" | "chart" | "table";
+export type ReportResource = "accounts" | "transactions" | "operations" | "ledgers" | "payments";
+export type DeliveryChannel = "email" | "webhook";
+
+export interface ReportComponentDefinition {
+  id: string;
+  type: ReportComponentType;
+  label: string;
+  dataKey: string;
+}
+
+export interface ReportTemplate {
+  id: string;
+  name: string;
+  description: string;
+  resource: ReportResource;
+  components: ReportComponentDefinition[];
+}
+
+export interface HorizonQueryConfig {
+  resource: ReportResource;
+  network?: "public" | "testnet" | string;
+  accountId?: string;
+  cursor?: string;
+  order?: "asc" | "desc";
+  limit?: number;
+  filters?: Record<string, string | number | boolean | undefined>;
+}
+
+export interface BuiltHorizonQuery {
+  resource: ReportResource;
+  endpoint: string;
+  params: Record<string, string>;
+  url: string;
+}
+
+export interface ReportDataSet {
+  account?: Record<string, any>;
+  transactions?: Record<string, any>;
+  network?: Record<string, any>;
+  activity?: Array<Record<string, any>>;
+  risks?: Array<Record<string, any>>;
+}
+
+export interface TransformedReportData {
+  templateId: string;
+  generatedAt: string;
+  metrics: Array<{ label: string; value: string | number }>;
+  chartData: Array<Record<string, any>>;
+  rows: Array<Record<string, any>>;
+  columns: string[];
+}
+
+export interface ReportSchedule {
+  id: string;
+  reportId: string;
+  cron: string;
+  timezone: string;
+  enabled: boolean;
+  channels: DeliveryChannel[];
+  recipients: string[];
+  webhookUrl?: string;
+  nextRunAt: string;
+}
+
+const HORIZON_BASE_URLS: Record<string, string> = {
+  public: "https://horizon.stellar.org",
+  testnet: "https://horizon-testnet.stellar.org",
+};
+
+const RESOURCE_ENDPOINTS: Record<ReportResource, string> = {
+  accounts: "/accounts",
+  transactions: "/transactions",
+  operations: "/operations",
+  ledgers: "/ledgers",
+  payments: "/payments",
+};
+
+export const REPORT_COMPONENT_PALETTE: ReportComponentDefinition[] = [
+  { id: "metric-total", type: "metric", label: "Metric", dataKey: "metrics" },
+  { id: "chart-activity", type: "chart", label: "Chart", dataKey: "activity" },
+  { id: "table-records", type: "table", label: "Table", dataKey: "rows" },
+];
+
+export const REPORT_TEMPLATES: ReportTemplate[] = [
+  {
+    id: "account-activity",
+    name: "Account Activity",
+    description: "Track balances, signer risk, and recent transaction volume for an account.",
+    resource: "accounts",
+    components: [
+      { id: "account-balance", type: "metric", label: "XLM Balance", dataKey: "account.xlmBalance" },
+      { id: "account-activity-chart", type: "chart", label: "Daily Activity", dataKey: "activity" },
+      { id: "account-risk-table", type: "table", label: "Risk Signals", dataKey: "risks" },
+    ],
+  },
+  {
+    id: "portfolio-performance",
+    name: "Portfolio Performance",
+    description: "Summarize trustlines, asset counts, and fee movement over time.",
+    resource: "accounts",
+    components: [
+      { id: "portfolio-assets", type: "metric", label: "Assets", dataKey: "account.totalAssets" },
+      { id: "portfolio-fees", type: "chart", label: "Fee Trend", dataKey: "activity" },
+      { id: "portfolio-summary", type: "table", label: "Portfolio Summary", dataKey: "account" },
+    ],
+  },
+  {
+    id: "transaction-analysis",
+    name: "Transaction Analysis",
+    description: "Inspect transaction success rates and operation mix.",
+    resource: "transactions",
+    components: [
+      { id: "tx-success-rate", type: "metric", label: "Success Rate", dataKey: "transactions.successRate" },
+      { id: "tx-activity", type: "chart", label: "Transaction Trend", dataKey: "activity" },
+      { id: "tx-breakdown", type: "table", label: "Operation Mix", dataKey: "transactions.opTypeCounts" },
+    ],
+  },
+  {
+    id: "network-health",
+    name: "Network Health",
+    description: "Monitor ledger freshness, fees, and close-time health.",
+    resource: "ledgers",
+    components: [
+      { id: "network-ledger", type: "metric", label: "Latest Ledger", dataKey: "network.latestLedgerSequence" },
+      { id: "network-close-time", type: "chart", label: "Close Time", dataKey: "activity" },
+      { id: "network-fees", type: "table", label: "Network Fees", dataKey: "network" },
+    ],
+  },
+];
+
+function normalizeLimit(limit?: number) {
+  const parsed = Number(limit);
+  if (!Number.isFinite(parsed)) return "200";
+  return String(Math.min(Math.max(Math.trunc(parsed), 1), 200));
+}
+
+function getNestedValue(source: Record<string, any>, path: string) {
+  return path.split(".").reduce<any>((value, key) => value?.[key], source);
+}
+
+function normalizeRowSet(value: any): Array<Record<string, any>> {
+  if (Array.isArray(value)) return value.map((entry, index) => ({ id: entry.id || index + 1, ...entry }));
+  if (value && typeof value === "object") {
+    return Object.entries(value).map(([key, entry]) => {
+      if (entry && typeof entry === "object") return { id: key, ...entry };
+      return { id: key, value: entry };
+    });
+  }
+  return [{ id: "value", value }];
+}
+
+function escapeCsvValue(value: any) {
+  const stringValue = value == null ? "" : String(value);
+  if (!/[",\n]/.test(stringValue)) return stringValue;
+  return `"${stringValue.replace(/"/g, '""')}"`;
+}
+
+function sanitizeFilePart(value: string) {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "") || "report";
+}
+
+export function getReportTemplate(templateId: string) {
+  return REPORT_TEMPLATES.find((template) => template.id === templateId) || REPORT_TEMPLATES[0];
+}
+
+export function buildHorizonQuery(config: HorizonQueryConfig): BuiltHorizonQuery {
+  const resource = config.resource;
+  const endpoint = RESOURCE_ENDPOINTS[resource];
+  if (!endpoint) {
+    throw new Error(`Unsupported Horizon report resource: ${resource}`);
+  }
+
+  const baseUrl = HORIZON_BASE_URLS[config.network || "testnet"] || String(config.network || "").replace(/\/$/, "");
+  if (!baseUrl) {
+    throw new Error("A Horizon base URL or known network is required");
+  }
+
+  const params: Record<string, string> = {
+    cursor: config.cursor || "now",
+    order: config.order || "desc",
+    limit: normalizeLimit(config.limit),
+  };
+
+  Object.entries(config.filters || {}).forEach(([key, value]) => {
+    if (value !== undefined && value !== "") params[key] = String(value);
+  });
+
+  const accountScoped = ["transactions", "operations", "payments"].includes(resource) && config.accountId;
+  const path = accountScoped ? `/accounts/${encodeURIComponent(config.accountId || "")}${endpoint}` : endpoint;
+  const search = new URLSearchParams(params);
+
+  return {
+    resource,
+    endpoint: path,
+    params,
+    url: `${baseUrl}${path}?${search.toString()}`,
+  };
+}
+
+export function transformReportData(templateId: string, dataSet: ReportDataSet): TransformedReportData {
+  const template = getReportTemplate(templateId);
+  const source = {
+    account: dataSet.account || {},
+    transactions: dataSet.transactions || {},
+    network: dataSet.network || {},
+    activity: dataSet.activity || [],
+    risks: dataSet.risks || [],
+  };
+
+  const metrics = template.components
+    .filter((component) => component.type === "metric")
+    .map((component) => {
+      const value = getNestedValue(source, component.dataKey);
+      const normalized = typeof value === "number" && component.dataKey.includes("successRate")
+        ? `${(value * 100).toFixed(1)}%`
+        : value ?? "N/A";
+      return { label: component.label, value: normalized };
+    });
+
+  const chartComponent = template.components.find((component) => component.type === "chart");
+  const tableComponent = template.components.find((component) => component.type === "table");
+  const chartData = normalizeRowSet(getNestedValue(source, chartComponent?.dataKey || "activity"));
+  const rows = normalizeRowSet(getNestedValue(source, tableComponent?.dataKey || template.resource));
+  const columns = Array.from(new Set(rows.flatMap((row) => Object.keys(row)))).slice(0, 8);
+
+  return {
+    templateId: template.id,
+    generatedAt: new Date().toISOString(),
+    metrics,
+    chartData,
+    rows,
+    columns,
+  };
+}
+
+export function createReportCache(ttlMs = 5 * 60 * 1000) {
+  const entries = new Map<string, { expiresAt: number; value: any }>();
+
+  return {
+    get(key: string) {
+      const entry = entries.get(key);
+      if (!entry) return undefined;
+      if (entry.expiresAt <= Date.now()) {
+        entries.delete(key);
+        return undefined;
+      }
+      return entry.value;
+    },
+    set(key: string, value: any) {
+      entries.set(key, { value, expiresAt: Date.now() + ttlMs });
+      return value;
+    },
+    remember(key: string, factory: () => any) {
+      const cached = this.get(key);
+      if (cached !== undefined) return cached;
+      return this.set(key, factory());
+    },
+    clear() {
+      entries.clear();
+    },
+    size() {
+      return entries.size;
+    },
+  };
+}
+
+export function exportReportAsJson(template: ReportTemplate, data: TransformedReportData) {
+  return JSON.stringify({ template, data }, null, 2);
+}
+
+export function exportReportAsCsv(data: TransformedReportData) {
+  const metricRows: Array<Record<string, any>> = data.metrics.map((metric) => ({
+    section: "metric",
+    label: metric.label,
+    value: metric.value,
+  }));
+  const tableRows: Array<Record<string, any>> = data.rows.map((row) => ({
+    section: "row",
+    ...row,
+  }));
+  const rows: Array<Record<string, any>> = [...metricRows, ...tableRows];
+  const headers = Array.from(new Set(rows.flatMap((row) => Object.keys(row))));
+  const body = rows.map((row) => headers.map((header) => escapeCsvValue(row[header])).join(","));
+  return [headers.join(","), ...body].join("\n");
+}
+
+export function createPdfReportPayload(template: ReportTemplate, data: TransformedReportData) {
+  const metricHtml = data.metrics
+    .map((metric) => `<li><strong>${metric.label}</strong>: ${metric.value}</li>`)
+    .join("");
+  const tableHead = data.columns.map((column) => `<th>${column}</th>`).join("");
+  const tableBody = data.rows
+    .slice(0, 25)
+    .map((row) => `<tr>${data.columns.map((column) => `<td>${row[column] ?? ""}</td>`).join("")}</tr>`)
+    .join("");
+
+  return {
+    filename: `${sanitizeFilePart(template.name)}.pdf.html`,
+    contentType: "text/html",
+    html: `<!doctype html><html><head><meta charset="utf-8"><title>${template.name}</title></head><body><h1>${template.name}</h1><p>${template.description}</p><h2>Metrics</h2><ul>${metricHtml}</ul><h2>Data</h2><table><thead><tr>${tableHead}</tr></thead><tbody>${tableBody}</tbody></table></body></html>`,
+    chartData: data.chartData,
+  };
+}
+
+export function parseCronSchedule(expression: string) {
+  const parts = expression.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    throw new Error("Report schedules use five-part cron expressions");
+  }
+
+  return {
+    minute: parts[0],
+    hour: parts[1],
+    dayOfMonth: parts[2],
+    month: parts[3],
+    dayOfWeek: parts[4],
+  };
+}
+
+function resolveCronPart(part: string, current: number, min: number, max: number) {
+  if (part === "*") return current;
+  if (part.startsWith("*/")) {
+    const step = Number(part.slice(2));
+    if (!Number.isFinite(step) || step <= 0) throw new Error(`Invalid cron step: ${part}`);
+    const next = current + (step - (current % step));
+    return next > max ? min : next;
+  }
+  const exact = Number(part);
+  if (!Number.isInteger(exact) || exact < min || exact > max) {
+    throw new Error(`Invalid cron value: ${part}`);
+  }
+  return exact;
+}
+
+export function getNextRunPreview(expression: string, from = new Date()) {
+  const cron = parseCronSchedule(expression);
+  const next = new Date(from);
+  next.setSeconds(0, 0);
+  next.setMinutes(next.getMinutes() + 1);
+  next.setMinutes(resolveCronPart(cron.minute, next.getMinutes(), 0, 59));
+  next.setHours(resolveCronPart(cron.hour, next.getHours(), 0, 23));
+
+  if (next.getTime() <= from.getTime()) {
+    next.setDate(next.getDate() + 1);
+  }
+
+  return next.toISOString();
+}
+
+function isEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function isWebhook(value?: string) {
+  return !value || /^https:\/\/.+/i.test(value);
+}
+
+export function createReportSchedule(input: Omit<ReportSchedule, "nextRunAt">): ReportSchedule {
+  parseCronSchedule(input.cron);
+  if (input.channels.includes("email") && !input.recipients.every(isEmail)) {
+    throw new Error("Email report schedules require valid recipients");
+  }
+  if (input.channels.includes("webhook") && !isWebhook(input.webhookUrl)) {
+    throw new Error("Webhook report schedules require an HTTPS URL");
+  }
+
+  return {
+    ...input,
+    timezone: input.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+    nextRunAt: getNextRunPreview(input.cron),
+  };
+}
+
+export function buildDeliveryPlan(schedule: ReportSchedule, template: ReportTemplate, data: TransformedReportData) {
+  return schedule.channels.map((channel) => ({
+    channel,
+    target: channel === "email" ? schedule.recipients.join(", ") : schedule.webhookUrl,
+    subject: `${template.name} report`,
+    attachments: [
+      { filename: `${sanitizeFilePart(template.name)}.json`, contentType: "application/json", body: exportReportAsJson(template, data) },
+      { filename: `${sanitizeFilePart(template.name)}.csv`, contentType: "text/csv", body: exportReportAsCsv(data) },
+      createPdfReportPayload(template, data),
+    ],
+  }));
+}


### PR DESCRIPTION
Closes #409.

## Summary
- add reusable custom report templates for account activity, portfolio performance, transaction analysis, and network health
- add a Horizon query builder, report transform pipeline, cache, CSV/JSON/PDF-ready exports, and scheduled delivery helpers
- surface a custom report builder panel in the Analytics tab with a draggable component palette and delivery preview

## Verification
- `git diff --check`
- `npx --yes -p typescript@6.0.3 tsc --ignoreConfig --noEmit --skipLibCheck --target ES2020 --lib ES2020,DOM --module ESNext --moduleResolution bundler --jsx react-jsx src/lib/customReports.ts`
- `npx --yes -p esbuild@0.24.2 esbuild src/components/dashboard/CustomReports.tsx --bundle --platform=browser --format=esm --external:react --external:react/jsx-runtime --external:lucide-react --outfile=/tmp/customReports.bundle.js`

Note: full `npm ci`/Vitest is currently blocked by existing package metadata: TypeScript 6 conflicts with react-i18next optional peer requirements, and `@tensorflow/tfjs-node@^5.0.0` has no matching published version.