### PR TITLE
Add saved query folders and search automation

### DIFF
--- a/src/components/dashboard/AdvancedSearch.tsx
+++ b/src/components/dashboard/AdvancedSearch.tsx
@@ -21,6 +21,10 @@ import {
   Globe,
   CheckCircle,
   AlertCircle,
+  Folder,
+  Share2,
+  BellRing,
+  Copy,
 } from 'lucide-react';
 import advancedSearchService from '../../lib/advancedSearch.js';
 import auditTrail from '../../lib/auditTrail.js';
@@ -33,10 +37,16 @@ export default function AdvancedSearch() {
   const [showFilters, setShowFilters] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [savedSearches, setSavedSearches] = useState([]);
+  const [savedFolders, setSavedFolders] = useState([]);
+  const [searchAnalytics, setSearchAnalytics] = useState(null);
   const [searchHistory, setSearchHistory] = useState([]);
   const [suggestions, setSuggestions] = useState([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedTypes, setSelectedTypes] = useState(['transactions', 'operations', 'contracts', 'accounts']);
+  const [savedSearchFolder, setSavedSearchFolder] = useState('General');
+  const [createAlertOnSave, setCreateAlertOnSave] = useState(false);
+  const [alertCron, setAlertCron] = useState('0 * * * *');
+  const [shareToken, setShareToken] = useState('');
   
   const [filters, setFilters] = useState({
     dateRange: { start: '', end: '' },
@@ -76,7 +86,9 @@ export default function AdvancedSearch() {
 
   const loadData = () => {
     setSavedSearches(advancedSearchService.getSavedSearches());
-    setSearchHistory(advancedSearchService.searchHistory);
+    setSavedFolders(advancedSearchService.getSavedSearchFolders());
+    setSearchHistory(advancedSearchService.getSearchHistory());
+    setSearchAnalytics(advancedSearchService.getSearchAnalytics());
   };
 
   const handleSearch = async () => {
@@ -104,6 +116,7 @@ export default function AdvancedSearch() {
         resultCount: results.total,
         searchTime: results.searchTime
       });
+      loadData();
 
     } catch (error) {
       auditTrail.logError(error, { operation: 'advancedSearch', query: searchQuery });
@@ -172,7 +185,15 @@ export default function AdvancedSearch() {
         filters: buildFilters(),
         sort
       };
-      advancedSearchService.saveSearch(name, query);
+      const saved = advancedSearchService.saveSearch(name, query, { folder: savedSearchFolder });
+      if (createAlertOnSave) {
+        advancedSearchService.createSearchAlert({
+          savedSearchId: saved.id,
+          name: `${name} alert`,
+          cron: alertCron,
+          channels: ['in-app'],
+        });
+      }
       loadData();
       
       auditTrail.logUserAction('Saved search', { name, query });
@@ -180,21 +201,30 @@ export default function AdvancedSearch() {
   };
 
   const loadSavedSearch = (savedSearch) => {
-    setSearchQuery(savedSearch.query.text || '');
-    setSelectedTypes(savedSearch.query.types || ['transactions', 'operations']);
+    const selectedSearch = advancedSearchService.loadSavedSearch(savedSearch.id) || savedSearch;
+    setSearchQuery(selectedSearch.query.text || '');
+    setSelectedTypes(selectedSearch.query.types || ['transactions', 'operations']);
     
     // Reset filters and load saved ones
     clearFilters();
-    if (savedSearch.query.filters) {
-      setFilters({ ...filters, ...savedSearch.query.filters });
+    if (selectedSearch.query.filters) {
+      setFilters({ ...filters, ...selectedSearch.query.filters });
     }
     
-    if (savedSearch.query.sort) {
-      setSort(savedSearch.query.sort);
+    if (selectedSearch.query.sort) {
+      setSort(selectedSearch.query.sort);
     }
     
     setShowHistory(false);
+    loadData();
     handleSearch();
+  };
+
+  const shareSavedSearch = (event, savedSearch) => {
+    event.stopPropagation();
+    const token = advancedSearchService.shareSearch(savedSearch.id);
+    setShareToken(token);
+    loadData();
   };
 
   const exportResults = () => {
@@ -343,6 +373,41 @@ export default function AdvancedSearch() {
               </button>
             ))}
           </div>
+        </div>
+
+        {/* Saved Query Options */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '10px', marginBottom: '16px' }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', color: 'var(--text-muted)' }}>
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: '5px' }}>
+              <Folder size={12} /> Save folder
+            </span>
+            <input
+              value={savedSearchFolder}
+              onChange={(e) => setSavedSearchFolder(e.target.value)}
+              style={{ ...inputStyle, fontSize: '12px' }}
+            />
+          </label>
+
+          <label style={{ display: 'flex', flexDirection: 'column', gap: '6px', fontSize: '12px', color: 'var(--text-muted)' }}>
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: '5px' }}>
+              <BellRing size={12} /> Alert schedule
+            </span>
+            <input
+              value={alertCron}
+              onChange={(e) => setAlertCron(e.target.value)}
+              disabled={!createAlertOnSave}
+              style={{ ...inputStyle, fontSize: '12px', opacity: createAlertOnSave ? 1 : 0.55 }}
+            />
+          </label>
+
+          <label style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '12px', color: 'var(--text-secondary)', alignSelf: 'end', minHeight: '34px' }}>
+            <input
+              type="checkbox"
+              checked={createAlertOnSave}
+              onChange={(e) => setCreateAlertOnSave(e.target.checked)}
+            />
+            Create alert when saved
+          </label>
         </div>
 
         {/* Filter Toggle */}
@@ -584,7 +649,46 @@ export default function AdvancedSearch() {
             </button>
           </div>
 
+          {searchAnalytics && (
+            <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '12px' }}>
+              <AnalyticsChip label="Searches" value={searchAnalytics.totalSearches} />
+              <AnalyticsChip label="Cache hits" value={searchAnalytics.cachedSearches} />
+              <AnalyticsChip label="Saved" value={searchAnalytics.savedSearches} />
+              <AnalyticsChip label="Alerts" value={searchAnalytics.alerts} />
+            </div>
+          )}
+
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '16px' }}>
+            {/* Folders */}
+            <div>
+              <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '8px' }}>Folders</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                {savedFolders.map((folder) => (
+                  <button
+                    key={folder.id}
+                    onClick={() => {
+                      setSavedSearchFolder(folder.name);
+                      setSavedSearches(advancedSearchService.getSavedSearches({ folder: folder.name }));
+                    }}
+                    style={{
+                      padding: '8px 12px',
+                      background: savedSearchFolder === folder.name ? 'var(--cyan-glow)' : 'var(--bg-elevated)',
+                      border: `1px solid ${savedSearchFolder === folder.name ? 'var(--cyan-dim)' : 'var(--border)'}`,
+                      borderRadius: 'var(--radius-md)',
+                      cursor: 'pointer',
+                      fontSize: '12px',
+                      color: 'var(--text-primary)',
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <span>{folder.name}</span>
+                    <span style={{ color: 'var(--text-muted)' }}>{folder.count}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
             {/* Recent Searches */}
             <div>
               <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '8px' }}>Recent Searches</div>
@@ -607,7 +711,7 @@ export default function AdvancedSearch() {
                   >
                     <div style={{ fontWeight: 500 }}>{item.query.text || 'Empty search'}</div>
                     <div style={{ color: 'var(--text-muted)', fontSize: '11px' }}>
-                      {format(new Date(item.timestamp), 'MMM dd, HH:mm')}
+                      {format(new Date(item.timestamp), 'MMM dd, HH:mm')} / {item.resultCount || 0} results / {item.cached ? 'cached' : `${item.searchTime || 0}ms`}
                     </div>
                   </div>
                 ))}
@@ -631,12 +735,33 @@ export default function AdvancedSearch() {
                       fontSize: '12px',
                     }}
                   >
-                    <div style={{ fontWeight: 500 }}>{item.name}</div>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '8px' }}>
+                      <div style={{ fontWeight: 500 }}>{item.name}</div>
+                      <button onClick={(event) => shareSavedSearch(event, item)} style={{ ...iconButtonStyle, width: '26px', height: '26px' }} title="Share query">
+                        <Share2 size={12} />
+                      </button>
+                    </div>
                     <div style={{ color: 'var(--text-muted)', fontSize: '11px' }}>
-                      {item.query.text || 'No query'} • {format(new Date(item.createdAt), 'MMM dd')}
+                      {item.folder || 'General'} / {item.query.text || 'No query'} / used {item.usageCount || 0}x
                     </div>
                   </div>
                 ))}
+                {shareToken && (
+                  <div style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '8px',
+                    padding: '8px 12px',
+                    background: 'var(--bg-elevated)',
+                    border: '1px solid var(--border)',
+                    borderRadius: 'var(--radius-md)',
+                    fontSize: '11px',
+                    color: 'var(--text-muted)',
+                  }}>
+                    <Copy size={12} />
+                    <span style={{ overflowWrap: 'anywhere' }}>{shareToken}</span>
+                  </div>
+                )}
               </div>
             </div>
           </div>
@@ -660,8 +785,13 @@ export default function AdvancedSearch() {
                 {searchResults.total} results found
               </div>
               <div style={{ fontSize: '12px', color: 'var(--text-muted)' }}>
-                Search completed in {searchResults.searchTime}ms
+                Search completed in {searchResults.searchTime}ms{searchResults.cached ? ' from cache' : ''}
               </div>
+              {searchResults.queryPlan && (
+                <div style={{ fontSize: '11px', color: 'var(--text-muted)', marginTop: '4px' }}>
+                  {searchResults.queryPlan.usesIndex ? 'Index-assisted' : 'Scan'} / {searchResults.queryPlan.filterCount} filters / cache TTL {Math.round(searchResults.queryPlan.cacheTtlMs / 1000)}s
+                </div>
+              )}
             </div>
             
             <div style={{ display: 'flex', gap: '8px' }}>

--- a/src/lib/__tests__/advancedSearchSavedQueries.test.js
+++ b/src/lib/__tests__/advancedSearchSavedQueries.test.js
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { AdvancedSearchService } from "../advancedSearch.js";
+
+function createStorage() {
+  const values = new Map();
+  return {
+    getItem: (key) => values.get(key) || null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+function createService() {
+  const service = new AdvancedSearchService({ storage: createStorage(), cacheTtlMs: 1000 });
+  service.indexData("transactions", [
+    {
+      id: "tx-1",
+      hash: "hash-payment",
+      type: "payment",
+      created_at: "2026-06-24T10:00:00Z",
+      amount: "25",
+      asset_type: "native",
+      source_account: "GABC",
+      successful: true,
+      memo: "rent payment",
+      network: "testnet",
+    },
+    {
+      id: "tx-2",
+      hash: "hash-failed",
+      type: "set_options",
+      created_at: "2026-06-24T11:00:00Z",
+      amount: "5",
+      asset_code: "USDC",
+      source_account: "GDEF",
+      successful: false,
+      memo: "failed threshold update",
+      network: "mainnet",
+    },
+  ]);
+  return service;
+}
+
+describe("advanced search saved queries", () => {
+  it("saves searches into folders and tracks usage", () => {
+    const service = createService();
+    const saved = service.saveSearch(
+      "Payments over 10 XLM",
+      { text: "payment", types: ["transactions"], filters: { amountRange: { min: 10 } } },
+      { folder: "Payments", tags: ["finance"] },
+    );
+
+    expect(service.getSavedSearchFolders()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "Payments", count: 1 })]),
+    );
+    expect(service.getSavedSearches({ folder: "Payments" })).toHaveLength(1);
+    expect(service.loadSavedSearch(saved.id).usageCount).toBe(1);
+  });
+
+  it("shares and imports saved searches", () => {
+    const service = createService();
+    const saved = service.saveSearch("Failed updates", { text: "failed", types: ["transactions"] }, { folder: "Ops" });
+    const token = service.shareSearch(saved.id, { users: ["ops@example.com"] });
+    const imported = service.importSharedSearch(token, { folder: "Shared" });
+
+    expect(token).toEqual(expect.any(String));
+    expect(service.getSavedSearches({ folder: "Shared" })).toContainEqual(expect.objectContaining({ id: imported.id }));
+    expect(service.getSavedSearches({ folder: "Ops" })[0].sharedWith).toContain("ops@example.com");
+  });
+
+  it("caches repeated searches and records analytics", () => {
+    const service = createService();
+    const first = service.search({ text: "payment", types: ["transactions"], page: 1, limit: 20 });
+    const second = service.search({ text: "payment", types: ["transactions"], page: 1, limit: 20 });
+    const analytics = service.getSearchAnalytics();
+
+    expect(first.cached).toBe(false);
+    expect(second.cached).toBe(true);
+    expect(second.total).toBe(1);
+    expect(second.queryPlan.usesIndex).toBe(true);
+    expect(analytics.totalSearches).toBe(2);
+    expect(analytics.cachedSearches).toBe(1);
+    expect(analytics.cacheEntries).toBe(1);
+  });
+
+  it("expires cached search results", () => {
+    vi.useFakeTimers();
+    const service = createService();
+
+    service.search({ text: "payment", types: ["transactions"] });
+    vi.advanceTimersByTime(1001);
+    const result = service.search({ text: "payment", types: ["transactions"] });
+
+    expect(result.cached).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it("creates and evaluates scheduled search alerts", () => {
+    const service = createService();
+    const saved = service.saveSearch("Payment alert", { text: "payment", types: ["transactions"] }, { folder: "Alerts" });
+    const alert = service.createSearchAlert({
+      savedSearchId: saved.id,
+      name: "Payment alert",
+      cron: "0 * * * *",
+      threshold: 1,
+    });
+    service.searchAlerts[0].nextRunAt = "2026-06-24T00:00:00.000Z";
+
+    const evaluations = service.evaluateSearchAlerts(new Date("2026-06-24T01:00:00.000Z"));
+
+    expect(alert.enabled).toBe(true);
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0].triggered).toBe(true);
+    expect(service.getSearchAlerts()[0].lastRunAt).toBe("2026-06-24T01:00:00.000Z");
+  });
+});

--- a/src/lib/advancedSearch.js
+++ b/src/lib/advancedSearch.js
@@ -3,10 +3,74 @@
  * Global search functionality across transactions, operations, and contracts
  */
 
+const STORAGE_KEYS = {
+  history: 'stellar-advanced-search-history-v1',
+  saved: 'stellar-advanced-search-saved-v1',
+  alerts: 'stellar-advanced-search-alerts-v1',
+  folders: 'stellar-advanced-search-folders-v1',
+};
+
+function getBrowserStorage() {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+function readStoredArray(storage, key, fallback = []) {
+  if (!storage) return [...fallback];
+  try {
+    const parsed = JSON.parse(storage.getItem(key) || 'null');
+    return Array.isArray(parsed) ? parsed : [...fallback];
+  } catch {
+    return [...fallback];
+  }
+}
+
+function writeStoredArray(storage, key, value) {
+  if (!storage) return;
+  try {
+    storage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Persistence is best-effort because private browsing can reject writes.
+  }
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function makeId(prefix) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function encodeSharePayload(payload) {
+  const serialized = encodeURIComponent(JSON.stringify(payload));
+  if (typeof btoa === 'function') return btoa(serialized);
+  return serialized;
+}
+
+function decodeSharePayload(token) {
+  const serialized = typeof atob === 'function' ? atob(token) : token;
+  return JSON.parse(decodeURIComponent(serialized));
+}
+
 class AdvancedSearchService {
-  constructor() {
-    this.searchHistory = [];
-    this.savedSearches = [];
+  constructor(options = {}) {
+    this.storage = options.storage || getBrowserStorage();
+    this.searchHistory = readStoredArray(this.storage, STORAGE_KEYS.history);
+    this.savedSearches = readStoredArray(this.storage, STORAGE_KEYS.saved);
+    this.searchAlerts = readStoredArray(this.storage, STORAGE_KEYS.alerts);
+    this.savedQueryFolders = readStoredArray(this.storage, STORAGE_KEYS.folders, [{ id: 'general', name: 'General', createdAt: new Date().toISOString() }]);
+    this.resultCache = new Map();
+    this.cacheTtlMs = options.cacheTtlMs || 60 * 1000;
     this.indexedData = new Map();
     this.searchIndex = new Map();
     this.filters = {
@@ -287,27 +351,48 @@ class AdvancedSearchService {
     const startTime = Date.now();
     
     try {
+      const optimizedQuery = this.optimizeQuery(query);
+
       // Update filters if provided
-      if (query.filters) {
-        this.filters = { ...this.filters, ...query.filters };
+      if (optimizedQuery.filters) {
+        this.filters = { ...this.filters, ...optimizedQuery.filters };
       }
 
       // Update sort options if provided
-      if (query.sort) {
-        this.sortOptions = { ...this.sortOptions, ...query.sort };
+      if (optimizedQuery.sort) {
+        this.sortOptions = { ...this.sortOptions, ...optimizedQuery.sort };
+      }
+
+      const queryPlan = this.buildQueryPlan(optimizedQuery);
+      const cacheKey = this.createQueryKey({ ...optimizedQuery, filters: this.filters, sort: this.sortOptions });
+      const cached = optimizedQuery.cache !== false ? this.getCachedResults(cacheKey) : null;
+      if (cached) {
+        const cachedResult = {
+          ...cached,
+          query: optimizedQuery,
+          cached: true,
+          searchTime: Date.now() - startTime,
+          queryPlan,
+        };
+        this.addToSearchHistory(optimizedQuery, {
+          resultCount: cached.total,
+          searchTime: cachedResult.searchTime,
+          cached: true,
+        });
+        return cachedResult;
       }
 
       // Get all indexed data
       let results = [];
       this.indexedData.forEach((items, type) => {
-        if (!query.types || query.types.includes(type)) {
+        if (!optimizedQuery.types || optimizedQuery.types.includes(type)) {
           results.push(...items);
         }
       });
 
       // Apply text search
-      if (query.text && query.text.trim()) {
-        results = this.applyTextSearch(results, query.text.trim());
+      if (optimizedQuery.text && optimizedQuery.text.trim()) {
+        results = this.applyTextSearch(results, optimizedQuery.text.trim());
       }
 
       // Apply filters
@@ -317,24 +402,33 @@ class AdvancedSearchService {
       results = this.applySorting(results);
 
       // Apply pagination
-      const paginatedResults = this.applyPagination(results, query.page, query.limit);
-
-      // Add to search history
-      this.addToSearchHistory(query);
+      const paginatedResults = this.applyPagination(results, optimizedQuery.page, optimizedQuery.limit);
 
       const searchTime = Date.now() - startTime;
 
-      return {
-        query,
+      const response = {
+        query: optimizedQuery,
         results: paginatedResults.items,
         total: paginatedResults.total,
         page: paginatedResults.page,
         limit: paginatedResults.limit,
         searchTime,
+        cached: false,
+        cacheKey,
+        queryPlan,
         filters: { ...this.filters },
         sort: { ...this.sortOptions },
         aggregations: this.calculateAggregations(results)
       };
+
+      this.setCachedResults(cacheKey, response);
+      this.addToSearchHistory(optimizedQuery, {
+        resultCount: response.total,
+        searchTime,
+        cached: false,
+      });
+
+      return response;
 
     } catch (error) {
       throw new Error(`Search failed: ${error.message}`);
@@ -555,15 +649,109 @@ class AdvancedSearchService {
   }
 
   /**
+   * Normalize query fields before execution.
+   * @param {object} query - Search query
+   * @returns {object} Optimized query
+   */
+  optimizeQuery(query = {}) {
+    const text = (query.text || '').trim();
+    const types = Array.isArray(query.types) && query.types.length
+      ? Array.from(new Set(query.types)).sort()
+      : null;
+
+    return {
+      ...query,
+      text,
+      types,
+      page: Math.max(Number(query.page) || 1, 1),
+      limit: Math.min(Math.max(Number(query.limit) || 20, 1), 100),
+    };
+  }
+
+  /**
+   * Build a stable cache key for the effective query.
+   * @param {object} query - Search query
+   * @returns {string} Cache key
+   */
+  createQueryKey(query) {
+    return stableStringify({
+      text: query.text || '',
+      types: query.types || null,
+      filters: query.filters || {},
+      sort: query.sort || {},
+      page: query.page || 1,
+      limit: query.limit || 20,
+    });
+  }
+
+  /**
+   * Store a result in the in-memory cache.
+   * @param {string} key - Cache key
+   * @param {object} result - Search response
+   */
+  setCachedResults(key, result) {
+    this.resultCache.set(key, {
+      expiresAt: Date.now() + this.cacheTtlMs,
+      result,
+    });
+  }
+
+  /**
+   * Read a result from the in-memory cache.
+   * @param {string} key - Cache key
+   * @returns {object|null} Cached response
+   */
+  getCachedResults(key) {
+    const entry = this.resultCache.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= Date.now()) {
+      this.resultCache.delete(key);
+      return null;
+    }
+    return entry.result;
+  }
+
+  clearResultCache() {
+    this.resultCache.clear();
+  }
+
+  /**
+   * Produce a lightweight plan for index/caching observability.
+   * @param {object} query - Optimized query
+   * @returns {object} Query plan summary
+   */
+  buildQueryPlan(query) {
+    const terms = (query.text || '').toLowerCase().split(/\s+/).filter(Boolean);
+    const indexedTerms = terms.filter((term) => this.searchIndex.has(term));
+    const filterCount = Object.values(query.filters || {}).filter((value) => {
+      if (value && typeof value === 'object') {
+        return Object.values(value).some((nested) => nested !== null && nested !== '');
+      }
+      return value !== null && value !== '';
+    }).length;
+
+    return {
+      textTerms: terms,
+      indexedTerms,
+      filterCount,
+      usesIndex: indexedTerms.length > 0,
+      cacheTtlMs: this.cacheTtlMs,
+      indexedTypes: query.types || Array.from(this.indexedData.keys()),
+    };
+  }
+
+  /**
    * Add search to history
    * @param {object} query - Search query
    */
-  addToSearchHistory(query) {
+  addToSearchHistory(query, meta = {}) {
     const historyEntry = {
-      id: Date.now(),
+      id: makeId('history'),
       timestamp: new Date().toISOString(),
       query: { ...query },
-      resultCount: this.searchIndex.size
+      resultCount: meta.resultCount || 0,
+      searchTime: meta.searchTime || 0,
+      cached: Boolean(meta.cached)
     };
 
     this.searchHistory.unshift(historyEntry);
@@ -572,6 +760,8 @@ class AdvancedSearchService {
     if (this.searchHistory.length > 50) {
       this.searchHistory = this.searchHistory.slice(0, 50);
     }
+
+    writeStoredArray(this.storage, STORAGE_KEYS.history, this.searchHistory);
   }
 
   /**
@@ -579,24 +769,180 @@ class AdvancedSearchService {
    * @param {string} name - Search name
    * @param {object} query - Search query
    */
-  saveSearch(name, query) {
+  saveSearch(name, query, options = {}) {
+    const folder = options.folder || 'General';
+    this.createSavedSearchFolder(folder);
     const savedSearch = {
-      id: Date.now(),
+      id: makeId('saved'),
       name,
       query: { ...query },
+      folder,
+      tags: options.tags || [],
+      description: options.description || '',
+      sharedWith: [],
+      shareToken: null,
       createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
       usageCount: 0
     };
 
     this.savedSearches.push(savedSearch);
+    writeStoredArray(this.storage, STORAGE_KEYS.saved, this.savedSearches);
+    return savedSearch;
   }
 
   /**
    * Get saved searches
    * @returns {array} Saved searches
    */
-  getSavedSearches() {
-    return this.savedSearches.sort((a, b) => b.usageCount - a.usageCount);
+  getSavedSearches(options = {}) {
+    return [...this.savedSearches]
+      .filter((search) => !options.folder || search.folder === options.folder)
+      .sort((a, b) => b.usageCount - a.usageCount || new Date(b.updatedAt || b.createdAt).getTime() - new Date(a.updatedAt || a.createdAt).getTime());
+  }
+
+  loadSavedSearch(id) {
+    const savedSearch = this.savedSearches.find((search) => search.id === id);
+    if (!savedSearch) return null;
+    savedSearch.usageCount += 1;
+    savedSearch.updatedAt = new Date().toISOString();
+    writeStoredArray(this.storage, STORAGE_KEYS.saved, this.savedSearches);
+    return savedSearch;
+  }
+
+  deleteSavedSearch(id) {
+    this.savedSearches = this.savedSearches.filter((search) => search.id !== id);
+    writeStoredArray(this.storage, STORAGE_KEYS.saved, this.savedSearches);
+  }
+
+  createSavedSearchFolder(name) {
+    const normalizedName = (name || 'General').trim() || 'General';
+    const existing = this.savedQueryFolders.find((folder) => folder.name.toLowerCase() === normalizedName.toLowerCase());
+    if (existing) return existing;
+
+    const folder = {
+      id: makeId('folder'),
+      name: normalizedName,
+      createdAt: new Date().toISOString(),
+    };
+    this.savedQueryFolders.push(folder);
+    writeStoredArray(this.storage, STORAGE_KEYS.folders, this.savedQueryFolders);
+    return folder;
+  }
+
+  getSavedSearchFolders() {
+    return this.savedQueryFolders.map((folder) => ({
+      ...folder,
+      count: this.savedSearches.filter((search) => search.folder === folder.name).length,
+    }));
+  }
+
+  shareSearch(id, options = {}) {
+    const savedSearch = this.savedSearches.find((search) => search.id === id);
+    if (!savedSearch) {
+      throw new Error('Saved search not found');
+    }
+
+    savedSearch.sharedWith = Array.from(new Set([...(savedSearch.sharedWith || []), ...(options.users || [])]));
+    savedSearch.shareToken = savedSearch.shareToken || encodeSharePayload({
+      id: savedSearch.id,
+      name: savedSearch.name,
+      query: savedSearch.query,
+      folder: savedSearch.folder,
+    });
+    savedSearch.updatedAt = new Date().toISOString();
+    writeStoredArray(this.storage, STORAGE_KEYS.saved, this.savedSearches);
+    return savedSearch.shareToken;
+  }
+
+  importSharedSearch(shareToken, options = {}) {
+    const parsed = decodeSharePayload(shareToken);
+    return this.saveSearch(options.name || parsed.name, parsed.query, {
+      folder: options.folder || parsed.folder || 'Shared',
+      tags: ['shared'],
+    });
+  }
+
+  createSearchAlert(input) {
+    const alert = {
+      id: makeId('alert'),
+      savedSearchId: input.savedSearchId || null,
+      name: input.name || 'Search alert',
+      query: input.query || this.savedSearches.find((search) => search.id === input.savedSearchId)?.query || {},
+      cron: input.cron || '0 * * * *',
+      channels: input.channels || ['in-app'],
+      threshold: Number(input.threshold || 1),
+      enabled: input.enabled !== false,
+      lastRunAt: null,
+      nextRunAt: this.getNextAlertRun(input.cron || '0 * * * *'),
+      createdAt: new Date().toISOString(),
+    };
+
+    this.searchAlerts.push(alert);
+    writeStoredArray(this.storage, STORAGE_KEYS.alerts, this.searchAlerts);
+    return alert;
+  }
+
+  getSearchAlerts() {
+    return [...this.searchAlerts].sort((a, b) => new Date(a.nextRunAt).getTime() - new Date(b.nextRunAt).getTime());
+  }
+
+  getNextAlertRun(cronExpression, from = new Date()) {
+    const [minute = '0', hour = '*'] = cronExpression.trim().split(/\s+/);
+    const next = new Date(from);
+    next.setSeconds(0, 0);
+    next.setMinutes(next.getMinutes() + 1);
+    if (minute !== '*') next.setMinutes(Number(minute.replace('*/', '')) || 0);
+    if (hour !== '*') next.setHours(Number(hour.replace('*/', '')) || next.getHours());
+    if (next.getTime() <= from.getTime()) next.setHours(next.getHours() + 1);
+    return next.toISOString();
+  }
+
+  evaluateSearchAlerts(now = new Date()) {
+    return this.searchAlerts
+      .filter((alert) => alert.enabled && new Date(alert.nextRunAt).getTime() <= now.getTime())
+      .map((alert) => {
+        const result = this.search({ ...alert.query, cache: false });
+        alert.lastRunAt = now.toISOString();
+        alert.nextRunAt = this.getNextAlertRun(alert.cron, now);
+        writeStoredArray(this.storage, STORAGE_KEYS.alerts, this.searchAlerts);
+        return {
+          alert,
+          resultCount: result.total,
+          triggered: result.total >= alert.threshold,
+        };
+      });
+  }
+
+  getSearchHistory() {
+    return [...this.searchHistory];
+  }
+
+  getFrequentSearches(limit = 5) {
+    const counts = new Map();
+    this.searchHistory.forEach((entry) => {
+      const key = entry.query?.text || JSON.stringify(entry.query?.filters || {});
+      counts.set(key, (counts.get(key) || 0) + 1);
+    });
+    return Array.from(counts.entries())
+      .map(([query, count]) => ({ query, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, limit);
+  }
+
+  getSearchAnalytics() {
+    const history = this.getSearchHistory();
+    const totalSearchTime = history.reduce((sum, entry) => sum + (entry.searchTime || 0), 0);
+    return {
+      totalSearches: history.length,
+      cachedSearches: history.filter((entry) => entry.cached).length,
+      averageSearchTime: history.length ? totalSearchTime / history.length : 0,
+      savedSearches: this.savedSearches.length,
+      folders: this.savedQueryFolders.length,
+      alerts: this.searchAlerts.length,
+      frequentSearches: this.getFrequentSearches(),
+      cacheEntries: this.resultCache.size,
+    };
   }
 
   /**


### PR DESCRIPTION
Closes #446.

## Summary
- add folder-aware saved searches, usage tracking, share/import tokens, and persisted search history
- add scheduled search alerts, alert evaluation, frequent-search analytics, query plans, and result caching
- expose save-folder, alert schedule, folder filtering, sharing, analytics, cache, and query-plan state in the Advanced Search UI
- cover saved queries, folders, sharing, cache expiry, analytics, and alert evaluation with focused tests

## Verification
- `git diff --check`
- `npx --yes -p vitest@3.2.4 vitest run src/lib/__tests__/advancedSearchSavedQueries.test.js --config /tmp/vitest.locale.config.mjs`
- `npx --yes -p esbuild@0.24.2 esbuild src/lib/advancedSearch.js --bundle --platform=browser --format=esm --outfile=/tmp/advancedSearch.bundle.js`
- `npx --yes -p esbuild@0.24.2 esbuild src/components/dashboard/AdvancedSearch.tsx --bundle --platform=browser --format=esm --external:react --external:react/jsx-runtime --external:lucide-react --external:date-fns --external:../../lib/auditTrail.js --outfile=/tmp/advancedSearchComponent.bundle.js`

Note: full `npm ci`/repo test execution remains blocked by existing package metadata: TypeScript 6 conflicts with react-i18next optional peer requirements, and `@tensorflow/tfjs-node@^5.0.0` has no matching published version.