### PR TITLE
Add advanced preference presets and sync helpers

### DIFF
--- a/src/components/preferences/UserPreferences.jsx
+++ b/src/components/preferences/UserPreferences.jsx
@@ -5,25 +5,84 @@ import ThemeSettings from './ThemeSettings'
 import AccessibilitySettings from './AccessibilitySettings'
 import NotificationPreferences from '../notifications/NotificationPreferences'
 import { showTestNotification } from '../../utils/offline'
-import { Bell } from 'lucide-react'
+import {
+  Bell,
+  Download,
+  RefreshCw,
+  Share2,
+  SlidersHorizontal,
+  Upload,
+} from 'lucide-react'
+import {
+  applyPreferencePreset,
+  createPreferencePreset,
+  exportPreferences,
+  getPreferenceSyncStatus,
+  importPreferences,
+  PREFERENCE_PRESETS,
+  sharePreferencePreset,
+  validatePreferences,
+} from '../../lib/userPreferences'
 
 const TABS = [
   { id: 'general', label: 'General' },
   { id: 'theme', label: 'Theme & Display' },
+  { id: 'presets', label: 'Presets & Sync' },
   { id: 'addresses', label: 'Address Book' },
   { id: 'accessibility', label: 'Accessibility' },
   { id: 'notifications', label: 'Notifications' },
 ]
 
 export default function UserPreferences({ onClose }) {
-  const { preferences, update, reset, loading } = usePreferences()
+  const { preferences, update, save, reset, loading } = usePreferences()
   const [activeTab, setActiveTab] = useState('general')
   const [saved, setSaved] = useState(false)
+  const [shareToken, setShareToken] = useState('')
+  const validation = validatePreferences(preferences)
+  const syncStatus = getPreferenceSyncStatus(preferences)
 
   const handleChange = async (key, value) => {
     await update(key, value)
     setSaved(true)
     setTimeout(() => setSaved(false), 1500)
+  }
+
+  const handleSavePreferences = async (nextPreferences) => {
+    await save(nextPreferences)
+    setSaved(true)
+    setTimeout(() => setSaved(false), 1500)
+  }
+
+  const handlePreset = async (presetId) => {
+    await handleSavePreferences(applyPreferencePreset(presetId, preferences))
+  }
+
+  const downloadText = (filename, content, type) => {
+    const blob = new Blob([content], { type })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const handleExport = () => {
+    downloadText('stellar-preferences.json', exportPreferences(preferences), 'application/json')
+  }
+
+  const handleImport = async () => {
+    const payload = prompt('Paste exported preferences JSON')
+    if (!payload) return
+    await handleSavePreferences(importPreferences(payload))
+  }
+
+  const handleSharePreset = () => {
+    const preset = createPreferencePreset('Shared preferences', preferences, {
+      description: 'Shared dashboard preference preset',
+      shared: true,
+    })
+    setShareToken(sharePreferencePreset(preset))
   }
 
   if (loading) {
@@ -70,7 +129,7 @@ export default function UserPreferences({ onClose }) {
       </div>
 
       {/* Tabs */}
-      <div style={{ padding: '10px 18px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '6px' }}>
+      <div style={{ padding: '10px 18px', borderBottom: '1px solid var(--border)', display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
         {TABS.map((tab) => (
           <button
             key={tab.id}
@@ -197,6 +256,75 @@ export default function UserPreferences({ onClose }) {
         {activeTab === 'theme' && (
           <ThemeSettings preferences={preferences} onChange={handleChange} />
         )}
+
+        {activeTab === 'presets' && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '10px' }}>
+              {PREFERENCE_PRESETS.map((preset) => (
+                <button
+                  key={preset.id}
+                  onClick={() => handlePreset(preset.id)}
+                  style={{
+                    ...presetButtonStyle,
+                    textAlign: 'left',
+                  }}
+                >
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '8px', fontWeight: 700 }}>
+                    <SlidersHorizontal size={14} />
+                    {preset.name}
+                  </span>
+                  <span style={{ color: 'var(--text-muted)', fontSize: '11px', lineHeight: 1.35 }}>
+                    {preset.description}
+                  </span>
+                </button>
+              ))}
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(130px, 1fr))', gap: '8px' }}>
+              <StatusChip label="Schema" value={`v${preferences.schemaVersion}`} />
+              <StatusChip label="Options" value={validation.preferenceCount} />
+              <StatusChip label="Validation" value={validation.valid ? 'Valid' : `${validation.errors.length} errors`} />
+              <StatusChip label="Sync" value={syncStatus.state} />
+            </div>
+
+            <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+              <button onClick={handleExport} style={actionButtonStyle}>
+                <Download size={14} />
+                Export JSON
+              </button>
+              <button onClick={handleImport} style={actionButtonStyle}>
+                <Upload size={14} />
+                Import JSON
+              </button>
+              <button onClick={handleSharePreset} style={actionButtonStyle}>
+                <Share2 size={14} />
+                Share Preset
+              </button>
+              <button
+                onClick={() => handleChange('sync', { ...preferences.sync, pendingChanges: 0, lastSyncedAt: new Date().toISOString() })}
+                style={actionButtonStyle}
+              >
+                <RefreshCw size={14} />
+                Mark Synced
+              </button>
+            </div>
+
+            {shareToken && (
+              <div style={{
+                padding: '10px',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-md)',
+                background: 'var(--bg-elevated)',
+                color: 'var(--text-muted)',
+                fontSize: '11px',
+                overflowWrap: 'anywhere',
+              }}>
+                {shareToken}
+              </div>
+            )}
+          </div>
+        )}
+
         {activeTab === 'accessibility' && (
           <AccessibilitySettings />
         )}
@@ -266,4 +394,44 @@ const selectStyle = {
   fontFamily: 'var(--font-mono)',
   cursor: 'pointer',
   outline: 'none',
+}
+
+const presetButtonStyle = {
+  padding: '10px',
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-md)',
+  color: 'var(--text-primary)',
+  cursor: 'pointer',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '7px',
+}
+
+const actionButtonStyle = {
+  padding: '8px 10px',
+  background: 'var(--bg-elevated)',
+  border: '1px solid var(--border-bright)',
+  borderRadius: 'var(--radius-md)',
+  color: 'var(--text-primary)',
+  fontSize: '12px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '7px',
+  cursor: 'pointer',
+}
+
+function StatusChip({ label, value }) {
+  return (
+    <div style={{
+      padding: '8px 10px',
+      border: '1px solid var(--border)',
+      borderRadius: 'var(--radius-md)',
+      background: 'var(--bg-elevated)',
+      fontSize: '11px',
+    }}>
+      <div style={{ color: 'var(--text-muted)', marginBottom: '4px' }}>{label}</div>
+      <div style={{ color: 'var(--text-primary)', fontWeight: 700 }}>{value}</div>
+    </div>
+  )
 }

--- a/src/lib/__tests__/userPreferencesAdvanced.test.ts
+++ b/src/lib/__tests__/userPreferencesAdvanced.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPreferencePreset,
+  createPreferencePreset,
+  CURRENT_PREFERENCE_SCHEMA_VERSION,
+  DEFAULT_PREFERENCES,
+  exportPreferences,
+  getPreferenceSyncStatus,
+  importPreferences,
+  importSharedPreferencePreset,
+  migratePreferences,
+  PREFERENCE_SCHEMA,
+  resolvePreferenceConflicts,
+  setAdvancedPreference,
+  sharePreferencePreset,
+  validatePreferences,
+} from "../userPreferences";
+
+describe("advanced user preferences", () => {
+  it("defines more than fifty granular preference options", () => {
+    expect(PREFERENCE_SCHEMA.length).toBeGreaterThan(50);
+    expect(PREFERENCE_SCHEMA.map((definition) => definition.path)).toContain("advanced.searchHistoryLimit");
+    expect(PREFERENCE_SCHEMA.map((definition) => definition.path)).toContain("advanced.syncConflictStrategy");
+  });
+
+  it("migrates older preferences into the current schema", () => {
+    const migrated = migratePreferences({
+      theme: "light",
+      advanced: {
+        dashboardColumns: 4,
+      },
+    });
+
+    expect(migrated.schemaVersion).toBe(CURRENT_PREFERENCE_SCHEMA_VERSION);
+    expect(migrated.theme).toBe("light");
+    expect(migrated.advanced.dashboardColumns).toBe(4);
+    expect(migrated.advanced.searchResultPageSize).toBe(20);
+    expect(migrated.sync.conflictStrategy).toBe("newest");
+  });
+
+  it("validates enum, numeric, and boolean preference values", () => {
+    const invalid = validatePreferences({
+      advanced: {
+        dashboardColumns: 99,
+        maxConcurrentRequests: 99,
+        reduceMotion: "no",
+      },
+    });
+
+    expect(invalid.valid).toBe(false);
+    expect(invalid.errors.join(" ")).toContain("advanced.dashboardColumns");
+    expect(invalid.errors.join(" ")).toContain("advanced.maxConcurrentRequests");
+    expect(invalid.errors.join(" ")).toContain("advanced.reduceMotion");
+  });
+
+  it("applies built-in presets without dropping unrelated preferences", () => {
+    const next = applyPreferencePreset("power-user", {
+      ...DEFAULT_PREFERENCES,
+      language: "es",
+    });
+
+    expect(next.language).toBe("es");
+    expect(next.compactMode).toBe(true);
+    expect(next.advanced.showRawXdr).toBe(true);
+    expect(next.advanced.dashboardColumns).toBe(4);
+  });
+
+  it("exports and imports preferences as versioned JSON", () => {
+    const exported = exportPreferences({
+      ...DEFAULT_PREFERENCES,
+      currency: "EUR",
+      advanced: {
+        ...DEFAULT_PREFERENCES.advanced,
+        defaultExportFormat: "csv",
+      },
+    });
+    const imported = importPreferences(exported);
+
+    expect(imported.currency).toBe("EUR");
+    expect(imported.advanced.defaultExportFormat).toBe("csv");
+    expect(validatePreferences(imported).valid).toBe(true);
+  });
+
+  it("shares and imports custom presets", () => {
+    const preset = createPreferencePreset("Desk setup", DEFAULT_PREFERENCES, { shared: true });
+    const token = sharePreferencePreset(preset);
+    const imported = importSharedPreferencePreset(token);
+
+    expect(token).toEqual(expect.any(String));
+    expect(imported.name).toBe("Desk setup");
+    expect(imported.shared).toBe(true);
+  });
+
+  it("resolves sync conflicts and reports sync status", () => {
+    const local = migratePreferences({
+      ...DEFAULT_PREFERENCES,
+      theme: "dark",
+      sync: {
+        ...DEFAULT_PREFERENCES.sync,
+        lastSyncedAt: "2026-06-24T10:00:00.000Z",
+        pendingChanges: 1,
+      },
+    });
+    const remote = migratePreferences({
+      ...DEFAULT_PREFERENCES,
+      theme: "light",
+      sync: {
+        ...DEFAULT_PREFERENCES.sync,
+        lastSyncedAt: "2026-06-24T11:00:00.000Z",
+      },
+    });
+
+    const resolved = resolvePreferenceConflicts(local, remote, "newest");
+    const status = getPreferenceSyncStatus(local);
+
+    expect(resolved.preferences.theme).toBe("light");
+    expect(resolved.conflicts).toContain("theme");
+    expect(status.state).toBe("pending");
+  });
+
+  it("sets individual advanced preferences through schema paths", () => {
+    const next = setAdvancedPreference(DEFAULT_PREFERENCES, "searchResultPageSize", 50);
+
+    expect(next.advanced.searchResultPageSize).toBe(50);
+  });
+});

--- a/src/lib/userPreferences.ts
+++ b/src/lib/userPreferences.ts
@@ -35,7 +35,55 @@ export interface NetworkProfile {
   updatedAt: string
 }
 
+export type PreferenceValue = string | number | boolean | string[] | number[] | Record<string, unknown> | null
+export type PreferenceType = 'boolean' | 'string' | 'number' | 'select' | 'multiselect' | 'object'
+export type PreferenceCategory =
+  | 'general'
+  | 'display'
+  | 'dashboard'
+  | 'data'
+  | 'search'
+  | 'notifications'
+  | 'privacy'
+  | 'accessibility'
+  | 'performance'
+  | 'developer'
+  | 'sync'
+
+export interface PreferenceDefinition {
+  key: string
+  path: string
+  category: PreferenceCategory
+  label: string
+  type: PreferenceType
+  defaultValue: PreferenceValue
+  options?: PreferenceValue[]
+  min?: number
+  max?: number
+  required?: boolean
+}
+
+export interface PreferencePreset {
+  id: string
+  name: string
+  description: string
+  values: Partial<UserPreferences>
+  schemaVersion: number
+  createdAt: string
+  shared?: boolean
+}
+
+export interface PreferenceSyncState {
+  enabled: boolean
+  deviceId: string
+  lastSyncedAt?: string
+  remoteVersion?: number
+  pendingChanges: number
+  conflictStrategy: 'newest' | 'local' | 'remote'
+}
+
 export interface UserPreferences {
+  schemaVersion: number
   theme: 'light' | 'dark' | 'auto'
   defaultNetwork: 'mainnet' | 'testnet' | 'futurenet' | 'local' | 'custom'
   savedAddresses: AddressEntry[]
@@ -46,6 +94,9 @@ export interface UserPreferences {
   showAdvancedPanels: boolean
   autoRefresh: boolean
   fontSize: 'small' | 'medium' | 'large'
+  advanced: Record<string, PreferenceValue>
+  customPresets?: PreferencePreset[]
+  sync: PreferenceSyncState
   customNetworkProfiles?: NetworkProfile[]
   activeCustomProfile?: string
   transactionConfirmation: {
@@ -60,7 +111,179 @@ export interface UserPreferences {
 
 // ─── Defaults ─────────────────────────────────────────────────────────────────
 
+export const CURRENT_PREFERENCE_SCHEMA_VERSION = 3
+
+export const DEFAULT_ADVANCED_PREFERENCES: Record<string, PreferenceValue> = {
+  startTab: 'overview',
+  rememberLastTab: true,
+  confirmBeforeReset: true,
+  defaultAccountScope: 'all',
+  defaultTimeRange: '7d',
+  density: 'comfortable',
+  sidebarLabels: true,
+  animatedTransitions: true,
+  highContrastCharts: false,
+  monospaceNumbers: true,
+  showTooltips: true,
+  chartPalette: 'balanced',
+  dashboardColumns: 3,
+  showPortfolioWidget: true,
+  showNetworkWidget: true,
+  showRiskWidget: true,
+  showRecentTransactionsWidget: true,
+  pinFavoriteAccounts: true,
+  widgetAutoHeight: true,
+  collapseEmptyWidgets: true,
+  defaultExportFormat: 'json',
+  includeFailedTransactions: true,
+  includeTestnetData: true,
+  normalizeAssetCodes: true,
+  staleDataWarningMinutes: 5,
+  ledgerRefreshSeconds: 30,
+  cacheAccountLookups: true,
+  cacheTransactionLookups: true,
+  searchDefaultTypes: ['transactions', 'operations', 'accounts'],
+  searchFuzzyMatching: true,
+  searchSavedQuerySuggestions: true,
+  searchHistoryLimit: 50,
+  searchResultPageSize: 20,
+  searchHighlightMatches: true,
+  searchAutoRunSavedQueries: false,
+  notifyTransactionFailures: true,
+  notifyLargePayments: true,
+  notifyNetworkDegradation: true,
+  notifyTrustlineChanges: false,
+  quietHoursEnabled: false,
+  quietHoursStart: '22:00',
+  quietHoursEnd: '07:00',
+  redactAccountIds: false,
+  redactMemoText: false,
+  shareAnalytics: false,
+  persistSessionState: true,
+  requireConfirmationForExports: false,
+  keyboardShortcuts: true,
+  reduceMotion: false,
+  focusRing: true,
+  screenReaderLabels: true,
+  tableRowHeight: 'normal',
+  prefetchAccountData: true,
+  prefetchNetworkStats: true,
+  maxConcurrentRequests: 4,
+  offlineQueueEnabled: true,
+  backgroundSync: true,
+  developerMode: false,
+  showRawXdr: false,
+  showApiTimings: false,
+  enableExperimentalSorobanPanels: false,
+  logLevel: 'warn',
+  syncAcrossDevices: false,
+  syncConflictStrategy: 'newest',
+}
+
+export const PREFERENCE_SCHEMA: PreferenceDefinition[] = [
+  { key: 'theme', path: 'theme', category: 'display', label: 'Theme', type: 'select', defaultValue: 'dark', options: ['light', 'dark', 'auto'], required: true },
+  { key: 'defaultNetwork', path: 'defaultNetwork', category: 'general', label: 'Default Network', type: 'select', defaultValue: 'testnet', options: ['mainnet', 'testnet', 'futurenet', 'local', 'custom'], required: true },
+  { key: 'currency', path: 'currency', category: 'general', label: 'Currency', type: 'select', defaultValue: 'USD', options: ['USD', 'EUR', 'XLM'], required: true },
+  { key: 'language', path: 'language', category: 'general', label: 'Language', type: 'string', defaultValue: 'en', required: true },
+  { key: 'compactMode', path: 'compactMode', category: 'display', label: 'Compact Mode', type: 'boolean', defaultValue: false },
+  { key: 'showAdvancedPanels', path: 'showAdvancedPanels', category: 'display', label: 'Show Advanced Panels', type: 'boolean', defaultValue: true },
+  { key: 'autoRefresh', path: 'autoRefresh', category: 'data', label: 'Auto Refresh', type: 'boolean', defaultValue: true },
+  { key: 'fontSize', path: 'fontSize', category: 'accessibility', label: 'Font Size', type: 'select', defaultValue: 'medium', options: ['small', 'medium', 'large'] },
+  ...Object.entries(DEFAULT_ADVANCED_PREFERENCES).map(([key, defaultValue]) => {
+    const categoryByKey: Record<string, PreferenceCategory> = {
+      startTab: 'general',
+      rememberLastTab: 'general',
+      confirmBeforeReset: 'general',
+      defaultAccountScope: 'general',
+      defaultTimeRange: 'general',
+      density: 'display',
+      sidebarLabels: 'display',
+      animatedTransitions: 'display',
+      highContrastCharts: 'display',
+      monospaceNumbers: 'display',
+      showTooltips: 'display',
+      chartPalette: 'display',
+      dashboardColumns: 'dashboard',
+      showPortfolioWidget: 'dashboard',
+      showNetworkWidget: 'dashboard',
+      showRiskWidget: 'dashboard',
+      showRecentTransactionsWidget: 'dashboard',
+      pinFavoriteAccounts: 'dashboard',
+      widgetAutoHeight: 'dashboard',
+      collapseEmptyWidgets: 'dashboard',
+      defaultExportFormat: 'data',
+      includeFailedTransactions: 'data',
+      includeTestnetData: 'data',
+      normalizeAssetCodes: 'data',
+      staleDataWarningMinutes: 'data',
+      ledgerRefreshSeconds: 'data',
+      cacheAccountLookups: 'data',
+      cacheTransactionLookups: 'data',
+      searchDefaultTypes: 'search',
+      searchFuzzyMatching: 'search',
+      searchSavedQuerySuggestions: 'search',
+      searchHistoryLimit: 'search',
+      searchResultPageSize: 'search',
+      searchHighlightMatches: 'search',
+      searchAutoRunSavedQueries: 'search',
+      notifyTransactionFailures: 'notifications',
+      notifyLargePayments: 'notifications',
+      notifyNetworkDegradation: 'notifications',
+      notifyTrustlineChanges: 'notifications',
+      quietHoursEnabled: 'notifications',
+      quietHoursStart: 'notifications',
+      quietHoursEnd: 'notifications',
+      redactAccountIds: 'privacy',
+      redactMemoText: 'privacy',
+      shareAnalytics: 'privacy',
+      persistSessionState: 'privacy',
+      requireConfirmationForExports: 'privacy',
+      keyboardShortcuts: 'accessibility',
+      reduceMotion: 'accessibility',
+      focusRing: 'accessibility',
+      screenReaderLabels: 'accessibility',
+      tableRowHeight: 'accessibility',
+      prefetchAccountData: 'performance',
+      prefetchNetworkStats: 'performance',
+      maxConcurrentRequests: 'performance',
+      offlineQueueEnabled: 'performance',
+      backgroundSync: 'performance',
+      developerMode: 'developer',
+      showRawXdr: 'developer',
+      showApiTimings: 'developer',
+      enableExperimentalSorobanPanels: 'developer',
+      logLevel: 'developer',
+      syncAcrossDevices: 'sync',
+      syncConflictStrategy: 'sync',
+    }
+    const optionsByKey: Record<string, PreferenceValue[]> = {
+      startTab: ['overview', 'analytics', 'search', 'settings'],
+      defaultAccountScope: ['all', 'favorites', 'active'],
+      defaultTimeRange: ['24h', '7d', '30d', '90d'],
+      density: ['compact', 'comfortable', 'spacious'],
+      chartPalette: ['balanced', 'contrast', 'colorblind'],
+      dashboardColumns: [1, 2, 3, 4],
+      defaultExportFormat: ['json', 'csv', 'xlsx'],
+      tableRowHeight: ['compact', 'normal', 'large'],
+      logLevel: ['error', 'warn', 'info', 'debug'],
+      syncConflictStrategy: ['newest', 'local', 'remote'],
+    }
+    return {
+      key,
+      path: `advanced.${key}`,
+      category: categoryByKey[key] || 'general',
+      label: key.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase()),
+      type: Array.isArray(defaultValue) ? 'multiselect' : typeof defaultValue === 'boolean' ? 'boolean' : typeof defaultValue === 'number' ? 'number' : optionsByKey[key] ? 'select' : 'string',
+      defaultValue,
+      options: optionsByKey[key],
+      min: key === 'maxConcurrentRequests' ? 1 : undefined,
+      max: key === 'maxConcurrentRequests' ? 12 : undefined,
+    } as PreferenceDefinition
+  }),
+]
+
 export const DEFAULT_PREFERENCES: UserPreferences = {
+  schemaVersion: CURRENT_PREFERENCE_SCHEMA_VERSION,
   theme: 'dark',
   defaultNetwork: 'testnet',
   savedAddresses: [],
@@ -71,6 +294,14 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   showAdvancedPanels: true,
   autoRefresh: true,
   fontSize: 'medium',
+  advanced: { ...DEFAULT_ADVANCED_PREFERENCES },
+  customPresets: [],
+  sync: {
+    enabled: false,
+    deviceId: 'local',
+    pendingChanges: 0,
+    conflictStrategy: 'newest',
+  },
   customNetworkProfiles: [],
   activeCustomProfile: undefined,
   transactionConfirmation: {
@@ -85,20 +316,75 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
 const PREFS_KEY = 'user-preferences-v2'
 const NETWORK_PROFILES_KEY = 'network-profiles-v1'
 
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value))
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function deepMerge<T>(base: T, override: Partial<T> | Record<string, unknown> | null | undefined): T {
+  if (!isPlainObject(base) || !isPlainObject(override)) {
+    return (override === undefined || override === null ? clone(base) : override) as T
+  }
+
+  const result = clone(base) as Record<string, unknown>
+  Object.entries(override).forEach(([key, value]) => {
+    if (isPlainObject(result[key]) && isPlainObject(value)) {
+      result[key] = deepMerge(result[key], value)
+    } else if (value !== undefined) {
+      result[key] = value
+    }
+  })
+  return result as T
+}
+
+function getPreferenceValue(source: Record<string, unknown>, path: string): unknown {
+  return path.split('.').reduce<unknown>((value, key) => {
+    return isPlainObject(value) ? value[key] : undefined
+  }, source)
+}
+
+function setPreferenceValue(source: Record<string, unknown>, path: string, value: unknown) {
+  const keys = path.split('.')
+  const target = keys.slice(0, -1).reduce<Record<string, unknown>>((current, key) => {
+    if (!isPlainObject(current[key])) current[key] = {}
+    return current[key] as Record<string, unknown>
+  }, source)
+  target[keys[keys.length - 1]] = value
+}
+
+function encodeSharePayload(payload: unknown) {
+  const serialized = encodeURIComponent(JSON.stringify(payload))
+  if (typeof btoa === 'function') return btoa(serialized)
+  return serialized
+}
+
+function decodeSharePayload<T>(token: string): T {
+  const serialized = typeof atob === 'function' ? atob(token) : token
+  return JSON.parse(decodeURIComponent(serialized)) as T
+}
+
 // ─── Persistence ──────────────────────────────────────────────────────────────
 
 export async function loadPreferences(): Promise<UserPreferences> {
   try {
     const stored = await getStoredValue(PREFS_KEY) as Partial<UserPreferences> | null
-    return { ...DEFAULT_PREFERENCES, ...(stored || {}) }
+    return migratePreferences(stored || {})
   } catch {
-    return { ...DEFAULT_PREFERENCES }
+    return clone(DEFAULT_PREFERENCES)
   }
 }
 
 export async function savePreferences(prefs: Partial<UserPreferences>): Promise<UserPreferences> {
   const current = await loadPreferences()
-  const next = { ...current, ...prefs }
+  const next = migratePreferences(deepMerge(current, prefs))
+  const explicitPendingChanges = isPlainObject(prefs.sync) && typeof prefs.sync.pendingChanges === 'number'
+  next.sync = {
+    ...next.sync,
+    pendingChanges: explicitPendingChanges ? prefs.sync!.pendingChanges : (current.sync?.pendingChanges || 0) + 1,
+  }
   await setStoredValue(PREFS_KEY, next)
   return next
 }
@@ -244,6 +530,293 @@ export async function setActiveProfile(profileId: string): Promise<void> {
 }
 
 export async function resetPreferences(): Promise<UserPreferences> {
-  await setStoredValue(PREFS_KEY, DEFAULT_PREFERENCES)
-  return { ...DEFAULT_PREFERENCES }
+  const defaults = clone(DEFAULT_PREFERENCES)
+  await setStoredValue(PREFS_KEY, defaults)
+  return defaults
+}
+
+// ─── Advanced preference helpers (Issue #448) ────────────────────────────────
+
+export const PREFERENCE_PRESETS: PreferencePreset[] = [
+  {
+    id: 'minimal',
+    name: 'Minimal',
+    description: 'Quiet workspace with fewer panels and lighter background activity.',
+    schemaVersion: CURRENT_PREFERENCE_SCHEMA_VERSION,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    values: {
+      compactMode: true,
+      showAdvancedPanels: false,
+      autoRefresh: false,
+      advanced: {
+        density: 'compact',
+        showPortfolioWidget: true,
+        showNetworkWidget: false,
+        showRiskWidget: false,
+        animatedTransitions: false,
+        searchSavedQuerySuggestions: false,
+        notifyNetworkDegradation: false,
+        prefetchAccountData: false,
+        prefetchNetworkStats: false,
+        backgroundSync: false,
+      },
+    },
+  },
+  {
+    id: 'power-user',
+    name: 'Power User',
+    description: 'Dense dashboard, faster data refresh, and developer-facing details.',
+    schemaVersion: CURRENT_PREFERENCE_SCHEMA_VERSION,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    values: {
+      compactMode: true,
+      showAdvancedPanels: true,
+      autoRefresh: true,
+      advanced: {
+        density: 'compact',
+        dashboardColumns: 4,
+        ledgerRefreshSeconds: 15,
+        searchHistoryLimit: 100,
+        searchResultPageSize: 50,
+        maxConcurrentRequests: 8,
+        developerMode: true,
+        showRawXdr: true,
+        showApiTimings: true,
+        logLevel: 'info',
+      },
+    },
+  },
+  {
+    id: 'analyst',
+    name: 'Analyst',
+    description: 'Report-friendly exports, longer history, and richer risk context.',
+    schemaVersion: CURRENT_PREFERENCE_SCHEMA_VERSION,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    values: {
+      defaultNetwork: 'mainnet',
+      showAdvancedPanels: true,
+      advanced: {
+        defaultTimeRange: '30d',
+        defaultExportFormat: 'csv',
+        showRiskWidget: true,
+        includeFailedTransactions: true,
+        searchHighlightMatches: true,
+        notifyLargePayments: true,
+        requireConfirmationForExports: true,
+      },
+    },
+  },
+  {
+    id: 'accessibility',
+    name: 'Accessibility',
+    description: 'Larger type, reduced motion, stronger focus treatment, and screen reader labels.',
+    schemaVersion: CURRENT_PREFERENCE_SCHEMA_VERSION,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    values: {
+      fontSize: 'large',
+      compactMode: false,
+      advanced: {
+        density: 'spacious',
+        animatedTransitions: false,
+        highContrastCharts: true,
+        reduceMotion: true,
+        focusRing: true,
+        screenReaderLabels: true,
+        tableRowHeight: 'large',
+      },
+    },
+  },
+]
+
+export function getPreferenceSchema(category?: PreferenceCategory): PreferenceDefinition[] {
+  return category ? PREFERENCE_SCHEMA.filter((definition) => definition.category === category) : PREFERENCE_SCHEMA
+}
+
+export function migratePreferences(input: Partial<UserPreferences> | Record<string, unknown> | null | undefined): UserPreferences {
+  const migrated = deepMerge(DEFAULT_PREFERENCES, input || {}) as UserPreferences
+  migrated.schemaVersion = CURRENT_PREFERENCE_SCHEMA_VERSION
+  migrated.advanced = {
+    ...DEFAULT_ADVANCED_PREFERENCES,
+    ...(isPlainObject((input as UserPreferences | null)?.advanced) ? (input as UserPreferences).advanced : {}),
+  }
+  migrated.customPresets = Array.isArray(migrated.customPresets) ? migrated.customPresets : []
+  migrated.sync = {
+    ...DEFAULT_PREFERENCES.sync,
+    ...(isPlainObject((input as UserPreferences | null)?.sync) ? (input as UserPreferences).sync : {}),
+  }
+  return migrated
+}
+
+export function validatePreferences(preferences: Partial<UserPreferences>) {
+  const migrated = migratePreferences(preferences as Partial<UserPreferences>)
+  const errors: string[] = []
+  const warnings: string[] = []
+
+  PREFERENCE_SCHEMA.forEach((definition) => {
+    const value = getPreferenceValue(migrated as unknown as Record<string, unknown>, definition.path)
+    if (definition.required && (value === undefined || value === null || value === '')) {
+      errors.push(`${definition.path} is required`)
+    }
+    if (definition.options && value !== undefined && value !== null) {
+      const values = Array.isArray(value) ? value : [value]
+      values.forEach((entry) => {
+        if (!definition.options?.includes(entry as PreferenceValue)) {
+          errors.push(`${definition.path} has unsupported value ${String(entry)}`)
+        }
+      })
+    }
+    if (definition.type === 'number' && typeof value === 'number') {
+      if (definition.min !== undefined && value < definition.min) errors.push(`${definition.path} is below ${definition.min}`)
+      if (definition.max !== undefined && value > definition.max) errors.push(`${definition.path} is above ${definition.max}`)
+    }
+    if (definition.type === 'boolean' && typeof value !== 'boolean') {
+      errors.push(`${definition.path} must be a boolean`)
+    }
+    if (definition.type === 'number' && typeof value !== 'number') {
+      errors.push(`${definition.path} must be a number`)
+    }
+  })
+
+  if (migrated.schemaVersion !== CURRENT_PREFERENCE_SCHEMA_VERSION) {
+    warnings.push(`Preference schema will be migrated to ${CURRENT_PREFERENCE_SCHEMA_VERSION}`)
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    preferenceCount: PREFERENCE_SCHEMA.length,
+  }
+}
+
+export function applyPreferencePreset(
+  presetId: string,
+  current: UserPreferences = DEFAULT_PREFERENCES,
+  customPresets: PreferencePreset[] = current.customPresets || []
+): UserPreferences {
+  const preset = [...PREFERENCE_PRESETS, ...customPresets].find((entry) => entry.id === presetId)
+  if (!preset) throw new Error(`Unknown preference preset: ${presetId}`)
+  return migratePreferences(deepMerge(current, preset.values))
+}
+
+export function createPreferencePreset(
+  name: string,
+  preferences: UserPreferences,
+  options: { description?: string; shared?: boolean } = {}
+): PreferencePreset {
+  return {
+    id: `preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    name,
+    description: options.description || '',
+    values: migratePreferences(preferences),
+    schemaVersion: CURRENT_PREFERENCE_SCHEMA_VERSION,
+    createdAt: new Date().toISOString(),
+    shared: Boolean(options.shared),
+  }
+}
+
+export function exportPreferences(preferences: UserPreferences) {
+  const migrated = migratePreferences(preferences)
+  return JSON.stringify({
+    exportedAt: new Date().toISOString(),
+    schemaVersion: CURRENT_PREFERENCE_SCHEMA_VERSION,
+    validation: validatePreferences(migrated),
+    preferences: migrated,
+  }, null, 2)
+}
+
+export function importPreferences(payload: string | Record<string, unknown>): UserPreferences {
+  const parsed = typeof payload === 'string' ? JSON.parse(payload) : payload
+  const candidate = isPlainObject(parsed) && isPlainObject(parsed.preferences)
+    ? parsed.preferences as Partial<UserPreferences>
+    : parsed as Partial<UserPreferences>
+  const migrated = migratePreferences(candidate)
+  const validation = validatePreferences(migrated)
+  if (!validation.valid) {
+    throw new Error(`Invalid preferences: ${validation.errors.join(', ')}`)
+  }
+  return migrated
+}
+
+export async function saveImportedPreferences(payload: string | Record<string, unknown>): Promise<UserPreferences> {
+  const imported = importPreferences(payload)
+  await setStoredValue(PREFS_KEY, imported)
+  return imported
+}
+
+export function sharePreferencePreset(preset: PreferencePreset) {
+  return encodeSharePayload({
+    schemaVersion: CURRENT_PREFERENCE_SCHEMA_VERSION,
+    preset,
+  })
+}
+
+export function importSharedPreferencePreset(token: string): PreferencePreset {
+  const payload = decodeSharePayload<{ schemaVersion: number; preset: PreferencePreset }>(token)
+  if (!payload.preset || !isPreferenceVersionCompatible(payload.schemaVersion)) {
+    throw new Error('Shared preset is not compatible with this preference schema')
+  }
+  return {
+    ...payload.preset,
+    schemaVersion: CURRENT_PREFERENCE_SCHEMA_VERSION,
+    shared: true,
+  }
+}
+
+export function isPreferenceVersionCompatible(version?: number) {
+  return !version || version <= CURRENT_PREFERENCE_SCHEMA_VERSION
+}
+
+export function resolvePreferenceConflicts(
+  local: UserPreferences,
+  remote: UserPreferences,
+  strategy: PreferenceSyncState['conflictStrategy'] = local.sync?.conflictStrategy || 'newest'
+) {
+  const localTime = new Date(local.sync?.lastSyncedAt || 0).getTime()
+  const remoteTime = new Date(remote.sync?.lastSyncedAt || 0).getTime()
+  const conflicts = PREFERENCE_SCHEMA
+    .filter((definition) => {
+      const localValue = getPreferenceValue(local as unknown as Record<string, unknown>, definition.path)
+      const remoteValue = getPreferenceValue(remote as unknown as Record<string, unknown>, definition.path)
+      return JSON.stringify(localValue) !== JSON.stringify(remoteValue)
+    })
+    .map((definition) => definition.path)
+
+  const winner = strategy === 'local'
+    ? local
+    : strategy === 'remote'
+      ? remote
+      : remoteTime > localTime ? remote : local
+
+  return {
+    preferences: migratePreferences(winner),
+    strategy,
+    conflicts,
+    resolvedAt: new Date().toISOString(),
+  }
+}
+
+export function getPreferenceSyncStatus(preferences: UserPreferences, remoteVersion?: number) {
+  const validation = validatePreferences(preferences)
+  const incompatible = remoteVersion !== undefined && !isPreferenceVersionCompatible(remoteVersion)
+  return {
+    state: incompatible ? 'incompatible' : preferences.sync.pendingChanges > 0 ? 'pending' : 'synced',
+    schemaVersion: preferences.schemaVersion,
+    remoteVersion,
+    pendingChanges: preferences.sync.pendingChanges,
+    lastSyncedAt: preferences.sync.lastSyncedAt,
+    conflictStrategy: preferences.sync.conflictStrategy,
+    valid: validation.valid,
+    issueCount: validation.errors.length + validation.warnings.length,
+  }
+}
+
+export function setAdvancedPreference(
+  preferences: UserPreferences,
+  key: string,
+  value: PreferenceValue
+): UserPreferences {
+  const next = migratePreferences(preferences)
+  setPreferenceValue(next as unknown as Record<string, unknown>, `advanced.${key}`, value)
+  return migratePreferences(next)
 }


### PR DESCRIPTION
Closes #448.

## Summary
- add a versioned preference schema with 50+ granular options across display, dashboard, data, search, notifications, privacy, accessibility, performance, developer, and sync categories
- add migration, validation, import/export, shared preset tokens, preset creation/application, conflict resolution, and sync status helpers
- add built-in Minimal, Power User, Analyst, and Accessibility presets
- expose a Presets & Sync tab in the preferences modal with preset application, validation status, export/import, share preset, and mark-synced controls
- cover schema size, migration, validation, presets, import/export, sharing, sync conflicts, and advanced preference updates with focused tests

## Verification
- `git diff --check`
- `npx --yes -p vitest@3.2.4 vitest run src/lib/__tests__/userPreferencesAdvanced.test.ts --config /tmp/vitest.locale.config.mjs`
- `npx --yes -p typescript@6.0.3 tsc --ignoreConfig --noEmit --skipLibCheck --noImplicitAny false --target ES2020 --lib ES2020,DOM --module ESNext --moduleResolution bundler src/lib/userPreferences.ts`
- `npx --yes -p esbuild@0.24.2 esbuild src/components/preferences/UserPreferences.jsx --bundle --platform=browser --format=esm --external:react --external:react/jsx-runtime --external:lucide-react --external:../../hooks/usePreferences --external:./AddressBook --external:./ThemeSettings --external:./AccessibilitySettings --external:../notifications/NotificationPreferences --external:../../utils/offline --outfile=/tmp/userPreferencesAdvanced.bundle.js`

Note: full `npm ci`/repo test execution remains blocked by existing package metadata: TypeScript 6 conflicts with react-i18next optional peer requirements, and `@tensorflow/tfjs-node@^5.0.0` has no matching published version.