### PR TITLE
Add heuristic query pattern analyzer for IndexedDB layer (#619)

### DIFF
--- a/src/lib/__tests__/queryOptimizer.test.ts
+++ b/src/lib/__tests__/queryOptimizer.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the query pattern analyzer / optimization advisor
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { recordQuery, getRecommendations, getReport, reset } from '../queryOptimizer'
+
+describe('queryOptimizer', () => {
+  beforeEach(() => {
+    reset()
+  })
+
+  it('reports zero totals with no recorded queries', () => {
+    const report = getReport()
+    expect(report.totalQueries).toBe(0)
+    expect(report.distinctPatterns).toBe(0)
+    expect(report.recommendations).toEqual([])
+  })
+
+  it('recommends an index for a repeated, wasteful full-table scan', () => {
+    for (let i = 0; i < 5; i++) {
+      recordQuery({
+        store: 'widgets',
+        operation: 'full-scan',
+        filterField: 'ownerId',
+        durationMs: 20,
+        rowsScanned: 1000,
+        rowsReturned: 10,
+      })
+    }
+
+    const recs = getRecommendations()
+    const indexRec = recs.find((r) => r.type === 'add-index')
+    expect(indexRec).toBeDefined()
+    expect(indexRec?.store).toBe('widgets')
+    expect(indexRec?.field).toBe('ownerId')
+    expect(indexRec?.occurrences).toBe(5)
+    expect(indexRec?.safe).toBe(true)
+    expect(indexRec?.estimatedSpeedupPercent).toBeGreaterThan(0)
+    expect(indexRec?.estimatedSpeedupPercent).toBeLessThanOrEqual(90)
+  })
+
+  it('does not recommend an index for an efficient index lookup', () => {
+    for (let i = 0; i < 10; i++) {
+      recordQuery({
+        store: 'alert-rules',
+        operation: 'index-lookup',
+        indexUsed: 'userId',
+        durationMs: 2,
+        rowsScanned: 5,
+        rowsReturned: 5,
+      })
+    }
+
+    const recs = getRecommendations()
+    expect(recs.find((r) => r.type === 'add-index')).toBeUndefined()
+  })
+
+  it('recommends caching for a slow query repeated many times', () => {
+    for (let i = 0; i < 8; i++) {
+      recordQuery({
+        store: 'transactions',
+        operation: 'index-lookup',
+        indexUsed: 'accountId',
+        durationMs: 75,
+        rowsScanned: 200,
+        rowsReturned: 200,
+      })
+    }
+
+    const recs = getRecommendations()
+    expect(recs.find((r) => r.type === 'cache-result')).toBeDefined()
+  })
+
+  it('ignores patterns seen fewer times than the occurrence threshold', () => {
+    recordQuery({
+      store: 'widgets',
+      operation: 'full-scan',
+      filterField: 'ownerId',
+      durationMs: 500,
+      rowsScanned: 10000,
+      rowsReturned: 1,
+    })
+
+    expect(getRecommendations()).toEqual([])
+  })
+
+  it('never produces an unsafe recommendation', () => {
+    for (let i = 0; i < 6; i++) {
+      recordQuery({
+        store: 'widgets',
+        operation: 'full-scan',
+        filterField: 'status',
+        durationMs: 40,
+        rowsScanned: 500,
+        rowsReturned: 5,
+      })
+    }
+
+    const recs = getRecommendations()
+    expect(recs.length).toBeGreaterThan(0)
+    for (const rec of recs) {
+      expect(rec.safe).toBe(true)
+    }
+  })
+
+  it('tracks total and slow query counts in the report', () => {
+    recordQuery({
+      store: 'widgets',
+      operation: 'index-lookup',
+      indexUsed: 'id',
+      durationMs: 5,
+      rowsScanned: 1,
+      rowsReturned: 1,
+    })
+    recordQuery({
+      store: 'widgets',
+      operation: 'full-scan',
+      filterField: 'status',
+      durationMs: 200,
+      rowsScanned: 5000,
+      rowsReturned: 3,
+    })
+
+    const report = getReport()
+    expect(report.totalQueries).toBe(2)
+    expect(report.slowQueries).toBe(1)
+    expect(report.distinctPatterns).toBe(2)
+  })
+
+  it('resets all recorded state', () => {
+    recordQuery({
+      store: 'widgets',
+      operation: 'full-scan',
+      filterField: 'ownerId',
+      durationMs: 20,
+      rowsScanned: 100,
+      rowsReturned: 5,
+    })
+    reset()
+    expect(getReport().totalQueries).toBe(0)
+    expect(getRecommendations()).toEqual([])
+  })
+})

--- a/src/lib/alertRulesDb.ts
+++ b/src/lib/alertRulesDb.ts
@@ -4,6 +4,7 @@
  */
 
 import type { AlertRule, AlertNotification } from '../types/alerts'
+import { recordQuery } from './queryOptimizer'
 
 // Use native IndexedDB instead of idb library to avoid adding new dependencies
 type IDBPDatabase = IDBDatabase
@@ -78,13 +79,25 @@ export async function deleteRule(ruleId: string): Promise<void> {
 
 export async function getRules(userId: string): Promise<AlertRule[]> {
   const db = await initDb()
+  const startedAt = performance.now()
   return new Promise((resolve, reject) => {
     const tx = db.transaction(RULES_STORE, 'readonly')
     const store = tx.objectStore(RULES_STORE)
     const index = store.index('userId')
     const request = index.getAll(userId)
-    
-    request.onsuccess = () => resolve(request.result)
+
+    request.onsuccess = () => {
+      const result = request.result
+      recordQuery({
+        store: RULES_STORE,
+        operation: 'index-lookup',
+        indexUsed: 'userId',
+        durationMs: performance.now() - startedAt,
+        rowsScanned: result.length,
+        rowsReturned: result.length,
+      })
+      resolve(result)
+    }
     request.onerror = () => reject(request.error)
   })
 }
@@ -142,23 +155,30 @@ export async function getNotifications(
   unreadOnly = false
 ): Promise<AlertNotification[]> {
   const db = await initDb()
+  const startedAt = performance.now()
   return new Promise((resolve, reject) => {
     const tx = db.transaction(NOTIFICATIONS_STORE, 'readonly')
     const store = tx.objectStore(NOTIFICATIONS_STORE)
     const index = store.index('accountAddress')
     const request = index.getAll(userId)
-    
+
     request.onsuccess = () => {
       const notifications = request.result
       const sorted = notifications.sort((a, b) => b.triggeredAt - a.triggeredAt)
-      
-      if (unreadOnly) {
-        resolve(sorted.filter(n => !n.read))
-      } else {
-        resolve(sorted)
-      }
+      const filtered = unreadOnly ? sorted.filter(n => !n.read) : sorted
+
+      recordQuery({
+        store: NOTIFICATIONS_STORE,
+        operation: 'index-lookup',
+        indexUsed: 'accountAddress',
+        durationMs: performance.now() - startedAt,
+        rowsScanned: notifications.length,
+        rowsReturned: filtered.length,
+      })
+
+      resolve(filtered)
     }
-    
+
     request.onerror = () => reject(request.error)
   })
 }

--- a/src/lib/queryOptimizer.ts
+++ b/src/lib/queryOptimizer.ts
@@ -1,0 +1,228 @@
+/**
+ * Query Pattern Analyzer & Optimization Advisor
+ *
+ * Watches how the app's IndexedDB-backed stores (see alertRulesDb.ts) are
+ * queried and surfaces heuristic, rule-based recommendations: missing
+ * indexes, repeated full-table scans, and hot queries worth caching.
+ *
+ * This is deliberately NOT a machine-learning system. There is no SQL
+ * database anywhere in this codebase (the "database layer" is IndexedDB in
+ * the browser), and training/serving an ML model needs production query
+ * telemetry this project doesn't collect. A rule-based advisor over
+ * observed scan-vs-return ratios and query frequency is the honest,
+ * verifiable thing to ship; it also satisfies the "safe" requirement below
+ * by construction (see `safe` on every recommendation).
+ *
+ * Usage:
+ *   queryOptimizer.recordQuery({ store: 'alert-rules', operation: 'index-lookup', ... })
+ *   const report = queryOptimizer.getReport()
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type QueryOperation = 'index-lookup' | 'full-scan' | 'get-by-key'
+
+export interface QueryEvent {
+  store: string
+  operation: QueryOperation
+  /** Index used for the lookup, if any (undefined implies a full-scan). */
+  indexUsed?: string
+  /** Field the query filtered on, when known (used for full-scan advice). */
+  filterField?: string
+  durationMs: number
+  /** Records examined to produce the result (== rowsReturned for an index lookup). */
+  rowsScanned: number
+  rowsReturned: number
+  timestamp?: number
+}
+
+export type RecommendationType = 'add-index' | 'cache-result' | 'avoid-full-scan'
+
+export interface OptimizationRecommendation {
+  id: string
+  type: RecommendationType
+  store: string
+  field?: string
+  reason: string
+  occurrences: number
+  avgDurationMs: number
+  avgScanRatio: number
+  estimatedImpact: 'high' | 'medium' | 'low'
+  /** Heuristic estimate only — derived from observed scan ratio, not measured before/after. */
+  estimatedSpeedupPercent: number
+  /** Always true: every recommendation here is additive (add an index / cache a read) and never rewrites or deletes existing data or schema. */
+  safe: true
+}
+
+export interface QueryPatternReport {
+  totalQueries: number
+  slowQueries: number
+  distinctPatterns: number
+  recommendations: OptimizationRecommendation[]
+  generatedAt: number
+}
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const SLOW_QUERY_MS = 50
+const MIN_OCCURRENCES = 3
+const FULL_SCAN_RATIO_THRESHOLD = 3
+const MAX_EVENTS = 500
+
+interface PatternStats {
+  store: string
+  operation: QueryOperation
+  field?: string
+  count: number
+  totalDurationMs: number
+  totalScanned: number
+  totalReturned: number
+  lastSeen: number
+}
+
+// ─── State ────────────────────────────────────────────────────────────────────
+
+const patterns = new Map<string, PatternStats>()
+const recentEvents: QueryEvent[] = []
+
+function patternKey(store: string, operation: QueryOperation, field?: string): string {
+  return `${store}::${operation}::${field ?? '*'}`
+}
+
+// ─── Recording ────────────────────────────────────────────────────────────────
+
+export function recordQuery(event: QueryEvent): void {
+  const timestamp = event.timestamp ?? Date.now()
+  const field = event.filterField ?? event.indexUsed
+
+  recentEvents.push({ ...event, timestamp })
+  if (recentEvents.length > MAX_EVENTS) {
+    recentEvents.shift()
+  }
+
+  const key = patternKey(event.store, event.operation, field)
+  const existing = patterns.get(key)
+  if (existing) {
+    existing.count += 1
+    existing.totalDurationMs += event.durationMs
+    existing.totalScanned += event.rowsScanned
+    existing.totalReturned += event.rowsReturned
+    existing.lastSeen = timestamp
+  } else {
+    patterns.set(key, {
+      store: event.store,
+      operation: event.operation,
+      field,
+      count: 1,
+      totalDurationMs: event.durationMs,
+      totalScanned: event.rowsScanned,
+      totalReturned: event.rowsReturned,
+      lastSeen: timestamp,
+    })
+  }
+}
+
+// ─── Analysis ─────────────────────────────────────────────────────────────────
+
+function impactFor(speedupPercent: number): 'high' | 'medium' | 'low' {
+  if (speedupPercent >= 60) return 'high'
+  if (speedupPercent >= 30) return 'medium'
+  return 'low'
+}
+
+function buildRecommendation(
+  stats: PatternStats,
+  type: RecommendationType,
+  reason: string
+): OptimizationRecommendation {
+  const avgDurationMs = stats.totalDurationMs / stats.count
+  const avgScanRatio = stats.totalReturned > 0 ? stats.totalScanned / stats.totalReturned : stats.totalScanned
+  // Model an index turning an O(scanned) walk into an O(returned) lookup: the
+  // fraction of scanned rows that were "wasted" is a reasonable proxy for
+  // potential speedup. Clamped to keep the estimate defensible as a heuristic.
+  const rawSpeedup = avgScanRatio > 1 ? (1 - 1 / avgScanRatio) * 100 : 0
+  const estimatedSpeedupPercent = Math.round(Math.min(90, Math.max(0, rawSpeedup)))
+
+  return {
+    id: `${type}:${patternKey(stats.store, stats.operation, stats.field)}`,
+    type,
+    store: stats.store,
+    field: stats.field,
+    reason,
+    occurrences: stats.count,
+    avgDurationMs: Math.round(avgDurationMs * 100) / 100,
+    avgScanRatio: Math.round(avgScanRatio * 100) / 100,
+    estimatedImpact: impactFor(estimatedSpeedupPercent),
+    estimatedSpeedupPercent,
+    safe: true,
+  }
+}
+
+export function getRecommendations(): OptimizationRecommendation[] {
+  const recommendations: OptimizationRecommendation[] = []
+
+  for (const stats of patterns.values()) {
+    if (stats.count < MIN_OCCURRENCES) continue
+
+    const avgScanRatio = stats.totalReturned > 0 ? stats.totalScanned / stats.totalReturned : stats.totalScanned
+    const avgDurationMs = stats.totalDurationMs / stats.count
+
+    if (stats.operation === 'full-scan' && avgScanRatio >= FULL_SCAN_RATIO_THRESHOLD) {
+      const field = stats.field ? `"${stats.field}"` : 'the queried field'
+      recommendations.push(
+        buildRecommendation(
+          stats,
+          'add-index',
+          `${stats.count} full scans of "${stats.store}" filtering on ${field} examined ` +
+            `~${avgScanRatio.toFixed(1)}x more rows than returned. Adding an index on ${field} ` +
+            `would let this query look up matches directly instead of scanning the whole store.`
+        )
+      )
+    } else if (stats.operation === 'full-scan') {
+      recommendations.push(
+        buildRecommendation(
+          stats,
+          'avoid-full-scan',
+          `${stats.count} scans of "${stats.store}" are reading the whole store. Consider an ` +
+            `index or a narrower query even though the scan ratio is currently low.`
+        )
+      )
+    }
+
+    if (stats.count >= MIN_OCCURRENCES * 2 && avgDurationMs >= SLOW_QUERY_MS) {
+      recommendations.push(
+        buildRecommendation(
+          stats,
+          'cache-result',
+          `"${stats.store}" was queried ${stats.count} times (avg ${avgDurationMs.toFixed(1)}ms each) ` +
+            `with the same pattern. Caching the result and invalidating on write would avoid repeat reads.`
+        )
+      )
+    }
+  }
+
+  return recommendations.sort((a, b) => b.estimatedSpeedupPercent - a.estimatedSpeedupPercent)
+}
+
+export function getReport(): QueryPatternReport {
+  const slowQueries = recentEvents.filter((e) => e.durationMs >= SLOW_QUERY_MS).length
+  return {
+    totalQueries: recentEvents.length,
+    slowQueries,
+    distinctPatterns: patterns.size,
+    recommendations: getRecommendations(),
+    generatedAt: Date.now(),
+  }
+}
+
+export function reset(): void {
+  patterns.clear()
+  recentEvents.length = 0
+}
+
+export const queryOptimizer = {
+  recordQuery,
+  getRecommendations,
+  getReport,
+  reset,
+}


### PR DESCRIPTION
## Summary

Closes #619 with a scoped, honest version of the request. Reading the issue literally (ML models, index/schema recommendations, "improves performance 60% of the time") assumes a SQL database and production query telemetry — neither exists in this repo. The actual "database layer" here is the browser IndexedDB store in `src/lib/alertRulesDb.ts`.

What this PR adds instead:

- `src/lib/queryOptimizer.ts` — a rule-based query pattern analyzer. It records each query's operation type, index used, rows scanned vs. returned, and duration, then surfaces recommendations:
  - **add-index**: repeated full scans with a high scan-to-return ratio
  - **cache-result**: a pattern queried often and slowly with the same shape
  - **avoid-full-scan**: full scans that don't (yet) meet the index threshold
- Every recommendation is additive only (add an index / cache a read) — never a destructive schema or data change — so "suggestions are safe" holds by construction, not by trusting a model.
- `estimatedSpeedupPercent` is a heuristic derived from the observed scan ratio, explicitly documented as an estimate, not a measured before/after benchmark.
- Wired into `alertRulesDb.ts`'s two real read paths (`getRules`, `getNotifications`) so data collection is automatic, not just a standalone library nobody calls.

## Why not literal ML

Training/serving a real ML model needs labeled production query performance data this project doesn't collect, and there's no SQL query layer for "index/schema recommendations" to attach to. Shipping a rule-based advisor over real, observed scan/return ratios is the verifiable thing to do; claiming "AI" or a specific performance-improvement rate without that data would be misleading. Happy to discuss if the maintainers want a different scope.

## Test plan
- [x] `vitest run src/lib/__tests__/queryOptimizer.test.ts` — 8 new tests covering: empty state, index recommendation for wasteful scans, no false-positive on efficient index lookups, cache recommendation for hot slow queries, occurrence threshold, safety invariant, report totals, reset
- [x] Confirmed no new TypeScript errors introduced by this change (repo currently has pre-existing, unrelated type errors)
- [ ] Manual verification in-browser (not done in this session)

Note (unrelated to this PR): `pnpm install` currently fails on `master` because `package.json` pins `@tensorflow/tfjs-node@^5.0.0`, a version that doesn't exist on npm (latest is 4.22.0). Flagging separately since it blocks fresh installs for any contributor.