### PR TITLE
feat(#625): add priority-based client-side resource allocator

### DIFF
--- a/src/lib/__tests__/resourceAllocation.test.ts
+++ b/src/lib/__tests__/resourceAllocation.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import { ResourceAllocator, getPriorityWeight } from '../resourceAllocation'
+
+function makeTask(id: string, priority: any, ms = 5) {
+  return {
+    id,
+    priority,
+    run: () =>
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve(id), ms)
+      }),
+  }
+}
+
+describe('ResourceAllocator', () => {
+  it('respects the maxConcurrent limit', async () => {
+    const allocator = new ResourceAllocator(2)
+    let peak = 0
+    const tasks = Array.from({ length: 6 }, (_, i) =>
+      allocator.submit({
+        id: `t${i}`,
+        priority: 'medium' as const,
+        run: async () => {
+          peak = Math.max(peak, allocator.getStats().currentlyRunning)
+          await new Promise((r) => setTimeout(r, 10))
+          return i
+        },
+      }),
+    )
+    await Promise.all(tasks)
+    expect(peak).toBeLessThanOrEqual(2)
+  })
+
+  it('runs critical tasks before low priority tasks queued while busy', async () => {
+    const allocator = new ResourceAllocator(1)
+    const order: string[] = []
+    const record = (id: string) => order.push(id)
+
+    // Occupy the single slot first so low/critical both queue up
+    // behind it, creating real contention between priorities.
+    const blocker = allocator.submit({
+      id: 'blocker',
+      priority: 'medium',
+      run: () => new Promise((resolve) => setTimeout(resolve, 20)),
+    })
+
+    const low = allocator.submit({
+      id: 'low',
+      priority: 'low',
+      run: async () => {
+        record('low')
+      },
+    })
+    const critical = allocator.submit({
+      id: 'critical',
+      priority: 'critical',
+      run: async () => {
+        record('critical')
+      },
+    })
+
+    await Promise.all([blocker, low, critical])
+    expect(order[0]).toBe('critical')
+  })
+
+  it('rejects an invalid maxConcurrent', () => {
+    expect(() => new ResourceAllocator(0)).toThrow()
+  })
+
+  it('tracks completion stats by priority', async () => {
+    const allocator = new ResourceAllocator(3)
+    await Promise.all([
+      allocator.submit(makeTask('a', 'high')),
+      allocator.submit(makeTask('b', 'high')),
+      allocator.submit(makeTask('c', 'low')),
+    ])
+    const stats = allocator.getStats()
+    expect(stats.totalCompleted).toBe(3)
+    expect(stats.completedByPriority.high).toBe(2)
+    expect(stats.completedByPriority.low).toBe(1)
+  })
+
+  it('tracks failures without blocking other tasks', async () => {
+    const allocator = new ResourceAllocator(2)
+    const failing = allocator
+      .submit({
+        id: 'fail',
+        priority: 'high',
+        run: async () => {
+          throw new Error('boom')
+        },
+      })
+      .catch(() => 'caught')
+    const ok = allocator.submit(makeTask('ok', 'high'))
+
+    await Promise.all([failing, ok])
+    const stats = allocator.getStats()
+    expect(stats.totalFailed).toBe(1)
+    expect(stats.totalCompleted).toBe(1)
+  })
+
+  it('prevents starvation: low priority tasks eventually run under sustained high-priority load', async () => {
+    const allocator = new ResourceAllocator(1)
+    const completedOrder: string[] = []
+
+    const low = allocator.submit({
+      id: 'low',
+      priority: 'low',
+      run: async () => {
+        completedOrder.push('low')
+      },
+    })
+
+    const highs = Array.from({ length: 10 }, (_, i) =>
+      allocator.submit({
+        id: `high${i}`,
+        priority: 'high',
+        run: async () => {
+          completedOrder.push(`high${i}`)
+        },
+      }),
+    )
+
+    await Promise.all([low, ...highs])
+    expect(completedOrder).toContain('low')
+    expect(completedOrder.indexOf('low')).toBeLessThan(completedOrder.length - 1)
+  })
+
+  it('exposes relative priority weights', () => {
+    expect(getPriorityWeight('critical')).toBeGreaterThan(getPriorityWeight('high'))
+    expect(getPriorityWeight('high')).toBeGreaterThan(getPriorityWeight('medium'))
+    expect(getPriorityWeight('medium')).toBeGreaterThan(getPriorityWeight('low'))
+  })
+})

--- a/src/lib/resourceAllocation.ts
+++ b/src/lib/resourceAllocation.ts
@@ -1,0 +1,171 @@
+/**
+ * resourceAllocation.ts
+ * #625: AI-Powered Resource Allocation
+ *
+ * Client-side priority scheduler for the dashboard's own concurrent
+ * work (API polling, WebSocket subscriptions, background jobs).
+ * Allocates a limited concurrency budget across pending tasks based
+ * on priority, so high-priority work isn't starved by low-priority
+ * background jobs.
+ *
+ * Scope note: this repo is a client-side dashboard with no backend
+ * infrastructure fleet, so "resource allocation" here scopes to the
+ * browser-side concurrent task budget the dashboard itself controls.
+ */
+
+export type TaskPriority = 'critical' | 'high' | 'medium' | 'low'
+
+export interface ResourceTask<T = unknown> {
+  id: string
+  priority: TaskPriority
+  cost?: number
+  run: () => Promise<T>
+}
+
+export interface AllocationStats {
+  totalSubmitted: number
+  totalCompleted: number
+  totalFailed: number
+  currentlyRunning: number
+  currentlyQueued: number
+  completedByPriority: Record<TaskPriority, number>
+}
+
+const PRIORITY_WEIGHT: Record<TaskPriority, number> = {
+  critical: 8,
+  high: 4,
+  medium: 2,
+  low: 1,
+}
+
+const PRIORITY_ORDER: TaskPriority[] = ['critical', 'high', 'medium', 'low']
+
+/**
+ * Priority-aware concurrency scheduler. Runs up to `maxConcurrent`
+ * tasks at once, always preferring higher-priority tasks, while still
+ * guaranteeing lower-priority tasks eventually run (no starvation)
+ * via a small round-robin allowance per priority tier.
+ */
+export class ResourceAllocator {
+  private readonly maxConcurrent: number
+  private readonly queues: Record<TaskPriority, ResourceTask[]> = {
+    critical: [],
+    high: [],
+    medium: [],
+    low: [],
+  }
+  private running = 0
+  private stats: AllocationStats = {
+    totalSubmitted: 0,
+    totalCompleted: 0,
+    totalFailed: 0,
+    currentlyRunning: 0,
+    currentlyQueued: 0,
+    completedByPriority: { critical: 0, high: 0, medium: 0, low: 0 },
+  }
+  /** Tracks consecutive dispatches per tier to prevent starvation. */
+  private consecutiveDispatches: Record<TaskPriority, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+  }
+  private readonly starvationLimit = 3
+
+  constructor(maxConcurrent = 4) {
+    if (maxConcurrent < 1) {
+      throw new Error('maxConcurrent must be at least 1')
+    }
+    this.maxConcurrent = maxConcurrent
+  }
+
+  submit<T>(task: ResourceTask<T>): Promise<T> {
+    this.stats.totalSubmitted += 1
+    return new Promise<T>((resolve, reject) => {
+      const wrapped: ResourceTask<T> = {
+        ...task,
+        run: async () => {
+          try {
+            const result = await task.run()
+            resolve(result)
+            return result
+          } catch (err) {
+            reject(err)
+            throw err
+          }
+        },
+      }
+      this.queues[task.priority].push(wrapped as ResourceTask)
+      this.dispatch()
+    })
+  }
+
+  getStats(): AllocationStats {
+    return {
+      ...this.stats,
+      currentlyRunning: this.running,
+      currentlyQueued: this.queueLength(),
+    }
+  }
+
+  private queueLength(): number {
+    return PRIORITY_ORDER.reduce((sum, p) => sum + this.queues[p].length, 0)
+  }
+
+  /** Picks the next task to run, honoring priority weight while
+   * preventing starvation: a tier that has dispatched too many tasks
+   * in a row yields to the next non-empty lower tier once. */
+  private pickNextTier(): TaskPriority | null {
+    for (const tier of PRIORITY_ORDER) {
+      if (this.queues[tier].length === 0) continue
+      if (this.consecutiveDispatches[tier] < this.starvationLimit) {
+        return tier
+      }
+    }
+    // All eligible tiers hit their starvation limit — reset and pick
+    // the first non-empty tier so nothing waits forever.
+    for (const tier of PRIORITY_ORDER) {
+      if (this.queues[tier].length > 0) {
+        this.consecutiveDispatches[tier] = 0
+        return tier
+      }
+    }
+    return null
+  }
+
+  private dispatch(): void {
+    while (this.running < this.maxConcurrent) {
+      const tier = this.pickNextTier()
+      if (!tier) break
+
+      const task = this.queues[tier].shift()
+      if (!task) continue
+
+      this.consecutiveDispatches[tier] += 1
+      for (const t of PRIORITY_ORDER) {
+        if (t !== tier) this.consecutiveDispatches[t] = 0
+      }
+
+      this.running += 1
+      task
+        .run()
+        .then(() => {
+          this.stats.totalCompleted += 1
+          this.stats.completedByPriority[tier] += 1
+        })
+        .catch(() => {
+          this.stats.totalFailed += 1
+        })
+        .finally(() => {
+          this.running -= 1
+          this.dispatch()
+        })
+    }
+  }
+}
+
+/** Relative priority weight, exposed for callers that want to reason
+ * about fairness ratios without depending on internals. */
+export function getPriorityWeight(priority: TaskPriority): number {
+  return PRIORITY_WEIGHT[priority]
+}


### PR DESCRIPTION
Adds a scoped implementation of #625 for this codebase. This repo is a client-side dashboard with no backend infrastructure fleet to manage CPU/memory/network for, so this scopes resource allocation to the concurrent task budget the dashboard itself controls (API polling, WebSocket subscriptions, background jobs). New ResourceAllocator class in src/lib/resourceAllocation.ts: priority-based concurrency scheduler (critical/high/medium/low), configurable max concurrent tasks, starvation prevention so low-priority tasks always eventually run, and stats tracking (completed/failed/queued/running, broken down by priority). 7 unit tests cover concurrency limits, priority ordering under contention, starvation prevention, failure isolation, and invalid config handling — all passing. Note: I'm not claiming the 35% utilization figure from the original acceptance criteria since there's no backend infrastructure in this repo to benchmark against; happy to adjust scope per maintainer feedback. Closes #625.