### PR TITLE
feat: add adaptive accessibility learning

### DIFF
--- a/src/components/accessibility/AccessibilitySettings.tsx
+++ b/src/components/accessibility/AccessibilitySettings.tsx
@@ -3,22 +3,13 @@ import { useAccessibility } from '../../context/AccessibilityContext';
 import '../../styles/accessibility.css';
 
 export default function AccessibilitySettings({ onClose }: { onClose: () => void }) {
-  const { settings, setReducedMotion, setHighContrast, setFontSize } = useAccessibility();
-  const [dyslexiaFont, setDyslexiaFont] = React.useState(false);
+  const { settings, recommendations, confidence, setReducedMotion, setHighContrast, setFontSize, setDyslexiaFont, setAdaptiveMode, applyRecommendations } = useAccessibility();
 
   const toggleReduced = () => setReducedMotion(!settings.reducedMotion);
   const toggleContrast = () => setHighContrast(!settings.highContrast);
   const changeFontSize = (size: 'small' | 'default' | 'large') => setFontSize(size);
-  
-  const toggleDyslexiaFont = () => {
-    const newValue = !dyslexiaFont;
-    setDyslexiaFont(newValue);
-    if (newValue) {
-      document.documentElement.style.setProperty('--font-family', 'OpenDyslexic, Arial, sans-serif');
-    } else {
-      document.documentElement.style.removeProperty('--font-family');
-    }
-  };
+  const toggleDyslexiaFont = () => setDyslexiaFont(!settings.dyslexiaFont);
+  const toggleAdaptiveMode = () => setAdaptiveMode(!settings.adaptiveMode);
 
   return (
     <div
@@ -43,7 +34,7 @@ export default function AccessibilitySettings({ onClose }: { onClose: () => void
           border: '1px solid var(--border)',
           borderRadius: 'var(--radius-lg)',
           width: '90%',
-          maxWidth: '500px',
+          maxWidth: '560px',
           overflow: 'hidden',
           boxShadow: '0 20px 60px rgba(0,0,0,0.6)',
         }}
@@ -73,54 +64,54 @@ export default function AccessibilitySettings({ onClose }: { onClose: () => void
             ×
           </button>
         </div>
-        <div style={{ padding: '16px 24px' }}>
-          {/* Reduced Motion */}
-          <div style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
+        <div style={{ padding: '16px 24px', display: 'grid', gap: '12px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <label style={{ flex: 1, fontSize: '14px', color: 'var(--text-primary)' }}>Adaptive accessibility</label>
+            <input type="checkbox" checked={settings.adaptiveMode} onChange={toggleAdaptiveMode} aria-checked={settings.adaptiveMode} />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <label style={{ flex: 1, fontSize: '14px', color: 'var(--text-primary)' }}>Reduced Motion</label>
-            <input
-              type="checkbox"
-              checked={settings.reducedMotion}
-              onChange={toggleReduced}
-              aria-checked={settings.reducedMotion}
-            />
+            <input type="checkbox" checked={settings.reducedMotion} onChange={toggleReduced} aria-checked={settings.reducedMotion} />
           </div>
-          {/* High Contrast */}
-          <div style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <label style={{ flex: 1, fontSize: '14px', color: 'var(--text-primary)' }}>High Contrast</label>
-            <input
-              type="checkbox"
-              checked={settings.highContrast}
-              onChange={toggleContrast}
-              aria-checked={settings.highContrast}
-            />
+            <input type="checkbox" checked={settings.highContrast} onChange={toggleContrast} aria-checked={settings.highContrast} />
           </div>
-          {/* Font Size */}
-          <div style={{ marginTop: '16px' }}>
+          <div>
             <div style={{ fontSize: '14px', marginBottom: '8px', color: 'var(--text-primary)' }}>Font Size</div>
-            <div style={{ display: 'flex', gap: '12px' }}>
+            <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
               {['small', 'default', 'large'].map((size) => (
                 <label key={size} style={{ display: 'flex', alignItems: 'center' }}>
-                  <input
-                    type="radio"
-                    name="fontSize"
-                    value={size}
-                    checked={settings.fontSize === size}
-                    onChange={() => changeFontSize(size as any)}
-                  />
+                  <input type="radio" name="fontSize" value={size} checked={settings.fontSize === size} onChange={() => changeFontSize(size as 'small' | 'default' | 'large')} />
                   <span style={{ marginLeft: '4px' }}>{size.charAt(0).toUpperCase() + size.slice(1)}</span>
                 </label>
               ))}
             </div>
           </div>
-          {/* Dyslexia-Friendly Font */}
-          <div style={{ display: 'flex', alignItems: 'center', marginTop: '16px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
             <label style={{ flex: 1, fontSize: '14px', color: 'var(--text-primary)' }}>Dyslexia-Friendly Font</label>
-            <input
-              type="checkbox"
-              checked={dyslexiaFont}
-              onChange={toggleDyslexiaFont}
-              aria-checked={dyslexiaFont}
-            />
+            <input type="checkbox" checked={settings.dyslexiaFont} onChange={toggleDyslexiaFont} aria-checked={settings.dyslexiaFont} />
+          </div>
+
+          <div style={{ border: '1px solid var(--border)', borderRadius: 'var(--radius-md)', padding: '12px', background: 'var(--bg-elevated)' }}>
+            <div style={{ fontSize: '13px', fontWeight: 700, marginBottom: '6px' }}>Adaptive recommendations</div>
+            <div style={{ fontSize: '12px', color: 'var(--text-muted)', marginBottom: '8px' }}>
+              Confidence: {(confidence * 100).toFixed(0)}%
+            </div>
+            {recommendations.length > 0 ? (
+              <ul style={{ margin: 0, paddingLeft: '16px', display: 'grid', gap: '6px' }}>
+                {recommendations.map((recommendation) => (
+                  <li key={`${recommendation.key}-${recommendation.value}`} style={{ fontSize: '12px', color: 'var(--text-primary)' }}>
+                    {recommendation.reason}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div style={{ fontSize: '12px', color: 'var(--text-muted)' }}>No recommendations yet. Continue using the dashboard to let the system learn your preferences.</div>
+            )}
+            <button type="button" onClick={applyRecommendations} style={{ marginTop: '10px', padding: '8px 12px', borderRadius: '8px', border: '1px solid var(--border)', background: 'var(--cyan)', color: 'var(--bg-primary)', cursor: 'pointer' }}>
+              Apply recommended settings
+            </button>
           </div>
         </div>
       </div>

--- a/src/context/AccessibilityContext.tsx
+++ b/src/context/AccessibilityContext.tsx
@@ -1,68 +1,193 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import ScreenReaderAnnouncer from '../components/accessibility/ScreenReaderAnnouncer';
+import {
+  createDefaultAccessibilityProfile,
+  learnAccessibilityPreferences,
+  type AccessibilityFeedback,
+  type AccessibilityInteractionSignal,
+  type AccessibilityPreferenceSettings,
+  type AccessibilityRecommendation,
+} from '../lib/accessibilityAdaptive';
 
-export type AccessibilitySettings = {
-  reducedMotion: boolean;
-  highContrast: boolean;
-  fontSize: 'small' | 'default' | 'large';
-};
+export type AccessibilitySettings = AccessibilityPreferenceSettings;
 
 const defaultSettings: AccessibilitySettings = {
   reducedMotion: false,
   highContrast: false,
   fontSize: 'default',
+  dyslexiaFont: false,
+  adaptiveMode: true,
 };
 
 const AccessibilityContext = createContext<{
   settings: AccessibilitySettings;
-  setReducedMotion: (v: boolean) => void;
-  setHighContrast: (v: boolean) => void;
-  setFontSize: (v: AccessibilitySettings['fontSize']) => void;
+  recommendations: AccessibilityRecommendation[];
+  confidence: number;
+  setReducedMotion: (_v: boolean) => void;
+  setHighContrast: (_v: boolean) => void;
+  setFontSize: (_v: AccessibilitySettings['fontSize']) => void;
+  setDyslexiaFont: (_v: boolean) => void;
+  setAdaptiveMode: (_v: boolean) => void;
+  applyRecommendations: () => void;
 }>({
   settings: defaultSettings,
+  recommendations: [],
+  confidence: 0.5,
   setReducedMotion: () => {},
   setHighContrast: () => {},
   setFontSize: () => {},
+  setDyslexiaFont: () => {},
+  setAdaptiveMode: () => {},
+  applyRecommendations: () => {},
 });
 
 export const AccessibilityProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [settings, setSettings] = useState<AccessibilitySettings>(() => {
+    if (typeof window === 'undefined') return defaultSettings;
     try {
-      const stored = localStorage.getItem('accessibility');
-      if (stored) return { ...defaultSettings, ...JSON.parse(stored) };
-    } catch (_) {}
-    // Respect OS setting for reduced motion
+      const stored = window.localStorage.getItem('accessibility');
+      if (stored) {
+        const parsed = JSON.parse(stored) as Partial<AccessibilitySettings>;
+        return { ...defaultSettings, ...parsed };
+      }
+    } catch {
+      // Fall back to defaults when localStorage is unavailable.
+    }
     const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     return { ...defaultSettings, reducedMotion: prefersReduced };
   });
+  const [, setProfile] = useState(() => createDefaultAccessibilityProfile({ ...defaultSettings, ...settings }));
+  const [recommendations, setRecommendations] = useState<AccessibilityRecommendation[]>([]);
+  const [confidence, setConfidence] = useState(0.5);
+  const interactionBufferRef = useRef<AccessibilityInteractionSignal[]>([]);
+  const feedbackBufferRef = useRef<AccessibilityFeedback[]>([]);
 
-  // Persist to localStorage and apply CSS variables / attributes
-  useEffect(() => {
-    localStorage.setItem('accessibility', JSON.stringify(settings));
+  const applySettingsToDom = useCallback((nextSettings: AccessibilitySettings) => {
     const html = document.documentElement;
-    if (settings.reducedMotion) {
+    if (nextSettings.reducedMotion) {
       html.setAttribute('data-reduced-motion', 'true');
     } else {
       html.removeAttribute('data-reduced-motion');
     }
-    if (settings.highContrast) {
+    if (nextSettings.highContrast) {
       html.setAttribute('data-high-contrast', 'true');
     } else {
       html.removeAttribute('data-high-contrast');
     }
-    // Font scaling via CSS variable
     let scale = '1';
-    if (settings.fontSize === 'small') scale = '0.875';
-    else if (settings.fontSize === 'large') scale = '1.15';
+    if (nextSettings.fontSize === 'small') scale = '0.875';
+    else if (nextSettings.fontSize === 'large') scale = '1.15';
     html.style.setProperty('--font-scale', scale);
-  }, [settings]);
+    if (nextSettings.dyslexiaFont) {
+      html.style.setProperty('--font-family', 'OpenDyslexic, Arial, sans-serif');
+    } else {
+      html.style.removeProperty('--font-family');
+    }
+  }, []);
 
-  const setReducedMotion = (v: boolean) => setSettings((s) => ({ ...s, reducedMotion: v }));
-  const setHighContrast = (v: boolean) => setSettings((s) => ({ ...s, highContrast: v }));
-  const setFontSize = (v: AccessibilitySettings['fontSize']) => setSettings((s) => ({ ...s, fontSize: v }));
+  const recordFeedback = useCallback((feedback: AccessibilityFeedback) => {
+    feedbackBufferRef.current = [...feedbackBufferRef.current, feedback].slice(-6);
+    setProfile((current) => {
+      const nextProfile = learnAccessibilityPreferences(current, interactionBufferRef.current, [feedback]);
+      setRecommendations(nextProfile.recommendations);
+      setConfidence(nextProfile.confidence);
+      return nextProfile;
+    });
+  }, []);
+
+  const recordInteraction = useCallback((signal: AccessibilityInteractionSignal) => {
+    interactionBufferRef.current = [...interactionBufferRef.current, signal].slice(-6);
+    setProfile((current) => {
+      const nextProfile = learnAccessibilityPreferences(current, [signal], feedbackBufferRef.current);
+      setRecommendations(nextProfile.recommendations);
+      setConfidence(nextProfile.confidence);
+      return nextProfile;
+    });
+  }, []);
+
+  const applyRecommendations = useCallback(() => {
+    setSettings((current) => {
+      const nextSettings = { ...current };
+      recommendations.forEach((recommendation) => {
+        if (recommendation.key === 'reducedMotion' && typeof recommendation.value === 'boolean') {
+          nextSettings.reducedMotion = recommendation.value;
+        }
+        if (recommendation.key === 'highContrast' && typeof recommendation.value === 'boolean') {
+          nextSettings.highContrast = recommendation.value;
+        }
+        if (recommendation.key === 'fontSize' && (recommendation.value === 'small' || recommendation.value === 'default' || recommendation.value === 'large')) {
+          nextSettings.fontSize = recommendation.value;
+        }
+        if (recommendation.key === 'dyslexiaFont' && typeof recommendation.value === 'boolean') {
+          nextSettings.dyslexiaFont = recommendation.value;
+        }
+        if (recommendation.key === 'adaptiveMode' && typeof recommendation.value === 'boolean') {
+          nextSettings.adaptiveMode = recommendation.value;
+        }
+      });
+      applySettingsToDom(nextSettings);
+      return nextSettings;
+    });
+  }, [applySettingsToDom, recommendations]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('accessibility', JSON.stringify(settings));
+    applySettingsToDom(settings);
+  }, [applySettingsToDom, settings]);
+
+  useEffect(() => {
+    if (!settings.adaptiveMode || recommendations.length === 0 || confidence < 0.72) return;
+    applyRecommendations();
+  }, [applyRecommendations, confidence, recommendations, settings.adaptiveMode]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleKeyboard = () => recordInteraction({ type: 'keyboard', value: 0.8 });
+    const handleFocus = () => recordInteraction({ type: 'focus', value: 0.55 });
+    const handleError = () => recordInteraction({ type: 'error', value: 0.75 });
+    const timer = window.setTimeout(() => recordInteraction({ type: 'long-session', value: 0.7 }), 300000);
+
+    window.addEventListener('keydown', handleKeyboard);
+    document.addEventListener('focusin', handleFocus);
+    window.addEventListener('error', handleError);
+
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener('keydown', handleKeyboard);
+      document.removeEventListener('focusin', handleFocus);
+      window.removeEventListener('error', handleError);
+    };
+  }, [recordInteraction]);
+
+  const setReducedMotion = (v: boolean) => {
+    setSettings((current) => ({ ...current, reducedMotion: v }));
+    recordFeedback({ type: 'explicit', preference: { reducedMotion: v }, strength: 0.9 });
+  };
+
+  const setHighContrast = (v: boolean) => {
+    setSettings((current) => ({ ...current, highContrast: v }));
+    recordFeedback({ type: 'explicit', preference: { highContrast: v }, strength: 0.9 });
+  };
+
+  const setFontSize = (v: AccessibilitySettings['fontSize']) => {
+    setSettings((current) => ({ ...current, fontSize: v }));
+    recordFeedback({ type: 'explicit', preference: { fontSize: v }, strength: 0.85 });
+  };
+
+  const setDyslexiaFont = (v: boolean) => {
+    setSettings((current) => ({ ...current, dyslexiaFont: v }));
+    recordFeedback({ type: 'explicit', preference: { dyslexiaFont: v }, strength: 0.85 });
+  };
+
+  const setAdaptiveMode = (v: boolean) => {
+    setSettings((current) => ({ ...current, adaptiveMode: v }));
+    recordFeedback({ type: 'explicit', preference: { adaptiveMode: v }, strength: 0.8 });
+  };
 
   return (
-    <AccessibilityContext.Provider value={{ settings, setReducedMotion, setHighContrast, setFontSize }}>
+    <AccessibilityContext.Provider value={{ settings, recommendations, confidence, setReducedMotion, setHighContrast, setFontSize, setDyslexiaFont, setAdaptiveMode, applyRecommendations }}>
       <ScreenReaderAnnouncer />
       <div
         role="alert"

--- a/src/lib/accessibilityAdaptive.test.ts
+++ b/src/lib/accessibilityAdaptive.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { learnAccessibilityPreferences } from './accessibilityAdaptive';
+
+describe('accessibilityAdaptive', () => {
+  it('learns from explicit feedback and interaction patterns to recommend comfort-focused settings', () => {
+    const profile = learnAccessibilityPreferences(
+      {
+        settings: {
+          reducedMotion: false,
+          highContrast: false,
+          fontSize: 'default',
+          dyslexiaFont: false,
+          adaptiveMode: true,
+        },
+        recommendations: [],
+        feedbackHistory: [],
+        confidence: 0,
+      },
+      [
+        { type: 'keyboard', value: 0.85 },
+        { type: 'long-session', value: 0.7 },
+        { type: 'error', value: 0.6 },
+      ],
+      [
+        {
+          type: 'explicit',
+          preference: {
+            reducedMotion: true,
+            highContrast: true,
+            fontSize: 'large',
+            dyslexiaFont: true,
+          },
+          strength: 0.9,
+        },
+      ]
+    );
+
+    expect(profile.recommendations.some((item) => item.key === 'highContrast' && item.value === true)).toBe(true);
+    expect(profile.recommendations.some((item) => item.key === 'fontSize' && item.value === 'large')).toBe(true);
+    expect(profile.recommendations.some((item) => item.key === 'dyslexiaFont' && item.value === true)).toBe(true);
+    expect(profile.confidence).toBeGreaterThan(0.8);
+  });
+});

--- a/src/lib/accessibilityAdaptive.ts
+++ b/src/lib/accessibilityAdaptive.ts
@@ -1,0 +1,203 @@
+export type AccessibilityPreferenceSettings = {
+  reducedMotion: boolean;
+  highContrast: boolean;
+  fontSize: 'small' | 'default' | 'large';
+  dyslexiaFont: boolean;
+  adaptiveMode: boolean;
+};
+
+export type AccessibilityInteractionSignal = {
+  type: 'keyboard' | 'long-session' | 'error' | 'focus';
+  value: number;
+};
+
+export type AccessibilityFeedback = {
+  type: 'explicit' | 'implicit';
+  preference: Partial<AccessibilityPreferenceSettings>;
+  strength: number;
+};
+
+export type AccessibilityRecommendation = {
+  key: 'reducedMotion' | 'highContrast' | 'fontSize' | 'dyslexiaFont' | 'adaptiveMode';
+  value: boolean | 'small' | 'default' | 'large';
+  reason: string;
+  confidence: number;
+};
+
+export type AccessibilityPreferenceProfile = {
+  settings: AccessibilityPreferenceSettings;
+  recommendations: AccessibilityRecommendation[];
+  feedbackHistory: AccessibilityFeedback[];
+  confidence: number;
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+export function createDefaultAccessibilityProfile(
+  settings: AccessibilityPreferenceSettings
+): AccessibilityPreferenceProfile {
+  return {
+    settings,
+    recommendations: [],
+    feedbackHistory: [],
+    confidence: 0.5,
+  };
+}
+
+export function learnAccessibilityPreferences(
+  previousProfile: AccessibilityPreferenceProfile,
+  interactions: AccessibilityInteractionSignal[],
+  feedbacks: AccessibilityFeedback[]
+): AccessibilityPreferenceProfile {
+  const nextSettings = {
+    ...previousProfile.settings,
+  };
+
+  let confidence = Math.max(previousProfile.confidence, 0.55);
+
+  for (const feedback of feedbacks) {
+    if (feedback.preference.reducedMotion !== undefined) {
+      nextSettings.reducedMotion = Boolean(feedback.preference.reducedMotion);
+    }
+    if (feedback.preference.highContrast !== undefined) {
+      nextSettings.highContrast = Boolean(feedback.preference.highContrast);
+    }
+    if (feedback.preference.fontSize) {
+      nextSettings.fontSize = feedback.preference.fontSize;
+    }
+    if (feedback.preference.dyslexiaFont !== undefined) {
+      nextSettings.dyslexiaFont = Boolean(feedback.preference.dyslexiaFont);
+    }
+    if (feedback.preference.adaptiveMode !== undefined) {
+      nextSettings.adaptiveMode = Boolean(feedback.preference.adaptiveMode);
+    }
+
+    confidence = clamp(confidence + feedback.strength * 0.18, 0.4, 1);
+  }
+
+  const keyboardIntensity = interactions.find((signal) => signal.type === 'keyboard')?.value ?? 0;
+  const longSessionIntensity = interactions.find((signal) => signal.type === 'long-session')?.value ?? 0;
+  const errorIntensity = interactions.find((signal) => signal.type === 'error')?.value ?? 0;
+
+  if (keyboardIntensity > 0.6) {
+    nextSettings.highContrast = true;
+    nextSettings.dyslexiaFont = true;
+    nextSettings.fontSize = 'large';
+    confidence = clamp(confidence + 0.1, 0.4, 1);
+  }
+
+  if (longSessionIntensity > 0.6) {
+    nextSettings.reducedMotion = true;
+    nextSettings.fontSize = 'large';
+    nextSettings.highContrast = true;
+    confidence = clamp(confidence + 0.09, 0.4, 1);
+  }
+
+  if (errorIntensity > 0.6) {
+    nextSettings.highContrast = true;
+    nextSettings.dyslexiaFont = true;
+    nextSettings.fontSize = 'large';
+    confidence = clamp(confidence + 0.12, 0.4, 1);
+  }
+
+  if (keyboardIntensity > 0.8 || errorIntensity > 0.7) {
+    nextSettings.adaptiveMode = true;
+  }
+
+  const recommendations: AccessibilityRecommendation[] = [];
+
+  for (const feedback of feedbacks) {
+    if (feedback.preference.reducedMotion !== undefined) {
+      recommendations.push({
+        key: 'reducedMotion',
+        value: Boolean(feedback.preference.reducedMotion),
+        reason: 'Your explicit preference indicates this motion setting should be applied.',
+        confidence: clamp(0.8 + feedback.strength * 0.12, 0.6, 0.95),
+      });
+    }
+    if (feedback.preference.highContrast !== undefined) {
+      recommendations.push({
+        key: 'highContrast',
+        value: Boolean(feedback.preference.highContrast),
+        reason: 'Your explicit preference indicates stronger contrast should be applied.',
+        confidence: clamp(0.8 + feedback.strength * 0.12, 0.6, 0.95),
+      });
+    }
+    if (feedback.preference.fontSize) {
+      recommendations.push({
+        key: 'fontSize',
+        value: feedback.preference.fontSize,
+        reason: 'Your explicit preference indicates this text scale should be used.',
+        confidence: clamp(0.78 + feedback.strength * 0.12, 0.6, 0.95),
+      });
+    }
+    if (feedback.preference.dyslexiaFont !== undefined) {
+      recommendations.push({
+        key: 'dyslexiaFont',
+        value: Boolean(feedback.preference.dyslexiaFont),
+        reason: 'Your explicit preference indicates a dyslexia-friendly font should be applied.',
+        confidence: clamp(0.78 + feedback.strength * 0.12, 0.6, 0.95),
+      });
+    }
+    if (feedback.preference.adaptiveMode !== undefined) {
+      recommendations.push({
+        key: 'adaptiveMode',
+        value: Boolean(feedback.preference.adaptiveMode),
+        reason: 'Adaptive mode should stay enabled so the interface can continue improving for you.',
+        confidence: clamp(0.76 + feedback.strength * 0.1, 0.6, 0.95),
+      });
+    }
+  }
+
+  if (!nextSettings.reducedMotion && longSessionIntensity > 0.6) {
+    recommendations.push({
+      key: 'reducedMotion',
+      value: true,
+      reason: 'Long sessions often benefit from calmer motion and fewer distractions.',
+      confidence: clamp(0.72 + longSessionIntensity * 0.2, 0.6, 0.95),
+    });
+  }
+
+  if (!nextSettings.highContrast && (keyboardIntensity > 0.6 || errorIntensity > 0.6)) {
+    recommendations.push({
+      key: 'highContrast',
+      value: true,
+      reason: 'High contrast helps keep focus and readability strong during intensive navigation.',
+      confidence: clamp(0.7 + keyboardIntensity * 0.15 + errorIntensity * 0.12, 0.6, 0.95),
+    });
+  }
+
+  if (nextSettings.fontSize !== 'large' && (keyboardIntensity > 0.6 || longSessionIntensity > 0.6 || errorIntensity > 0.6)) {
+    recommendations.push({
+      key: 'fontSize',
+      value: 'large',
+      reason: 'A larger text scale usually improves legibility for extended use.',
+      confidence: clamp(0.68 + longSessionIntensity * 0.16 + keyboardIntensity * 0.12, 0.6, 0.95),
+    });
+  }
+
+  if (!nextSettings.dyslexiaFont && (keyboardIntensity > 0.6 || errorIntensity > 0.6)) {
+    recommendations.push({
+      key: 'dyslexiaFont',
+      value: true,
+      reason: 'A dyslexia-friendly font can reduce reading strain during repetitive tasks.',
+      confidence: clamp(0.7 + errorIntensity * 0.15, 0.6, 0.95),
+    });
+  }
+
+  if (!nextSettings.adaptiveMode) {
+    recommendations.push({
+      key: 'adaptiveMode',
+      value: true,
+      reason: 'Adaptive mode can keep applying comfort-focused changes as your behavior changes.',
+      confidence: 0.68,
+    });
+  }
+
+  return {
+    settings: nextSettings,
+    recommendations,
+    feedbackHistory: [...previousProfile.feedbackHistory, ...feedbacks].slice(-8),
+    confidence: clamp(confidence, 0.4, 1),
+  };
+}


### PR DESCRIPTION
Closes #583

## Summary
- add adaptive accessibility learning that reacts to interaction patterns and explicit feedback
- expose adaptive recommendations in the accessibility settings modal
- persist and apply comfort-focused settings automatically when confidence is high

## Testing
- pnpm vitest run --config vitest.config.js src/lib/accessibilityAdaptive.test.ts
- pnpm eslint src/context/AccessibilityContext.tsx src/components/accessibility/AccessibilitySettings.tsx src/lib/accessibilityAdaptive.ts src/lib/accessibilityAdaptive.test.ts