### PR TITLE
Remove fee prediction configuration example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,7 @@ const { transaction, prediction } = await integration.predictFeeForTransaction({
 
 ### Configuration
 
-```json
-{
-  "feePrediction": {
-    "enabled": true,
-    "updateIntervalMs": 15000,
-    "cacheTTLHours": 24,
-    "accuracyThreshold": 0.95
-  }
-}
-```
+
 
 ## ML Training Pipeline
 


### PR DESCRIPTION
Closes #590 
Removed JSON configuration example for fee prediction.