### PR TITLE
fix(#597): resolve TypeScript export conflict in code review assistant

### DIFF
--- a/src/lib/codeReview/codeReviewSuggestions.ts
+++ b/src/lib/codeReview/codeReviewSuggestions.ts
@@ -230,4 +230,3 @@ export function runCodeReview(
   };
 }
 
-export type { PrioritizedSuggestion };


### PR DESCRIPTION
## Description

Fixes a TypeScript compilation error (TS2484) in the AI-Powered Code Review Assistant module. The `PrioritizedSuggestion` type was declared as both an `export interface` and then redundantly re-exported as `export type { PrioritizedSuggestion }` at the end of the same file, causing a conflict.

## Changes

- Removed the redundant `export type { PrioritizedSuggestion }` from `src/lib/codeReview/codeReviewSuggestions.ts`
- The interface is already exported via `export interface PrioritizedSuggestion`, so the duplicate re-export caused TS2484

## Testing

- All 37 existing unit tests pass
- TypeScript compilation of the code review module succeeds

Closes #597