### PR TITLE
feat(a11y): provide text alternatives for interactive charts (#777)

### DIFF
--- a/CHART_ACCESSIBILITY_GUIDE.md
+++ b/CHART_ACCESSIBILITY_GUIDE.md
@@ -1,0 +1,106 @@
+# Chart Accessibility Guide
+
+Addresses [#777 — Provide text alternatives for interactive charts](.github/roadmap-issues-2026-07-29.json).
+
+Recharts renders an SVG with no built-in semantics: screen reader users get
+nothing, and keyboard-only users can't reach the data behind a line or bar.
+This guide describes the reusable pattern used across the dashboard's
+Recharts components and analytics views to fix that.
+
+## The pattern
+
+Two pieces do the work:
+
+- **`src/utils/chartAccessibility.ts`** — framework-free helpers that turn a
+  chart's dataset into text:
+  - `isRenderableChartData(data)` — validates a dataset before rendering.
+    Returns `false` for `null`/`undefined`/non-arrays/empty arrays instead of
+    throwing, so callers can show a "no data" state.
+  - `summarizeSeries(data, series)` — min/max/average/trend for one series.
+    Non-finite or missing values are skipped rather than coerced to `0`, so
+    malformed rows don't skew the average.
+  - `describeChart({ title, data, series })` — one sentence combining the
+    above, used as the screen-reader summary.
+  - `buildChartTable(data, columns)` — converts the dataset into
+    `{ headers, rows }` for an HTML table.
+
+- **`src/components/charts/AccessibleChart.tsx`** — a wrapper component:
+  - Renders the visually-hidden summary sentence and attaches it to the chart
+    via `aria-describedby`.
+  - Renders a "Show data table" button (a real, keyboard-focusable
+    `<button aria-expanded>`) that reveals an HTML `<table>` with `scope="col"`
+    / `scope="row"` headers — usable with a screen reader or keyboard alone,
+    and independent of SVG/canvas support.
+  - If `data` is missing, empty, or not an array (an unsupported environment,
+    a failed fetch, a bad API response), it renders a `role="status"` message
+    **instead of** the chart tree — it never passes malformed data into
+    Recharts, which would otherwise render a blank or broken SVG with no
+    indication anything went wrong.
+
+## Usage
+
+```tsx
+import AccessibleChart from '../charts/AccessibleChart';
+
+<AccessibleChart
+  title="Fees (Stroops)"
+  data={data}
+  series={[{ key: 'fees', label: 'Fees', unit: 'stroops' }]}
+  categoryKey="date"
+  categoryLabel="Date"
+  height={250}
+  emptyMessage="No fee data is currently available."
+>
+  <ResponsiveContainer width="100%" height="100%">
+    <BarChart data={data}>
+      {/* ...existing Recharts tree, unchanged... */}
+    </BarChart>
+  </ResponsiveContainer>
+</AccessibleChart>
+```
+
+The Recharts tree itself does not change — `AccessibleChart` only wraps it.
+`series` should list the same `dataKey`s already passed to `<Line>`/`<Bar>`/
+`<Area>` so the summary and table stay in sync with what's drawn.
+
+## Compatibility notes
+
+- No new dependencies; the table and summary are plain HTML/ARIA.
+- Works when Recharts fails to render (e.g. `ResponsiveContainer` measuring a
+  zero-size container in some test/SSR environments) because the summary and
+  table are rendered independently of the chart's own rendering path.
+- The empty/failure state replaces the chart entirely rather than rendering
+  Recharts with invalid data, avoiding console errors from malformed props.
+
+## Adopted so far
+
+- `src/components/charts/AnalyticsChart.jsx` (activity, latency, fee trend charts)
+- `src/components/dashboard/NetworkStats.tsx` (consensus close time / operations chart)
+- `src/components/dashboard/TransactionAnalyticsDashboard.tsx` (frequency, amount distribution)
+
+## Migrating another chart
+
+The dashboard has ~28 files importing from `recharts` (see
+`src/components/dashboard/*`, `src/components/charts/*`,
+`src/components/sentiment/SentimentVisualizations.tsx`). To migrate one:
+
+1. Import `AccessibleChart` from `src/components/charts/AccessibleChart`.
+2. Wrap the existing `<ResponsiveContainer>`/chart tree in `<AccessibleChart>`,
+   passing the same `data` array, a `title`, and a `series` array describing
+   each plotted `dataKey`.
+3. Set `categoryKey` to whatever field drives the X axis (`date`, `timestamp`,
+   `sequence`, etc.).
+4. Leave the inner Recharts markup untouched — no prop changes needed there.
+
+No chart should be migrated by deleting its visual rendering; `AccessibleChart`
+is additive.
+
+## Testing
+
+- `src/utils/__tests__/chartAccessibility.test.ts` — primary flow (multi-point
+  trend), boundary cases (single point, empty array), and failure cases
+  (non-array/`null`/non-numeric values) for every helper.
+- `src/components/charts/__tests__/AccessibleChart.test.tsx` — renders with
+  data and asserts the summary text and keyboard-toggleable table; asserts the
+  empty-state and malformed-data fallbacks render `role="status"` instead of
+  the chart.

--- a/src/components/charts/AccessibleChart.tsx
+++ b/src/components/charts/AccessibleChart.tsx
@@ -1,0 +1,131 @@
+// src/components/charts/AccessibleChart.tsx
+//
+// Wraps a Recharts visualization with a screen-reader summary and a
+// keyboard-toggleable data table, so the same information the chart conveys
+// visually is also available to assistive technology and non-pointer users.
+// See CHART_ACCESSIBILITY_GUIDE.md for the adoption pattern.
+import React, { useId, useState } from "react";
+import {
+  buildChartTable,
+  describeChart,
+  isRenderableChartData,
+  type ChartSeriesConfig,
+} from "../../utils/chartAccessibility";
+
+export interface AccessibleChartProps {
+  /** Title announced to screen readers and shown above the chart */
+  title: string;
+  /** The dataset driving the chart (same array passed to Recharts) */
+  data: unknown;
+  /** Series rendered in the chart, used to build the summary + table */
+  series: ChartSeriesConfig[];
+  /** Column driving the X axis / row label, e.g. "date" or "timestamp" */
+  categoryKey: string;
+  /** Label for the category column in the accessible table */
+  categoryLabel?: string;
+  /** The actual Recharts tree (ResponsiveContainer + chart) */
+  children: React.ReactNode;
+  /** Message shown when data is missing/empty/invalid, instead of the chart */
+  emptyMessage?: string;
+  height?: number | string;
+}
+
+/**
+ * Recharts renders to SVG with no semantic fallback, so screen readers and
+ * environments without canvas/SVG support (older browsers, some test runners)
+ * get nothing. This wrapper always renders a text summary and an accessible
+ * table alongside — or instead of — the visual chart.
+ */
+export default function AccessibleChart({
+  title,
+  data,
+  series,
+  categoryKey,
+  categoryLabel = "Label",
+  children,
+  emptyMessage = "No data is currently available for this chart.",
+  height = 250,
+}: AccessibleChartProps) {
+  const [showTable, setShowTable] = useState(false);
+  const summaryId = useId();
+  const hasData = isRenderableChartData(data);
+
+  const summary = hasData ? describeChart({ title, data, series }) : `${title}: ${emptyMessage}`;
+  const table = hasData
+    ? buildChartTable(data, [{ key: categoryKey, label: categoryLabel }, ...series])
+    : { headers: [], rows: [] };
+
+  return (
+    <div>
+      <p id={summaryId} className="sr-only">
+        {summary}
+      </p>
+
+      {hasData ? (
+        <div role="img" aria-label={title} aria-describedby={summaryId} style={{ height }}>
+          {children}
+        </div>
+      ) : (
+        <div
+          role="status"
+          style={{
+            height,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "var(--text-muted)",
+            fontSize: "12px",
+          }}
+        >
+          {emptyMessage}
+        </div>
+      )}
+
+      {hasData && (
+        <button
+          type="button"
+          onClick={() => setShowTable((v) => !v)}
+          aria-expanded={showTable}
+          style={{
+            marginTop: "8px",
+            background: "transparent",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-sm)",
+            color: "var(--text-secondary)",
+            fontSize: "11px",
+            padding: "4px 10px",
+            cursor: "pointer",
+          }}
+        >
+          {showTable ? "Hide data table" : "Show data table"}
+        </button>
+      )}
+
+      {hasData && showTable && (
+        <table style={{ width: "100%", marginTop: "8px", borderCollapse: "collapse", fontSize: "12px" }}>
+          <caption className="sr-only">{title} — tabular data</caption>
+          <thead>
+            <tr>
+              {table.headers.map((h) => (
+                <th key={h} scope="col" style={{ textAlign: "left", padding: "4px 8px", borderBottom: "1px solid var(--border)" }}>
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {table.rows.map((row, i) => (
+              <tr key={i}>
+                {row.map((cell, j) => (
+                  j === 0
+                    ? <th key={j} scope="row" style={{ textAlign: "left", padding: "4px 8px", fontWeight: 500 }}>{cell}</th>
+                    : <td key={j} style={{ padding: "4px 8px" }}>{cell}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/components/charts/AnalyticsChart.jsx
+++ b/src/components/charts/AnalyticsChart.jsx
@@ -10,8 +10,9 @@ import {
   BarChart,
   Bar,
 } from "recharts";
+import AccessibleChart from "./AccessibleChart";
 
-function ChartShell({ title, children, height = 250 }) {
+function ChartShell({ title, children }) {
   return (
     <div
       style={{
@@ -30,9 +31,7 @@ function ChartShell({ title, children, height = 250 }) {
       >
         {title}
       </div>
-      <div style={{ height }}>
-        {children}
-      </div>
+      {children}
     </div>
   );
 }
@@ -40,15 +39,25 @@ function ChartShell({ title, children, height = 250 }) {
 export function ActivityTrendChart({ data = [] }) {
   return (
     <ChartShell title="14-Day Activity">
-      <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data}>
-          <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" />
-          <XAxis dataKey="date" tick={{ fontSize: 10, fill: "var(--text-muted)" }} />
-          <YAxis tick={{ fontSize: 10, fill: "var(--text-muted)" }} />
-          <Tooltip />
-          <Line dataKey="transactions" stroke="var(--cyan)" strokeWidth={2} dot={false} />
-        </LineChart>
-      </ResponsiveContainer>
+      <AccessibleChart
+        title="14-Day Activity"
+        data={data}
+        series={[{ key: "transactions", label: "Transactions" }]}
+        categoryKey="date"
+        categoryLabel="Date"
+        height={250}
+        emptyMessage="No activity data is currently available."
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" />
+            <XAxis dataKey="date" tick={{ fontSize: 10, fill: "var(--text-muted)" }} />
+            <YAxis tick={{ fontSize: 10, fill: "var(--text-muted)" }} />
+            <Tooltip />
+            <Line dataKey="transactions" stroke="var(--cyan)" strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </AccessibleChart>
     </ChartShell>
   );
 }
@@ -56,24 +65,34 @@ export function ActivityTrendChart({ data = [] }) {
 export function LatencyTrendChart({ data = [] }) {
   return (
     <ChartShell title="Latency (Last 24h)">
-      <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={data}>
-          <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" />
-          <XAxis
-            dataKey="timestamp"
-            tick={{ fontSize: 10, fill: "var(--text-muted)" }}
-            tickFormatter={(value) => new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-            minTickGap={40}
-          />
-          <YAxis
-            tick={{ fontSize: 10, fill: "var(--text-muted)" }}
-            domain={[0, 'dataMax + 100']}
-            unit="ms"
-          />
-          <Tooltip formatter={(value) => [`${value} ms`, 'Latency']} />
-          <Line dataKey="latency" stroke="var(--cyan)" strokeWidth={2} dot={false} />
-        </LineChart>
-      </ResponsiveContainer>
+      <AccessibleChart
+        title="Latency (Last 24h)"
+        data={data}
+        series={[{ key: "latency", label: "Latency", unit: "ms" }]}
+        categoryKey="timestamp"
+        categoryLabel="Time"
+        height={250}
+        emptyMessage="No latency data is currently available."
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" />
+            <XAxis
+              dataKey="timestamp"
+              tick={{ fontSize: 10, fill: "var(--text-muted)" }}
+              tickFormatter={(value) => new Date(value).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+              minTickGap={40}
+            />
+            <YAxis
+              tick={{ fontSize: 10, fill: "var(--text-muted)" }}
+              domain={[0, 'dataMax + 100']}
+              unit="ms"
+            />
+            <Tooltip formatter={(value) => [`${value} ms`, 'Latency']} />
+            <Line dataKey="latency" stroke="var(--cyan)" strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </AccessibleChart>
     </ChartShell>
   );
 }
@@ -81,15 +100,25 @@ export function LatencyTrendChart({ data = [] }) {
 export function FeeTrendChart({ data = [] }) {
   return (
     <ChartShell title="Fees (Stroops)">
-      <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data}>
-          <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" />
-          <XAxis dataKey="date" tick={{ fontSize: 10, fill: "var(--text-muted)" }} />
-          <YAxis tick={{ fontSize: 10, fill: "var(--text-muted)" }} />
-          <Tooltip />
-          <Bar dataKey="fees" fill="var(--amber)" />
-        </BarChart>
-      </ResponsiveContainer>
+      <AccessibleChart
+        title="Fees (Stroops)"
+        data={data}
+        series={[{ key: "fees", label: "Fees", unit: "stroops" }]}
+        categoryKey="date"
+        categoryLabel="Date"
+        height={250}
+        emptyMessage="No fee data is currently available."
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data}>
+            <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" />
+            <XAxis dataKey="date" tick={{ fontSize: 10, fill: "var(--text-muted)" }} />
+            <YAxis tick={{ fontSize: 10, fill: "var(--text-muted)" }} />
+            <Tooltip />
+            <Bar dataKey="fees" fill="var(--amber)" />
+          </BarChart>
+        </ResponsiveContainer>
+      </AccessibleChart>
     </ChartShell>
   );
 }

--- a/src/components/charts/__tests__/AccessibleChart.test.tsx
+++ b/src/components/charts/__tests__/AccessibleChart.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AccessibleChart from '../AccessibleChart';
+
+const data = [
+  { date: '2026-01-01', fees: 100 },
+  { date: '2026-01-02', fees: 150 },
+  { date: '2026-01-03', fees: 200 },
+];
+
+const series = [{ key: 'fees', label: 'Fees', unit: 'stroops' }];
+
+describe('<AccessibleChart />', () => {
+  it('renders a screen-reader summary and the chart content (primary flow)', () => {
+    render(
+      <AccessibleChart title="Fee Trend" data={data} series={series} categoryKey="date" categoryLabel="Date">
+        <div data-testid="chart-body">chart</div>
+      </AccessibleChart>
+    );
+
+    expect(screen.getByTestId('chart-body')).toBeInTheDocument();
+    expect(screen.getByText(/Fee Trend: 3 data points/)).toBeInTheDocument();
+  });
+
+  it('reveals an accessible data table when toggled via keyboard-operable button', () => {
+    render(
+      <AccessibleChart title="Fee Trend" data={data} series={series} categoryKey="date" categoryLabel="Date">
+        <div>chart</div>
+      </AccessibleChart>
+    );
+
+    const toggle = screen.getByRole('button', { name: /show data table/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    const table = screen.getByRole('table');
+    expect(table).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Date' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Fees' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: '100' })).toBeInTheDocument();
+  });
+
+  it('renders an empty-state message instead of the chart for an empty dataset (boundary case)', () => {
+    render(
+      <AccessibleChart title="Fee Trend" data={[]} series={series} categoryKey="date">
+        <div data-testid="chart-body">chart</div>
+      </AccessibleChart>
+    );
+
+    expect(screen.queryByTestId('chart-body')).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('No data is currently available for this chart.');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('falls back gracefully instead of crashing on malformed data (failure case)', () => {
+    render(
+      <AccessibleChart
+        title="Fee Trend"
+        data={'not-an-array' as unknown as Array<Record<string, unknown>>}
+        series={series}
+        categoryKey="date"
+        emptyMessage="Chart data failed to load."
+      >
+        <div data-testid="chart-body">chart</div>
+      </AccessibleChart>
+    );
+
+    expect(screen.queryByTestId('chart-body')).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Chart data failed to load.');
+  });
+});

--- a/src/components/dashboard/NetworkStats.tsx
+++ b/src/components/dashboard/NetworkStats.tsx
@@ -6,6 +6,7 @@ import Card, { StatCard } from './Card'
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine, AreaChart, Area
 } from 'recharts'
+import AccessibleChart from '../charts/AccessibleChart'
 import {
   Activity, Cpu, Shield, Coins, Zap, Clock, Globe, Terminal, Info,
   TrendingUp, Database, CheckCircle2, AlertTriangle, XCircle, Play
@@ -360,79 +361,92 @@ export default function Network() {
             {ledgersLoading ? (
               <div style={{ padding: '48px', display: 'flex', justifyContent: 'center' }}><div className="spinner" /></div>
             ) : chartData.length > 0 ? (
-              <div style={{ padding: '18px', height: '280px' }}>
-                <ResponsiveContainer width="100%" height="100%">
-                  <AreaChart data={chartData} margin={{ top: 5, right: 30, left: 10, bottom: 5 }}>
-                    <defs>
-                      <linearGradient id="colorInterval" x1="0" y1="0" x2="0" y2="1">
-                        <stop offset="5%" stopColor="var(--cyan)" stopOpacity={0.2}/>
-                        <stop offset="95%" stopColor="var(--cyan)" stopOpacity={0.02}/>
-                      </linearGradient>
-                      <linearGradient id="colorOps" x1="0" y1="0" x2="0" y2="1">
-                        <stop offset="5%" stopColor="var(--amber)" stopOpacity={0.15}/>
-                        <stop offset="95%" stopColor="var(--amber)" stopOpacity={0.01}/>
-                      </linearGradient>
-                    </defs>
-                    <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" opacity={0.5} />
-                    <XAxis
-                      dataKey="sequence"
-                      tick={{ fontSize: 10, fill: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}
-                      tickFormatter={(value) => value.toLocaleString()}
-                    />
-                    <YAxis
-                      yAxisId="left"
-                      tick={{ fontSize: 10, fill: 'var(--text-muted)' }}
-                      label={{ value: 'Segundos', angle: -90, position: 'insideLeft', style: { textAnchor: 'middle', fontSize: '10px', fill: 'var(--text-muted)', fontFamily: 'var(--font-display)' } }}
-                    />
-                    <YAxis
-                      yAxisId="right"
-                      orientation="right"
-                      tick={{ fontSize: 10, fill: 'var(--text-muted)' }}
-                      label={{ value: 'Operaciones', angle: 90, position: 'insideRight', style: { textAnchor: 'middle', fontSize: '10px', fill: 'var(--text-muted)', fontFamily: 'var(--font-display)' } }}
-                    />
-                    <Tooltip
-                      contentStyle={{
-                        background: 'var(--bg-surface)',
-                        border: '1px solid var(--border-bright)',
-                        borderRadius: 'var(--radius-md)',
-                        fontSize: '12px',
-                        color: 'var(--text-primary)',
-                        fontFamily: 'var(--font-mono)',
-                        boxShadow: '0 8px 24px rgba(0,0,0,0.4)'
-                      }}
-                      formatter={(value, name) => {
-                        if (name === 'interval') return [`${value.toFixed(2)}s`, 'Tiempo de Cierre']
-                        return [value, 'Operaciones']
-                      }}
-                      labelFormatter={(label) => `Ledger #${label.toLocaleString()}`}
-                    />
-                    <ReferenceLine
-                      yAxisId="left"
-                      y={averageCloseTime}
-                      stroke="var(--cyan-dim)"
-                      strokeDasharray="4 4"
-                      label={{ value: `Avg: ${averageCloseTime.toFixed(2)}s`, position: 'topRight', fontSize: 10, fill: 'var(--cyan)' }}
-                    />
-                    <Area
-                      yAxisId="left"
-                      type="monotone"
-                      dataKey="interval"
-                      stroke="var(--cyan)"
-                      strokeWidth={2}
-                      fillOpacity={1}
-                      fill="url(#colorInterval)"
-                    />
-                    <Area
-                      yAxisId="right"
-                      type="monotone"
-                      dataKey="operations"
-                      stroke="var(--amber)"
-                      strokeWidth={1.5}
-                      fillOpacity={1}
-                      fill="url(#colorOps)"
-                    />
-                  </AreaChart>
-                </ResponsiveContainer>
+              <div style={{ padding: '18px' }}>
+                <AccessibleChart
+                  title="Consensus Close Time and Operations"
+                  data={chartData}
+                  series={[
+                    { key: 'interval', label: 'Close time', unit: 's' },
+                    { key: 'operations', label: 'Operations' },
+                  ]}
+                  categoryKey="formattedSequence"
+                  categoryLabel="Ledger"
+                  height={280}
+                  emptyMessage="No telemetry chart data available. Waiting for consensus signals..."
+                >
+                  <ResponsiveContainer width="100%" height="100%">
+                    <AreaChart data={chartData} margin={{ top: 5, right: 30, left: 10, bottom: 5 }}>
+                      <defs>
+                        <linearGradient id="colorInterval" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="5%" stopColor="var(--cyan)" stopOpacity={0.2}/>
+                          <stop offset="95%" stopColor="var(--cyan)" stopOpacity={0.02}/>
+                        </linearGradient>
+                        <linearGradient id="colorOps" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="5%" stopColor="var(--amber)" stopOpacity={0.15}/>
+                          <stop offset="95%" stopColor="var(--amber)" stopOpacity={0.01}/>
+                        </linearGradient>
+                      </defs>
+                      <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" opacity={0.5} />
+                      <XAxis
+                        dataKey="sequence"
+                        tick={{ fontSize: 10, fill: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}
+                        tickFormatter={(value) => value.toLocaleString()}
+                      />
+                      <YAxis
+                        yAxisId="left"
+                        tick={{ fontSize: 10, fill: 'var(--text-muted)' }}
+                        label={{ value: 'Segundos', angle: -90, position: 'insideLeft', style: { textAnchor: 'middle', fontSize: '10px', fill: 'var(--text-muted)', fontFamily: 'var(--font-display)' } }}
+                      />
+                      <YAxis
+                        yAxisId="right"
+                        orientation="right"
+                        tick={{ fontSize: 10, fill: 'var(--text-muted)' }}
+                        label={{ value: 'Operaciones', angle: 90, position: 'insideRight', style: { textAnchor: 'middle', fontSize: '10px', fill: 'var(--text-muted)', fontFamily: 'var(--font-display)' } }}
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          background: 'var(--bg-surface)',
+                          border: '1px solid var(--border-bright)',
+                          borderRadius: 'var(--radius-md)',
+                          fontSize: '12px',
+                          color: 'var(--text-primary)',
+                          fontFamily: 'var(--font-mono)',
+                          boxShadow: '0 8px 24px rgba(0,0,0,0.4)'
+                        }}
+                        formatter={(value, name) => {
+                          if (name === 'interval') return [`${value.toFixed(2)}s`, 'Tiempo de Cierre']
+                          return [value, 'Operaciones']
+                        }}
+                        labelFormatter={(label) => `Ledger #${label.toLocaleString()}`}
+                      />
+                      <ReferenceLine
+                        yAxisId="left"
+                        y={averageCloseTime}
+                        stroke="var(--cyan-dim)"
+                        strokeDasharray="4 4"
+                        label={{ value: `Avg: ${averageCloseTime.toFixed(2)}s`, position: 'topRight', fontSize: 10, fill: 'var(--cyan)' }}
+                      />
+                      <Area
+                        yAxisId="left"
+                        type="monotone"
+                        dataKey="interval"
+                        stroke="var(--cyan)"
+                        strokeWidth={2}
+                        fillOpacity={1}
+                        fill="url(#colorInterval)"
+                      />
+                      <Area
+                        yAxisId="right"
+                        type="monotone"
+                        dataKey="operations"
+                        stroke="var(--amber)"
+                        strokeWidth={1.5}
+                        fillOpacity={1}
+                        fill="url(#colorOps)"
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </AccessibleChart>
               </div>
             ) : (
               <div style={{ padding: '32px', textAlign: 'center', color: 'var(--text-muted)', fontSize: '12px' }}>

--- a/src/components/dashboard/TransactionAnalyticsDashboard.tsx
+++ b/src/components/dashboard/TransactionAnalyticsDashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchTransactions } from '../../api/transactions';
 import { LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer, Legend } from 'recharts';
+import AccessibleChart from '../charts/AccessibleChart';
 
 // Mock data generators (replace with real data)
 const generateFrequencyData = (transactions) => {
@@ -48,27 +49,47 @@ export default function TransactionAnalyticsDashboard() {
     <div style={{ padding: '16px', display: 'grid', gap: '24px' }}>
       <h2 style={{ fontFamily: 'var(--font-display)', fontSize: '24px' }}>Transaction Analytics</h2>
       {/* Frequency Chart */}
-      <ResponsiveContainer width='100%' height={300}>
-        <LineChart data={freqData}>
-          <CartesianGrid strokeDasharray='3 3' />
-          <XAxis dataKey='date' />
-          <YAxis />
-          <Tooltip />
-          <Legend />
-          <Line type='monotone' dataKey='count' stroke='var(--cyan)' name='Tx Count' />
-        </LineChart>
-      </ResponsiveContainer>
+      <AccessibleChart
+        title="Transaction Frequency"
+        data={freqData}
+        series={[{ key: 'count', label: 'Tx Count' }]}
+        categoryKey="date"
+        categoryLabel="Date"
+        height={300}
+        emptyMessage="No transaction frequency data is currently available."
+      >
+        <ResponsiveContainer width='100%' height='100%'>
+          <LineChart data={freqData}>
+            <CartesianGrid strokeDasharray='3 3' />
+            <XAxis dataKey='date' />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Line type='monotone' dataKey='count' stroke='var(--cyan)' name='Tx Count' />
+          </LineChart>
+        </ResponsiveContainer>
+      </AccessibleChart>
       {/* Amount Distribution */}
-      <ResponsiveContainer width='100%' height={300}>
-        <BarChart data={distData}>
-          <CartesianGrid strokeDasharray='3 3' />
-          <XAxis dataKey='range' />
-          <YAxis />
-          <Tooltip />
-          <Legend />
-          <Bar dataKey='count' fill='var(--amber)' name='Transactions' />
-        </BarChart>
-      </ResponsiveContainer>
+      <AccessibleChart
+        title="Transaction Amount Distribution"
+        data={distData}
+        series={[{ key: 'count', label: 'Transactions' }]}
+        categoryKey="range"
+        categoryLabel="Amount range"
+        height={300}
+        emptyMessage="No transaction amount distribution data is currently available."
+      >
+        <ResponsiveContainer width='100%' height='100%'>
+          <BarChart data={distData}>
+            <CartesianGrid strokeDasharray='3 3' />
+            <XAxis dataKey='range' />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey='count' fill='var(--amber)' name='Transactions' />
+          </BarChart>
+        </ResponsiveContainer>
+      </AccessibleChart>
       {/* Additional charts (counterparty, time‑of‑day, seasonal, prediction) can be added similarly */}
     </div>
   );

--- a/src/utils/__tests__/chartAccessibility.test.ts
+++ b/src/utils/__tests__/chartAccessibility.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isRenderableChartData,
+  summarizeSeries,
+  describeChart,
+  buildChartTable,
+} from '../chartAccessibility';
+
+const data = [
+  { date: '2026-01-01', fees: 100, latency: 200 },
+  { date: '2026-01-02', fees: 150, latency: 180 },
+  { date: '2026-01-03', fees: 200, latency: 160 },
+];
+
+describe('isRenderableChartData', () => {
+  it('accepts a non-empty array of objects (primary flow)', () => {
+    expect(isRenderableChartData(data)).toBe(true);
+  });
+
+  it('rejects an empty array (boundary case)', () => {
+    expect(isRenderableChartData([])).toBe(false);
+  });
+
+  it('rejects null, undefined, and non-array input (failure case)', () => {
+    expect(isRenderableChartData(null)).toBe(false);
+    expect(isRenderableChartData(undefined)).toBe(false);
+    expect(isRenderableChartData('not an array')).toBe(false);
+    expect(isRenderableChartData(42)).toBe(false);
+    expect(isRenderableChartData([1, 2, 3])).toBe(false);
+  });
+});
+
+describe('summarizeSeries', () => {
+  it('computes min/max/average/trend for a numeric series (primary flow)', () => {
+    const summary = summarizeSeries(data, { key: 'fees', label: 'Fees', unit: 'stroops' });
+    expect(summary.count).toBe(3);
+    expect(summary.min).toBe(100);
+    expect(summary.max).toBe(200);
+    expect(summary.average).toBe(150);
+    expect(summary.trend).toBe('up');
+  });
+
+  it('detects a downward trend', () => {
+    const summary = summarizeSeries(data, { key: 'latency', label: 'Latency' });
+    expect(summary.trend).toBe('down');
+  });
+
+  it('returns a safe empty summary for a single data point (boundary case)', () => {
+    const summary = summarizeSeries([{ date: '2026-01-01', fees: 100 }], { key: 'fees' });
+    expect(summary.count).toBe(1);
+    expect(summary.trend).toBe('flat');
+  });
+
+  it('skips non-finite values instead of throwing (failure case)', () => {
+    const malformed = [
+      { date: '2026-01-01', fees: 'not-a-number' },
+      { date: '2026-01-02', fees: NaN },
+      { date: '2026-01-03', fees: 300 },
+    ];
+    const summary = summarizeSeries(malformed, { key: 'fees' });
+    expect(summary.count).toBe(1);
+    expect(summary.average).toBe(300);
+  });
+
+  it('returns an empty summary for invalid/empty datasets', () => {
+    expect(summarizeSeries(null, { key: 'fees' }).count).toBe(0);
+    expect(summarizeSeries([], { key: 'fees' }).min).toBeNull();
+  });
+});
+
+describe('describeChart', () => {
+  it('produces a readable sentence describing the series (primary flow)', () => {
+    const text = describeChart({
+      title: 'Fee Trend',
+      data,
+      series: [{ key: 'fees', label: 'Fees', unit: 'stroops' }],
+    });
+    expect(text).toContain('Fee Trend');
+    expect(text).toContain('3 data points');
+    expect(text).toContain('Fees ranges from 100');
+  });
+
+  it('reports no data available for empty datasets (boundary case)', () => {
+    expect(describeChart({ title: 'Fee Trend', data: [], series: [] })).toBe(
+      'Fee Trend: no data is currently available.'
+    );
+  });
+
+  it('does not throw for malformed input (failure case)', () => {
+    expect(() =>
+      describeChart({ title: 'Broken', data: 'garbage' as unknown, series: [] })
+    ).not.toThrow();
+    expect(describeChart({ title: 'Broken', data: undefined, series: [] })).toContain(
+      'no data is currently available'
+    );
+  });
+});
+
+describe('buildChartTable', () => {
+  it('builds headers and rows matching the dataset (primary flow)', () => {
+    const table = buildChartTable(data, [
+      { key: 'date', label: 'Date' },
+      { key: 'fees', label: 'Fees' },
+    ]);
+    expect(table.headers).toEqual(['Date', 'Fees']);
+    expect(table.rows).toHaveLength(3);
+    expect(table.rows[0]).toEqual(['2026-01-01', '100']);
+  });
+
+  it('renders an em dash for missing values (boundary case)', () => {
+    const table = buildChartTable([{ date: '2026-01-01' }], [
+      { key: 'date', label: 'Date' },
+      { key: 'fees', label: 'Fees' },
+    ]);
+    expect(table.rows[0]).toEqual(['2026-01-01', '—']);
+  });
+
+  it('returns an empty table for invalid data or columns instead of throwing (failure case)', () => {
+    expect(buildChartTable(null, [{ key: 'fees' }])).toEqual({ headers: [], rows: [] });
+    expect(buildChartTable(data, [])).toEqual({ headers: [], rows: [] });
+    expect(buildChartTable('garbage' as unknown, [{ key: 'fees' }])).toEqual({
+      headers: [],
+      rows: [],
+    });
+  });
+});

--- a/src/utils/chartAccessibility.ts
+++ b/src/utils/chartAccessibility.ts
@@ -1,0 +1,171 @@
+// src/utils/chartAccessibility.ts
+//
+// Pure helpers that turn Recharts-style datasets into screen-reader text and
+// keyboard-navigable table data. No React/DOM dependency so they work in any
+// environment (SSR, tests, workers) and never throw on malformed input.
+
+export interface ChartSeriesConfig {
+  /** Object key read from each data row */
+  key: string;
+  /** Human-readable label used in the summary and table header */
+  label?: string;
+  /** Unit suffix appended to values in the summary, e.g. "ms", "XLM" */
+  unit?: string;
+}
+
+export interface ChartTable {
+  headers: string[];
+  rows: Array<Array<string>>;
+}
+
+export interface ChartSeriesSummary {
+  key: string;
+  label: string;
+  unit: string;
+  count: number;
+  min: number | null;
+  max: number | null;
+  average: number | null;
+  first: number | null;
+  last: number | null;
+  trend: "up" | "down" | "flat" | "unknown";
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const toFiniteNumber = (value: unknown): number | null => {
+  const num = typeof value === "string" ? Number(value) : value;
+  return typeof num === "number" && Number.isFinite(num) ? num : null;
+};
+
+/**
+ * Validates that a dataset is usable for accessible rendering.
+ * Returns false (rather than throwing) for null/undefined/non-array/empty input
+ * so callers can render a "no data" fallback instead of crashing.
+ */
+export function isRenderableChartData(data: unknown): data is Array<Record<string, unknown>> {
+  return Array.isArray(data) && data.length > 0 && data.some(isPlainObject);
+}
+
+const round = (value: number, precision = 2): number => {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+/**
+ * Computes summary statistics (min/max/average/trend) for one series in a dataset.
+ * Non-finite / missing values are skipped rather than treated as zero, so a
+ * partially-malformed row can't silently distort the average.
+ */
+export function summarizeSeries(
+  data: unknown,
+  series: ChartSeriesConfig
+): ChartSeriesSummary {
+  const base: ChartSeriesSummary = {
+    key: series.key,
+    label: series.label || series.key,
+    unit: series.unit || "",
+    count: 0,
+    min: null,
+    max: null,
+    average: null,
+    first: null,
+    last: null,
+    trend: "unknown",
+  };
+
+  if (!isRenderableChartData(data)) return base;
+
+  const values = data
+    .map((row) => (isPlainObject(row) ? toFiniteNumber(row[series.key]) : null))
+    .filter((v): v is number => v !== null);
+
+  if (values.length === 0) return base;
+
+  const sum = values.reduce((acc, v) => acc + v, 0);
+  const first = values[0];
+  const last = values[values.length - 1];
+
+  let trend: ChartSeriesSummary["trend"] = "flat";
+  if (values.length > 1) {
+    const delta = last - first;
+    const threshold = Math.abs(first) * 0.01 || 0.01;
+    trend = delta > threshold ? "up" : delta < -threshold ? "down" : "flat";
+  }
+
+  return {
+    ...base,
+    count: values.length,
+    min: round(Math.min(...values)),
+    max: round(Math.max(...values)),
+    average: round(sum / values.length),
+    first: round(first),
+    last: round(last),
+    trend,
+  };
+}
+
+/**
+ * Builds a short, human-readable sentence describing a chart for screen
+ * readers (used as the accessible summary / aria-describedby text).
+ */
+export function describeChart(options: {
+  title: string;
+  data: unknown;
+  series: ChartSeriesConfig[];
+}): string {
+  const { title, data, series } = options;
+
+  if (!isRenderableChartData(data)) {
+    return `${title}: no data is currently available.`;
+  }
+
+  if (!Array.isArray(series) || series.length === 0) {
+    return `${title}: chart with ${data.length} data points.`;
+  }
+
+  const parts = series.map((s) => {
+    const summary = summarizeSeries(data, s);
+    if (summary.count === 0) {
+      return `${summary.label} has no numeric data`;
+    }
+    const unit = summary.unit ? ` ${summary.unit}` : "";
+    const trendWord =
+      summary.trend === "up"
+        ? "trending up"
+        : summary.trend === "down"
+          ? "trending down"
+          : "roughly flat";
+    return `${summary.label} ranges from ${summary.min}${unit} to ${summary.max}${unit}, averaging ${summary.average}${unit} and ${trendWord}`;
+  });
+
+  return `${title}: ${data.length} data points. ${parts.join("; ")}.`;
+}
+
+/**
+ * Converts a dataset into a plain headers/rows table structure suitable for
+ * rendering as an accessible HTML <table>. Falls back to an empty table for
+ * unusable input instead of throwing.
+ */
+export function buildChartTable(
+  data: unknown,
+  columns: Array<{ key: string; label?: string }>
+): ChartTable {
+  if (!isRenderableChartData(data) || !Array.isArray(columns) || columns.length === 0) {
+    return { headers: [], rows: [] };
+  }
+
+  const headers = columns.map((c) => c.label || c.key);
+  const rows = data
+    .filter(isPlainObject)
+    .map((row) =>
+      columns.map((c) => {
+        const value = row[c.key];
+        if (value === null || value === undefined) return "—";
+        return typeof value === "number" ? String(round(value)) : String(value);
+      })
+    );
+
+  return { headers, rows };
+}


### PR DESCRIPTION
## Summary

 Recharts renders to SVG with no built-in semantics, so screen reader users got nothing from any chart and keyboard-only users had no way to reach the underlying data. This adds a reusable pattern that exposes both a text summary and a full data table alongside every chart it's applied to.

- `src/utils/chartAccessibility.ts` — dependency-free helpers: `isRenderableChartData`, `summarizeSeries` (min/max/average/trend), `describeChart` (one-sentence summary), `buildChartTable` (headers/rows for an HTML table). All treat `null`/non-array/empty/non-numeric input as a normal case, not an error.
- `src/components/charts/AccessibleChart.tsx` — wrapper component that:
  - renders a visually-hidden summary wired to the chart via `aria-describedby`, plus `aria-label` on the chart region
  - renders a keyboard-operable "Show data table" button (`aria-expanded`) that reveals an accessible `<table>` with `scope="col"`/`scope="row"` headers
  - renders a `role="status"` message instead of the chart when data is missing, empty, or the wrong shape, instead of handing Recharts something it can't render
- Adopted in `AnalyticsChart.jsx`, `NetworkStats.tsx`, and `TransactionAnalyticsDashboard.tsx` as the reference implementation — the underlying Recharts trees are unchanged, only wrapped.
- `CHART_ACCESSIBILITY_GUIDE.md` documents the pattern, compatibility notes, and a migration checklist for the ~25 remaining Recharts usages across the dashboard.

## Test plan

- [x] `npx vitest run src/utils/__tests__/chartAccessibility.test.ts src/components/charts/__tests__/AccessibleChart.test.tsx` — 18 tests covering primary flow, boundary cases (single data point, empty dataset), and failure cases (non-array/`null`/non-numeric data) for both the utilities and the component
- [x] `npx tsc --noEmit` — no new type errors
- [x] `npx eslint` on all changed files — no new lint errors (only pre-existing warnings in files this PR touches)
- [ ] Manual screen reader spot-check on the three adopted charts (recommended before merge)

Closes #777