### PR TITLE
Handle browser storage quota exhaustion gracefully

### DIFF
--- a/docs/api/storage.md
+++ b/docs/api/storage.md
@@ -75,3 +75,59 @@ Returns size estimates for each store.
 const stats = await storageStats();
 // { appState: 42, apiCache: 128, offlineQueue: 3 } (entry counts)
 ```
+
+---
+
+## Quota handling
+
+Browsers cap how much a site can persist in IndexedDB and localStorage. `setStoredValue`
+and `setCachedApiResponse` — the two write paths shared by `cache.js` and `cacheManager.ts`
+— detect quota exhaustion and try to recover automatically instead of just failing:
+
+1. A write fails with a quota error.
+2. `evictSafeCacheEntries()` frees space by deleting expendable `api-cache` rows —
+   expired entries first, then the oldest still-alive ones (see `selectEvictionCandidates`
+   in `storageQuota.js`). Cache entries are safe to evict because they're re-fetchable;
+   losing one just becomes a future cache miss.
+3. The write is retried once.
+4. Either way, `notifyQuotaExceeded()` fires so the UI can tell the user what happened.
+   The `useStorageQuotaAlerts()` hook (mounted in `DashboardLayout`) subscribes to this
+   and shows a toast — "we freed up space" if the retry succeeded, or instructions to
+   clear site data manually if it didn't.
+
+If IndexedDB itself is unsupported or blocked (e.g. private browsing in some browsers),
+`setStoredValue` falls back to `localStorage`; if that also throws a quota error, the
+failure is reported the same way rather than swallowed silently.
+
+### `evictSafeCacheEntries(maxEntries?)`
+
+Manually free up space by evicting expendable `api-cache` entries. Returns the number
+of entries removed. Safe to call at any time.
+
+```js
+const freed = await evictSafeCacheEntries(100);
+```
+
+### Compatibility notes
+
+Quota-exceeded errors aren't reported identically everywhere:
+
+| Environment | Error shape |
+|---|---|
+| Chrome, Edge, Safari, current Firefox | `DOMException` with `name === 'QuotaExceededError'` |
+| Older Firefox | `name === 'NS_ERROR_DOM_QUOTA_REACHED'` (or legacy `code === 1014`) |
+| Legacy fallback | Legacy `code === 22` (`DOMException.QUOTA_EXCEEDED_ERR`) |
+
+`isQuotaExceededError()` in `storageQuota.js` checks all of the above, plus a
+message-text fallback (`/quota/i` + `/exceed|reached|full/i`) for environments that
+only surface the failure as a plain string.
+
+### Subscribing to quota events
+
+```js
+import { onQuotaExceeded } from '../lib/storageQuota.js';
+
+const unsubscribe = onQuotaExceeded(({ store, recovered, evictedCount }) => {
+  // ...
+});
+```

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "build-storybook": "storybook build",
     "docs:validate-drift": "node scripts/validate-docs-drift.mjs",
     "docs:api:generate": "node scripts/generate-api-docs.mjs",
-    "docs:validate-drift": "node scripts/validate-docs-drift.mjs",
     "api:start": "node api/server.js"
   },
   "dependencies": {
@@ -56,7 +55,6 @@
     "@sentry/react": "8.54.0",
     "@stellar/stellar-sdk": "^12.3.0",
     "@tensorflow/tfjs": "^4.22.0",
-    "@tensorflow/tfjs-node": "4.22.0",
     "@tensorflow/tfjs-node": "^4.22.0",
     "d3-array": "^3.2.4",
     "d3-force-3d": "^3.0.6",
@@ -86,7 +84,6 @@
   },
   "optionalDependencies": {
     "@ledgerhq/hw-transport-webhid": "^6.29.4",
-    "@ledgerhq/hw-transport-webusb": "^6.29.4"
     "@ledgerhq/hw-transport-webusb": "^6.29.4",
     "@stellar/ledger": "^1.0.0",
     "ioredis": "^5.4.0"

--- a/src/hooks/useStorageQuotaAlerts.ts
+++ b/src/hooks/useStorageQuotaAlerts.ts
@@ -1,0 +1,48 @@
+/**
+ * Subscribes to storage quota-exceeded events (see lib/storageQuota.js) and
+ * surfaces them as a toast notification explaining what happened and how to
+ * recover. Mount once near the app root.
+ */
+import { useEffect, useRef } from 'react';
+import { onQuotaExceeded } from '../lib/storageQuota';
+import { useNotifications } from './useNotifications';
+
+interface QuotaEvent {
+  store: string;
+  key?: string;
+  recovered: boolean;
+  evictedCount: number;
+  fallback?: string;
+}
+
+// Avoid spamming the user if several writes fail in a short window.
+const NOTIFY_THROTTLE_MS = 60_000;
+
+export function useStorageQuotaAlerts(): void {
+  const { warning } = useNotifications();
+  const lastNotifiedAt = useRef(0);
+
+  useEffect(() => {
+    return onQuotaExceeded((event: QuotaEvent) => {
+      const now = Date.now();
+      if (now - lastNotifiedAt.current < NOTIFY_THROTTLE_MS) return;
+      lastNotifiedAt.current = now;
+
+      if (event.recovered) {
+        const entries = event.evictedCount === 1 ? 'entry' : 'entries';
+        warning(
+          'Storage space freed up',
+          `Your browser's storage was full, so we cleared ${event.evictedCount} cached ${entries} to make room. Your data was saved.`,
+        );
+      } else {
+        warning(
+          'Storage is full',
+          "Your browser's storage is full and we couldn't free up enough space automatically. Try clearing this site's data in your browser settings, or free up disk space and reload.",
+          0,
+        );
+      }
+    });
+  }, [warning]);
+}
+
+export default useStorageQuotaAlerts;

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -6,7 +6,15 @@
  *   - getCachedApiResponse / setCachedApiResponse  (TTL-aware API cache in IDB)
  *   - getOfflineQueue / enqueueOfflineOp / dequeueOfflineOp  (offline write queue)
  *   - storageStats  (size estimates)
+ *   - evictSafeCacheEntries  (frees space by dropping expendable API cache rows)
+ *
+ * Quota handling: writes that fail with a storage quota error (see storageQuota.js)
+ * trigger one round of eviction of "safe" (re-fetchable) API cache entries, then
+ * retry once. If the write still fails, it falls back the same way a non-quota
+ * failure would, and `notifyQuotaExceeded` fires so the UI can inform the user.
  */
+
+import { isQuotaExceededError, selectEvictionCandidates, notifyQuotaExceeded } from './storageQuota.js';
 
 // ─── DB config ────────────────────────────────────────────────────────────────
 
@@ -97,6 +105,66 @@ async function tx(storeName, mode, fn) {
   });
 }
 
+// ─── Quota-aware write recovery ────────────────────────────────────────────────
+
+/**
+ * Free up space by evicting expendable API cache entries: expired rows first,
+ * then the oldest still-alive rows. Safe to call any time — the API cache is
+ * re-fetchable, so evicted entries just become cache misses.
+ *
+ * @param {number} [maxEntries] Upper bound on how many entries to remove
+ * @returns {Promise<number>} Number of entries actually evicted
+ */
+export async function evictSafeCacheEntries(maxEntries = 50) {
+  try {
+    const db    = await openDB();
+    const trans = db.transaction(STORES.API_CACHE, 'readwrite');
+    const store = trans.objectStore(STORES.API_CACHE);
+
+    const all = await new Promise((resolve, reject) => {
+      const req = store.getAll();
+      req.onsuccess = () => resolve(req.result || []);
+      req.onerror   = () => reject(req.error);
+    });
+
+    const toEvict = selectEvictionCandidates(all, maxEntries);
+    for (const entry of toEvict) store.delete(entry.key);
+
+    return toEvict.length;
+  } catch {
+    // Unsupported environment, or the eviction transaction itself failed —
+    // report zero freed so callers know recovery didn't happen.
+    return 0;
+  }
+}
+
+/**
+ * Run a readwrite IndexedDB transaction, and if it fails with a quota error,
+ * evict safe cache entries and retry once. Notifies subscribers either way so
+ * the UI can explain what happened. Non-quota errors are rethrown immediately.
+ *
+ * @param {string} storeName
+ * @param {(store: IDBObjectStore) => IDBRequest|void} fn
+ * @param {{ store: string, key?: string }} context
+ */
+async function writeWithQuotaRecovery(storeName, fn, context) {
+  try {
+    return await tx(storeName, 'readwrite', fn);
+  } catch (err) {
+    if (!isQuotaExceededError(err)) throw err;
+
+    const evictedCount = await evictSafeCacheEntries();
+    try {
+      const result = await tx(storeName, 'readwrite', fn);
+      notifyQuotaExceeded({ ...context, recovered: true, evictedCount });
+      return result;
+    } catch (retryErr) {
+      notifyQuotaExceeded({ ...context, recovered: false, evictedCount });
+      throw retryErr;
+    }
+  }
+}
+
 // ─── App-state store (Zustand persistence) ───────────────────────────────────
 
 export async function getStoredValue(key) {
@@ -113,9 +181,15 @@ export async function getStoredValue(key) {
 
 export async function setStoredValue(key, value) {
   try {
-    await tx(STORES.APP_STATE, 'readwrite', (s) => s.put(value, key));
+    await writeWithQuotaRecovery(STORES.APP_STATE, (s) => s.put(value, key), { store: STORES.APP_STATE, key });
   } catch {
-    try { localStorage.setItem(`idb:${key}`, JSON.stringify(value)); } catch { /* ignore */ }
+    try {
+      localStorage.setItem(`idb:${key}`, JSON.stringify(value));
+    } catch (lsErr) {
+      if (isQuotaExceededError(lsErr)) {
+        notifyQuotaExceeded({ store: STORES.APP_STATE, key, recovered: false, evictedCount: 0, fallback: 'localStorage' });
+      }
+    }
   }
 }
 
@@ -163,8 +237,8 @@ export async function getCachedApiResponse(key) {
 export async function setCachedApiResponse(key, value, ttl, tag = '') {
   try {
     const record = { key, value, expiresAt: Date.now() + ttl, tag, cachedAt: Date.now() };
-    await tx(STORES.API_CACHE, 'readwrite', (s) => s.put(record));
-  } catch { /* ignore */ }
+    await writeWithQuotaRecovery(STORES.API_CACHE, (s) => s.put(record), { store: STORES.API_CACHE, key });
+  } catch { /* ignore — the API cache is expendable; a dropped write is just a future cache miss */ }
 }
 
 /**

--- a/src/lib/storageQuota.js
+++ b/src/lib/storageQuota.js
@@ -1,0 +1,137 @@
+/**
+ * Browser Storage Quota — detection, eviction selection, and recovery notifications
+ *
+ * Browsers throw different errors when persistent storage (IndexedDB, localStorage)
+ * runs out of quota:
+ *   - Modern browsers (Chrome, Edge, Safari, current Firefox): a `DOMException`
+ *     with `name === 'QuotaExceededError'` (and legacy `code === 22`).
+ *   - Older Firefox: `name === 'NS_ERROR_DOM_QUOTA_REACHED'` (and legacy `code === 1014`).
+ *
+ * This module is DOM/IndexedDB-agnostic on purpose so it can be unit tested without
+ * a real (or faked) IndexedDB implementation. `storage.js` uses it to detect quota
+ * errors on writes, decide which "safe" (re-fetchable) cache entries to evict first,
+ * and notify subscribers so the UI can explain recovery options to the user.
+ */
+
+const QUOTA_ERROR_NAMES = new Set(['QuotaExceededError', 'NS_ERROR_DOM_QUOTA_REACHED']);
+const QUOTA_ERROR_CODES = new Set([22, 1014]);
+
+/**
+ * Determine whether an error represents a storage quota exhaustion failure.
+ * Handles missing/invalid input gracefully (returns false rather than throwing).
+ * @param {*} error
+ * @returns {boolean}
+ */
+export function isQuotaExceededError(error) {
+  if (!error || typeof error !== 'object') return false;
+
+  if (typeof error.name === 'string' && QUOTA_ERROR_NAMES.has(error.name)) return true;
+  if (typeof error.code === 'number' && QUOTA_ERROR_CODES.has(error.code)) return true;
+
+  // Last resort: some environments only surface this in the message text.
+  if (typeof error.message === 'string') {
+    const message = error.message.toLowerCase();
+    if (message.includes('quota') && (message.includes('exceed') || message.includes('reached') || message.includes('full'))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Pick which cache records to evict to free up quota, given a maximum number
+ * of entries to remove. Expired entries are evicted first (no cost to the user),
+ * then the oldest still-alive entries (least likely to be reused soon).
+ *
+ * Pure function — no IndexedDB dependency — so it's independently testable.
+ *
+ * @param {Array<{ key: string, expiresAt: number, cachedAt: number }>} records
+ * @param {number} maxEntries  Maximum number of entries to select for eviction
+ * @param {number} [now]       Injectable clock for deterministic tests
+ * @returns {Array<{ key: string, expiresAt: number, cachedAt: number }>}
+ */
+export function selectEvictionCandidates(records, maxEntries, now = Date.now()) {
+  if (!Array.isArray(records) || maxEntries <= 0) return [];
+
+  const expired = records.filter((r) => r.expiresAt <= now);
+  const alive = records
+    .filter((r) => r.expiresAt > now)
+    .sort((a, b) => a.cachedAt - b.cachedAt);
+
+  return [...expired, ...alive].slice(0, maxEntries);
+}
+
+/**
+ * Whether the current environment supports querying storage usage/quota.
+ * @returns {boolean}
+ */
+export function isStorageEstimateSupported() {
+  return typeof navigator !== 'undefined' &&
+    !!navigator.storage &&
+    typeof navigator.storage.estimate === 'function';
+}
+
+/**
+ * Read the browser's storage usage estimate, if supported.
+ * Returns null in unsupported environments or on failure — never throws.
+ * @returns {Promise<{ usage: number, quota: number, usageRatio: number }|null>}
+ */
+export async function getStorageEstimate() {
+  if (!isStorageEstimateSupported()) return null;
+  try {
+    const { usage = 0, quota = 0 } = await navigator.storage.estimate();
+    return { usage, quota, usageRatio: quota > 0 ? usage / quota : 0 };
+  } catch {
+    return null;
+  }
+}
+
+// ─── Recovery notifications ────────────────────────────────────────────────────
+// Plain pub/sub so this module has no React dependency. UI layers (e.g. a hook)
+// subscribe to explain recovery options to the user when quota is exhausted.
+
+const listeners = new Set();
+
+/**
+ * @typedef {Object} QuotaEvent
+ * @property {string} store            Which store the write targeted (e.g. 'api-cache')
+ * @property {string} [key]            The key being written, if applicable
+ * @property {boolean} recovered       Whether eviction + retry freed enough space
+ * @property {number} evictedCount     Number of entries evicted during recovery
+ * @property {string} [fallback]       Fallback storage used, if any (e.g. 'localStorage')
+ */
+
+/**
+ * Subscribe to quota-exceeded events.
+ * @param {(event: QuotaEvent) => void} listener
+ * @returns {() => void} Unsubscribe function
+ */
+export function onQuotaExceeded(listener) {
+  if (typeof listener !== 'function') return () => {};
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * Emit a quota-exceeded event to all subscribers. Listener errors are swallowed
+ * so a broken subscriber can never break a storage write.
+ * @param {QuotaEvent} event
+ */
+export function notifyQuotaExceeded(event) {
+  for (const listener of listeners) {
+    try {
+      listener(event);
+    } catch {
+      // A subscriber (e.g. a UI toast) must never break the storage layer.
+    }
+  }
+}
+
+/**
+ * Remove all subscribers. Exposed for test teardown.
+ * @internal
+ */
+export function _resetQuotaListeners() {
+  listeners.clear();
+}

--- a/src/routes/DashboardLayout.tsx
+++ b/src/routes/DashboardLayout.tsx
@@ -43,6 +43,7 @@ import DebugAssistantButton from '../components/debug/DebugAssistantButton';
 import DebugAssistantPanel from '../components/debug/DebugAssistantPanel';
 import ConversationPanel from '../components/conversation/ConversationPanel';
 import { useRouteFocus } from '../hooks/useRouteFocus';
+import { useStorageQuotaAlerts } from '../hooks/useStorageQuotaAlerts';
 
 interface SearchResult {
   type?: string;
@@ -248,6 +249,7 @@ export default function DashboardLayout() {
   const preferencesTriggerRef = React.useRef<HTMLButtonElement>(null);
 
   useRouteFocus(activeTab);
+  useStorageQuotaAlerts();
 
   useEffect(() => {
     // v2: full multi-layer cache initialization (warm, prune, SW bridge)

--- a/tests/unit/hooks/useStorageQuotaAlerts.test.tsx
+++ b/tests/unit/hooks/useStorageQuotaAlerts.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { notifyQuotaExceeded, _resetQuotaListeners } from '../../../src/lib/storageQuota';
+import { useStore } from '../../../src/lib/store';
+import { useStorageQuotaAlerts } from '../../../src/hooks/useStorageQuotaAlerts';
+
+describe('useStorageQuotaAlerts', () => {
+  beforeEach(() => {
+    useStore.setState({ notifications: [], notificationHistory: [] });
+  });
+
+  afterEach(() => {
+    _resetQuotaListeners();
+    vi.restoreAllMocks();
+  });
+
+  it('shows a recovery notification when eviction freed enough space (primary flow)', () => {
+    renderHook(() => useStorageQuotaAlerts());
+
+    act(() => {
+      notifyQuotaExceeded({ store: 'api-cache', key: 'account:GABC', recovered: true, evictedCount: 5 });
+    });
+
+    const { notifications } = useStore.getState();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({ type: 'warning', title: 'Storage space freed up' });
+    expect(notifications[0].message).toContain('5');
+  });
+
+  it('shows a persistent recovery-options notification when eviction could not free enough space (failure case)', () => {
+    renderHook(() => useStorageQuotaAlerts());
+
+    act(() => {
+      notifyQuotaExceeded({ store: 'app-state', key: 'theme', recovered: false, evictedCount: 0 });
+    });
+
+    const { notifications } = useStore.getState();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({ type: 'warning', title: 'Storage is full', timeout: 0 });
+  });
+
+  it('throttles repeated events so the user is not spammed (boundary case)', () => {
+    renderHook(() => useStorageQuotaAlerts());
+
+    act(() => {
+      notifyQuotaExceeded({ store: 'api-cache', recovered: true, evictedCount: 1 });
+      notifyQuotaExceeded({ store: 'api-cache', recovered: true, evictedCount: 2 });
+      notifyQuotaExceeded({ store: 'api-cache', recovered: true, evictedCount: 3 });
+    });
+
+    expect(useStore.getState().notifications).toHaveLength(1);
+  });
+
+  it('unsubscribes on unmount so later events produce no notification', () => {
+    const { unmount } = renderHook(() => useStorageQuotaAlerts());
+    unmount();
+
+    act(() => {
+      notifyQuotaExceeded({ store: 'api-cache', recovered: true, evictedCount: 1 });
+    });
+
+    expect(useStore.getState().notifications).toHaveLength(0);
+  });
+});

--- a/tests/unit/lib/storage.quota.test.js
+++ b/tests/unit/lib/storage.quota.test.js
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * These tests exercise storage.js's quota-recovery integration: a write that
+ * fails with a quota error should trigger eviction of safe API cache entries
+ * and one retry, and should notify subscribers either way.
+ *
+ * jsdom doesn't ship a real IndexedDB implementation, so we install a small
+ * fake `global.indexedDB` — just enough of the API surface storage.js uses
+ * (open/transaction/objectStore/put/get/getAll/delete) — and control exactly
+ * when a `put()` call fails with a quota error via `armQuotaFailures()`.
+ */
+
+function makeRequest() {
+  return { result: undefined, error: undefined, onsuccess: null, onerror: null };
+}
+
+function resolveRequest(req, result) {
+  req.result = result;
+  queueMicrotask(() => req.onsuccess && req.onsuccess({ target: req }));
+}
+
+function rejectRequest(req, error) {
+  req.error = error;
+  queueMicrotask(() => req.onerror && req.onerror({ target: req }));
+}
+
+function quotaError() {
+  return new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+}
+
+class FakeStore {
+  constructor(name, opts = {}) {
+    this.name = name;
+    this.keyPath = opts.keyPath;
+    this.data = new Map();
+    this._failPutTimes = 0;
+  }
+
+  armQuotaFailures(times) {
+    this._failPutTimes = times;
+  }
+
+  createIndex() { /* not needed for the write paths under test */ }
+
+  put(value, key) {
+    const req = makeRequest();
+    const resolvedKey = this.keyPath ? value[this.keyPath] : key;
+    if (this._failPutTimes > 0) {
+      this._failPutTimes -= 1;
+      rejectRequest(req, quotaError());
+      return req;
+    }
+    this.data.set(resolvedKey, value);
+    resolveRequest(req, resolvedKey);
+    return req;
+  }
+
+  get(key) {
+    const req = makeRequest();
+    resolveRequest(req, this.data.get(key));
+    return req;
+  }
+
+  getAll() {
+    const req = makeRequest();
+    resolveRequest(req, Array.from(this.data.values()));
+    return req;
+  }
+
+  delete(key) {
+    const req = makeRequest();
+    this.data.delete(key);
+    resolveRequest(req, undefined);
+    return req;
+  }
+
+  clear() {
+    const req = makeRequest();
+    this.data.clear();
+    resolveRequest(req, undefined);
+    return req;
+  }
+
+  count() {
+    const req = makeRequest();
+    resolveRequest(req, this.data.size);
+    return req;
+  }
+}
+
+class FakeDB {
+  constructor() {
+    this._stores = new Map();
+    this.onversionchange = null;
+    this.objectStoreNames = { contains: (n) => this._stores.has(n) };
+  }
+
+  createObjectStore(name, opts) {
+    const store = new FakeStore(name, opts);
+    this._stores.set(name, store);
+    return store;
+  }
+
+  transaction() {
+    const db = this;
+    return { objectStore: (n) => db._stores.get(n) };
+  }
+
+  close() {}
+}
+
+function installFakeIndexedDB() {
+  const db = new FakeDB();
+  global.indexedDB = {
+    open() {
+      const req = { onupgradeneeded: null, onsuccess: null, onerror: null, onblocked: null, result: db };
+      queueMicrotask(() => {
+        req.onupgradeneeded && req.onupgradeneeded({ target: { result: db } });
+        req.onsuccess && req.onsuccess({ target: req });
+      });
+      return req;
+    },
+  };
+  return db;
+}
+
+describe('storage.js quota recovery', () => {
+  let db;
+  let localStorageStore;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    db = installFakeIndexedDB();
+
+    localStorageStore = new Map();
+    global.localStorage = {
+      getItem: (k) => (localStorageStore.has(k) ? localStorageStore.get(k) : null),
+      setItem: (k, v) => localStorageStore.set(k, String(v)),
+      removeItem: (k) => localStorageStore.delete(k),
+      clear: () => localStorageStore.clear(),
+    };
+  });
+
+  afterEach(() => {
+    delete global.indexedDB;
+    vi.restoreAllMocks();
+  });
+
+  it('evicts safe cache entries and retries once after a quota error (primary flow)', async () => {
+    const storage = await import('../../../src/lib/storage.js');
+    const { onQuotaExceeded } = await import('../../../src/lib/storageQuota.js');
+
+    // Seed some evictable API cache entries so eviction has something to remove.
+    await storage.setCachedApiResponse('old-1', { a: 1 }, 60_000, 'accounts');
+    await storage.setCachedApiResponse('old-2', { a: 2 }, 60_000, 'accounts');
+
+    const events = [];
+    onQuotaExceeded((e) => events.push(e));
+
+    // Fail the first write to app-state with a quota error, succeed on retry.
+    db._stores.get('app-state').armQuotaFailures(1);
+
+    await storage.setStoredValue('theme', 'dark');
+
+    expect(await storage.getStoredValue('theme')).toBe('dark');
+    expect(events).toEqual([
+      expect.objectContaining({ store: 'app-state', key: 'theme', recovered: true }),
+    ]);
+  });
+
+  it('falls back to localStorage when eviction cannot free enough space (boundary case)', async () => {
+    const storage = await import('../../../src/lib/storage.js');
+    const { onQuotaExceeded } = await import('../../../src/lib/storageQuota.js');
+
+    // Force the DB (and its stores) into existence before arming failures.
+    await storage.getStoredValue('__warm__');
+
+    // No API cache entries exist to evict, and every app-state write keeps failing.
+    const appState = db._stores.get('app-state');
+    appState.armQuotaFailures(Infinity);
+
+    const events = [];
+    onQuotaExceeded((e) => events.push(e));
+
+    await storage.setStoredValue('theme', 'dark');
+
+    expect(events).toEqual([
+      expect.objectContaining({ store: 'app-state', key: 'theme', recovered: false }),
+    ]);
+    // The value still landed via the localStorage fallback.
+    expect(JSON.parse(global.localStorage.getItem('idb:theme'))).toBe('dark');
+  });
+
+  it('notifies with recovered:false and does not throw when every layer is out of quota (failure case)', async () => {
+    const storage = await import('../../../src/lib/storage.js');
+    const { onQuotaExceeded } = await import('../../../src/lib/storageQuota.js');
+
+    // Force the DB (and its stores) into existence before arming failures.
+    await storage.getStoredValue('__warm__');
+
+    db._stores.get('app-state').armQuotaFailures(Infinity);
+    global.localStorage.setItem = () => { throw new DOMException('quota exceeded', 'QuotaExceededError'); };
+
+    const events = [];
+    onQuotaExceeded((e) => events.push(e));
+
+    await expect(storage.setStoredValue('theme', 'dark')).resolves.toBeUndefined();
+
+    // One event for the failed IDB retry, one for the failed localStorage fallback.
+    expect(events).toEqual([
+      expect.objectContaining({ store: 'app-state', key: 'theme', recovered: false }),
+      expect.objectContaining({ store: 'app-state', key: 'theme', recovered: false, fallback: 'localStorage' }),
+    ]);
+  });
+
+  it('leaves invalid/unsupported-environment writes as silent no-ops, matching prior behavior', async () => {
+    delete global.indexedDB;
+    global.localStorage.setItem = () => { throw new Error('private mode'); };
+
+    const storage = await import('../../../src/lib/storage.js');
+
+    await expect(storage.setStoredValue('theme', 'dark')).resolves.toBeUndefined();
+    expect(await storage.getStoredValue('theme')).toBeNull();
+  });
+});

--- a/tests/unit/lib/storageQuota.test.js
+++ b/tests/unit/lib/storageQuota.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  isQuotaExceededError,
+  selectEvictionCandidates,
+  isStorageEstimateSupported,
+  getStorageEstimate,
+  onQuotaExceeded,
+  notifyQuotaExceeded,
+  _resetQuotaListeners,
+} from '../../../src/lib/storageQuota.js';
+
+describe('isQuotaExceededError', () => {
+  it('detects the modern DOMException name (primary flow)', () => {
+    const err = new DOMException('The quota has been exceeded.', 'QuotaExceededError');
+    expect(isQuotaExceededError(err)).toBe(true);
+  });
+
+  it('detects the legacy Firefox error name', () => {
+    expect(isQuotaExceededError({ name: 'NS_ERROR_DOM_QUOTA_REACHED' })).toBe(true);
+  });
+
+  it('detects the legacy numeric error codes', () => {
+    expect(isQuotaExceededError({ code: 22 })).toBe(true);
+    expect(isQuotaExceededError({ code: 1014 })).toBe(true);
+  });
+
+  it('falls back to sniffing the message when name/code are absent', () => {
+    expect(isQuotaExceededError({ message: 'Storage quota exceeded for this origin' })).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isQuotaExceededError(new TypeError('boom'))).toBe(false);
+    expect(isQuotaExceededError({ name: 'NotFoundError' })).toBe(false);
+  });
+
+  it('handles invalid input without throwing (boundary case)', () => {
+    expect(isQuotaExceededError(null)).toBe(false);
+    expect(isQuotaExceededError(undefined)).toBe(false);
+    expect(isQuotaExceededError('QuotaExceededError')).toBe(false);
+    expect(isQuotaExceededError(42)).toBe(false);
+  });
+});
+
+describe('selectEvictionCandidates', () => {
+  const now = 1_000_000;
+
+  it('prefers expired entries over the oldest alive ones (primary flow)', () => {
+    const records = [
+      { key: 'alive-old', expiresAt: now + 10_000, cachedAt: now - 5_000 },
+      { key: 'expired-1', expiresAt: now - 1_000, cachedAt: now - 20_000 },
+      { key: 'alive-new', expiresAt: now + 20_000, cachedAt: now - 1_000 },
+      { key: 'expired-2', expiresAt: now - 500, cachedAt: now - 10_000 },
+    ];
+
+    const evicted = selectEvictionCandidates(records, 3, now);
+
+    expect(evicted.map((r) => r.key)).toEqual(['expired-1', 'expired-2', 'alive-old']);
+  });
+
+  it('returns an empty array when there is nothing to evict (boundary case)', () => {
+    expect(selectEvictionCandidates([], 10, now)).toEqual([]);
+    expect(selectEvictionCandidates([{ key: 'a', expiresAt: now + 1, cachedAt: now }], 0, now)).toEqual([]);
+  });
+
+  it('handles invalid input without throwing (failure case)', () => {
+    expect(selectEvictionCandidates(null, 5, now)).toEqual([]);
+    expect(selectEvictionCandidates(undefined, 5, now)).toEqual([]);
+  });
+});
+
+describe('storage estimate', () => {
+  const originalStorage = globalThis.navigator?.storage;
+
+  afterEach(() => {
+    if (globalThis.navigator) {
+      Object.defineProperty(globalThis.navigator, 'storage', {
+        value: originalStorage,
+        configurable: true,
+      });
+    }
+  });
+
+  it('reports supported and returns usage/quota when available (primary flow)', async () => {
+    Object.defineProperty(globalThis.navigator, 'storage', {
+      value: { estimate: vi.fn().mockResolvedValue({ usage: 50, quota: 200 }) },
+      configurable: true,
+    });
+
+    expect(isStorageEstimateSupported()).toBe(true);
+    await expect(getStorageEstimate()).resolves.toEqual({ usage: 50, quota: 200, usageRatio: 0.25 });
+  });
+
+  it('reports unsupported and returns null in environments without navigator.storage (failure case)', async () => {
+    Object.defineProperty(globalThis.navigator, 'storage', { value: undefined, configurable: true });
+
+    expect(isStorageEstimateSupported()).toBe(false);
+    await expect(getStorageEstimate()).resolves.toBeNull();
+  });
+
+  it('returns null instead of throwing if estimate() rejects', async () => {
+    Object.defineProperty(globalThis.navigator, 'storage', {
+      value: { estimate: vi.fn().mockRejectedValue(new Error('nope')) },
+      configurable: true,
+    });
+
+    await expect(getStorageEstimate()).resolves.toBeNull();
+  });
+});
+
+describe('quota event pub/sub', () => {
+  afterEach(() => _resetQuotaListeners());
+
+  it('delivers events to subscribers (primary flow)', () => {
+    const listener = vi.fn();
+    onQuotaExceeded(listener);
+
+    const event = { store: 'api-cache', recovered: true, evictedCount: 3 };
+    notifyQuotaExceeded(event);
+
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it('stops delivering events after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = onQuotaExceeded(listener);
+    unsubscribe();
+
+    notifyQuotaExceeded({ store: 'api-cache', recovered: false, evictedCount: 0 });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('never lets a broken subscriber throw out of notifyQuotaExceeded (failure case)', () => {
+    onQuotaExceeded(() => { throw new Error('broken listener'); });
+
+    expect(() => notifyQuotaExceeded({ store: 'api-cache', recovered: false, evictedCount: 0 })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

Browser storage writes (IndexedDB, with a localStorage fallback) had no handling for quota exhaustion. When a user's storage quota fills up, `setStoredValue`/`setCachedApiResponse` in `src/lib/storage.js` — the write path shared by `cache.js` and `cacheManager.ts` — just swallowed the error and silently dropped the write, with no attempt to recover and no way for the user to know why their data wasn't persisting.

| Scenario | Before | After |
|---|---|---|
| Quota exceeded on a persistence-layer write (`setStoredValue`) | Write silently dropped | Evicts expendable cache entries, retries once, notifies the user either way |
| Quota exceeded on an API cache write (`setCachedApiResponse`) | Write silently dropped | Same eviction + retry (cache entries are the "safe" thing being evicted, so this is self-healing) |
| IndexedDB unsupported/blocked (e.g. some private-browsing modes) | Falls back to localStorage | Unchanged, but a quota failure in the fallback is now also detected and reported |
| Different browsers' quota error shapes (Chrome/Edge/Safari vs. older Firefox) | N/A | `isQuotaExceededError()` recognizes both, plus legacy numeric codes and a message-text fallback |

## Solution

Detect quota errors at the point of failure, evict "safe" (re-fetchable) API cache entries to free space, retry the write once, and notify subscribers of the outcome so the UI can explain what happened and what the user can do about it.

## Changes

- **`src/lib/storageQuota.js`** (new) — DOM/IndexedDB-independent utilities: `isQuotaExceededError()` (covers `QuotaExceededError`, legacy Firefox `NS_ERROR_DOM_QUOTA_REACHED`, legacy codes 22/1014, message-text fallback), `selectEvictionCandidates()` (pure eviction-ordering logic: expired entries first, then oldest-first), `getStorageEstimate()`/`isStorageEstimateSupported()`, and a small pub/sub (`onQuotaExceeded`/`notifyQuotaExceeded`) so this logic has no React dependency and is independently unit-testable.
- **`src/lib/storage.js`** — `setStoredValue()` and `setCachedApiResponse()` now route writes through a new `writeWithQuotaRecovery()` helper: on a quota error, call the new `evictSafeCacheEntries()` (deletes expired/oldest `api-cache` rows), retry once, and emit a `notifyQuotaExceeded` event either way. The existing localStorage fallback behavior is preserved; a quota failure there is now also detected and reported instead of silently ignored.
- **`src/hooks/useStorageQuotaAlerts.ts`** (new) — subscribes to quota events and shows a throttled (60s) toast via the existing `useNotifications` system: "we freed up space" when recovery succeeded, or instructions to clear site data manually when it didn't.
- **`src/routes/DashboardLayout.tsx`** — mounts `useStorageQuotaAlerts()` alongside the other global-concern hooks already wired in there (2-line addition).
- **`docs/api/storage.md`** — new "Quota handling" section documenting the recovery flow, a browser compatibility table for quota error shapes, and a subscription example.
- **`package.json`** — separate, unrelated fix (see Notes for Reviewers).

## Regression Tests

| Acceptance criterion | Covered by |
|---|---|
| Clear handling for invalid input | `storageQuota.test.js`: `isQuotaExceededError`/`selectEvictionCandidates` handle `null`/`undefined`/non-object input without throwing |
| Clear handling for unsupported environments | `storageQuota.test.js`: `getStorageEstimate()` returns `null` when `navigator.storage` is absent; `storage.quota.test.js`: writes still no-op safely with no `indexedDB` global |
| Clear handling for failure paths | `storage.quota.test.js`: quota error on both IndexedDB and the localStorage fallback resolves without throwing and still notifies `recovered:false` |
| Primary flow | `storage.quota.test.js`: quota error → eviction → retry → write succeeds; `useStorageQuotaAlerts.test.tsx`: recovery toast shown |
| Boundary case | `storage.quota.test.js`: nothing evictable → falls back to localStorage; `useStorageQuotaAlerts.test.tsx`: repeated events throttled to one toast |
| User-facing documentation updated | `docs/api/storage.md` "Quota handling" section |

## Testing

```
$ npx vitest run tests/unit/lib/storageQuota.test.js tests/unit/lib/storage.quota.test.js tests/unit/hooks/useStorageQuotaAlerts.test.tsx tests/unit/lib/cacheManager.test.ts tests/unit/cacheOptimization.test.ts

 ✓ tests/unit/lib/storageQuota.test.js (15 tests)
 ✓ tests/unit/lib/storage.quota.test.js (4 tests)
 ✓ tests/unit/lib/cacheManager.test.ts (13 tests)
 ✓ tests/unit/cacheOptimization.test.ts (4 tests)
 ✓ tests/unit/hooks/useStorageQuotaAlerts.test.tsx (4 tests)

 Test Files  5 passed (5)
      Tests  40 passed (40)
```

ESLint on all new/changed files: clean, no errors or warnings.

## Notes for Reviewers

- **`package.json` fix is unrelated to this issue but necessary for CI to run at all.** `upstream/master`'s `package.json` currently has invalid JSON (duplicate `@tensorflow/tfjs-node` and `@ledgerhq/hw-transport-webusb` keys, with a missing comma before the latter), which makes `npm`/`vitest`/esbuild fail to even parse the file — blocking install, build, and test for *any* PR against this repo, not just this one. I kept it as its own commit so it's easy to review/drop separately if you're already fixing it elsewhere.
- **`npm run type-check` will very likely still fail in CI, for reasons predating this PR and unrelated to it.** `DashboardLayout.tsx` on `master` already references `useExpertise`, `ExpertiseBadge`, `TipButton`, and `PredictiveFeatureSuggestions` without importing them (the symbols exist elsewhere in the repo — the imports appear to have been dropped, possibly in a merge), and destructures `debugAssistantOpen`/`debugAssistantIssueCount`/`toggleDebugAssistant` from the store even though `store.ts` doesn't define them. I confirmed (via `git stash`) these errors are identical before and after this PR's changes, so I left them out of scope rather than expand this PR into an unrelated repair — flagging here so it's not mistaken for something this PR broke.
- I scoped quota recovery to the two write paths that `cache.js` and `cacheManager.ts` actually route through (`setStoredValue`, `setCachedApiResponse`), since that's where the app's caching layer funnels all its persistent writes. The other IndexedDB stores in `storage.js` (offline queue, contract history, biometric profiles) weren't touched — they're lower-volume and outside the "caching" surface the issue calls out.

Closes #750