### PR TITLE
feat: implement performance budgets, SEP-0002 federation, timebounds …

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ml:backup:train": "node src/ml/backup/train.js",
     "ml:backup:server": "node src/ml/backup/server.js",
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/check-bundle-budgets.mjs",
     "build:analyze": "ANALYZE=1 vite build",
     "preview": "vite preview",
     "lint": "eslint .",
@@ -86,7 +86,6 @@
   },
   "optionalDependencies": {
     "@ledgerhq/hw-transport-webhid": "^6.29.4",
-    "@ledgerhq/hw-transport-webusb": "^6.29.4"
     "@ledgerhq/hw-transport-webusb": "^6.29.4",
     "@stellar/ledger": "^1.0.0",
     "ioredis": "^5.4.0"

--- a/scripts/check-bundle-budgets.mjs
+++ b/scripts/check-bundle-budgets.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { readdirSync, statSync, readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import zlib from 'node:zlib';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const DIST_ASSETS = join(ROOT, 'dist', 'assets');
+
+// Budgets in KB (compressed)
+const BUDGETS = {
+  'vendor': 500,
+  'react-vendor': 200,
+  'charts-vendor': 350,
+  'stellar-sdk': 400,
+  'index': 100, // Initial shell
+  'default': 150 // Route chunks / lazy chunks
+};
+
+function checkBudgets() {
+  console.log('Checking bundle budgets...');
+  
+  try {
+    const files = readdirSync(DIST_ASSETS).filter(f => f.endsWith('.js'));
+    let hasFailures = false;
+
+    for (const file of files) {
+      const filePath = join(DIST_ASSETS, file);
+      const content = readFileSync(filePath);
+      const gzipped = zlib.gzipSync(content);
+      const sizeKB = gzipped.length / 1024;
+
+      // Extract chunk name: chunkName-[hash].js
+      const chunkNameMatch = file.match(/^(.+)-[a-f0-9]+\.js$/);
+      const chunkName = chunkNameMatch ? chunkNameMatch[1] : 'unknown';
+
+      const budget = BUDGETS[chunkName] || BUDGETS['default'];
+
+      if (sizeKB > budget) {
+        console.error(`❌ Budget Exceeded: ${file} is ${sizeKB.toFixed(2)} KB (Limit: ${budget} KB)`);
+        hasFailures = true;
+      } else {
+        console.log(`✅ ${file}: ${sizeKB.toFixed(2)} KB (Limit: ${budget} KB)`);
+      }
+    }
+
+    if (hasFailures) {
+      console.error('\nBundle budget check failed. Please optimize your imports.');
+      process.exit(1);
+    } else {
+      console.log('\nAll bundle budgets passed!');
+    }
+  } catch (error) {
+    console.error('Failed to analyze bundles:', error);
+    process.exit(1);
+  }
+}
+
+checkBudgets();

--- a/src/components/dashboard/TransactionBuilder.tsx
+++ b/src/components/dashboard/TransactionBuilder.tsx
@@ -7,10 +7,146 @@ import {
   getCachedUserTransactionTemplates,
   upsertUserTransactionTemplate,
 } from "../../lib/transactionTemplateVault.ts";
-import { fetchContractData } from "../../lib/stellar";
+import { fetchContractData, resolveFederatedAddress } from "../../lib/stellar";
 import { useTransactionHistory } from "../../lib/txHistory";
 import { Copy, Play, Download, AlertCircle, CheckCircle, ArrowDown, GripVertical, Trash2, Plus, Zap } from "lucide-react";
 import { useExpertise } from "../../context/ExpertiseContext";
+
+function FederatedAddressInput({ value, onChange, placeholder, style, network, hasError }) {
+  const [inputValue, setInputValue] = useState(value);
+  const [resolvedData, setResolvedData] = useState(null);
+  const [isResolving, setIsResolving] = useState(false);
+  const [error, setError] = useState(null);
+  const [confirmed, setConfirmed] = useState(false);
+
+  useEffect(() => {
+    if (value !== inputValue && !confirmed) {
+      setInputValue(value || "");
+      setConfirmed(false);
+      setResolvedData(null);
+      setError(null);
+    }
+  }, [value]);
+
+  async function handleResolve(e) {
+    e.preventDefault();
+    if (!inputValue.includes('*')) return;
+    setIsResolving(true);
+    setError(null);
+    try {
+      const result = await resolveFederatedAddress(inputValue, network);
+      if (result && (result.account_id || result.accountId)) {
+        setResolvedData(result);
+      } else {
+        setError("Could not resolve address");
+      }
+    } catch (e) {
+      setError(e.message || "Resolution failed");
+    } finally {
+      setIsResolving(false);
+    }
+  }
+
+  function handleConfirm(e) {
+    e.preventDefault();
+    if (resolvedData) {
+      setConfirmed(true);
+      const address = resolvedData.account_id || resolvedData.accountId;
+      onChange(address);
+      setInputValue(address);
+      setResolvedData(null);
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', width: '100%' }}>
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <input 
+          value={inputValue}
+          onChange={(e) => {
+             setInputValue(e.target.value);
+             setConfirmed(false);
+             setResolvedData(null);
+             setError(null);
+             onChange(e.target.value);
+          }}
+          placeholder={placeholder}
+          style={{ ...style, flex: 1, ...(hasError ? { borderColor: 'var(--red)' } : {}) }}
+        />
+        {inputValue.includes('*') && !confirmed && !resolvedData && (
+          <button onClick={handleResolve} disabled={isResolving} style={{ padding: '0 12px', borderRadius: '4px', background: 'var(--bg-elevated)', color: 'var(--text-primary)', border: '1px solid var(--border)', fontSize: '12px', cursor: 'pointer' }}>
+            {isResolving ? '...' : 'Resolve'}
+          </button>
+        )}
+      </div>
+      {error && <div style={{ color: 'var(--red)', fontSize: '11px' }}>{error}</div>}
+      {resolvedData && !confirmed && (
+        <div style={{ background: 'var(--bg-elevated)', border: '1px solid var(--cyan)', padding: '8px', borderRadius: '4px', fontSize: '11px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div>
+            <span style={{ color: 'var(--text-muted)' }}>Resolved: </span>
+            <span style={{ fontFamily: 'var(--font-mono)' }}>{resolvedData.account_id || resolvedData.accountId}</span>
+          </div>
+          <button onClick={handleConfirm} style={{ background: 'var(--cyan)', color: 'var(--bg-base)', border: 'none', padding: '4px 8px', borderRadius: '4px', cursor: 'pointer', fontWeight: 'bold' }}>
+            Confirm
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TimeboundsPreset({ timeout, setTimeout }) {
+  const absoluteTime = useMemo(() => {
+    const s = parseInt(timeout);
+    if (isNaN(s)) return null;
+    return new Date(Date.now() + s * 1000);
+  }, [timeout]);
+
+  const isExpired = absoluteTime ? absoluteTime.getTime() <= Date.now() : false;
+  const isTooShort = absoluteTime ? absoluteTime.getTime() <= Date.now() + 60000 : false; // < 1 min warning
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', width: '100%' }}>
+      <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+        {[
+          { label: '5m', val: '300' },
+          { label: '15m', val: '900' },
+          { label: '1h', val: '3600' },
+          { label: '1d', val: '86400' },
+        ].map((preset) => (
+          <button
+            key={preset.label}
+            onClick={() => setTimeout(preset.val)}
+            style={{
+              padding: '4px 8px',
+              fontSize: '11px',
+              borderRadius: '4px',
+              border: timeout === preset.val ? '1px solid var(--cyan)' : '1px solid var(--border)',
+              background: timeout === preset.val ? 'var(--cyan-glow)' : 'var(--bg-elevated)',
+              color: timeout === preset.val ? 'var(--cyan)' : 'var(--text-secondary)',
+              cursor: 'pointer'
+            }}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+      {absoluteTime && (
+        <div style={{ 
+          fontSize: '11px', 
+          color: isExpired || isTooShort ? 'var(--red)' : 'var(--text-muted)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px'
+        }}>
+          {isExpired || isTooShort ? <AlertCircle size={12} /> : null}
+          Expires at {absoluteTime.toLocaleTimeString()} {isExpired ? '(Expired)' : isTooShort ? '(Too short!)' : ''}
+        </div>
+      )}
+    </div>
+  );
+}
+
 
 function Panel({ title, subtitle, children }) {
   return (
@@ -144,7 +280,7 @@ export default function TransactionBuilder() {
   const [memo, setMemo] = useState("");
   const [memoType, setMemoType] = useState("text");
   const [baseFee, setBaseFee] = useState("100");
-  const [timeout, setTimeout] = useState("180");
+  const [timeout, setTimeout] = useState("300");
   const [operations, setOperations] = useState([
     {
       id: Date.now(),
@@ -304,7 +440,7 @@ export default function TransactionBuilder() {
     setMemo(snap.memo || "");
     setMemoType(snap.memoType || "text");
     setBaseFee(snap.baseFee || "100");
-    setTimeout(snap.timeout || "180");
+    setTimeout(snap.timeout || "300");
     setOperations((snap.operations || []).map((op) => ({ ...op, id: op.id || Date.now() + Math.random() })));
   }
 
@@ -401,13 +537,15 @@ export default function TransactionBuilder() {
         return (
           <>
             <LabeledField label="Destination">
-              <input
+              <FederatedAddressInput
                 value={op.params.destination || ""}
-                onChange={(e) =>
-                  updateOperation(op.id, "destination", e.target.value)
+                onChange={(val) =>
+                  updateOperation(op.id, "destination", val)
                 }
-                placeholder="G... destination address"
+                placeholder="G... destination address (or name*domain)"
                 style={textInputStyle(hasErrors)}
+                network={network}
+                hasError={hasErrors}
               />
             </LabeledField>
             <LabeledField label="Amount">
@@ -427,13 +565,15 @@ export default function TransactionBuilder() {
         return (
           <>
             <LabeledField label="Destination">
-              <input
+              <FederatedAddressInput
                 value={op.params.destination || ""}
-                onChange={(e) =>
-                  updateOperation(op.id, "destination", e.target.value)
+                onChange={(val) =>
+                  updateOperation(op.id, "destination", val)
                 }
-                placeholder="G... new account address"
+                placeholder="G... new account address (or name*domain)"
                 style={textInputStyle(hasErrors)}
+                network={network}
+                hasError={hasErrors}
               />
             </LabeledField>
             <LabeledField label="Starting Balance">
@@ -463,13 +603,15 @@ export default function TransactionBuilder() {
               />
             </LabeledField>
             <LabeledField label="Asset Issuer">
-              <input
+              <FederatedAddressInput
                 value={op.params.assetIssuer || ""}
-                onChange={(e) =>
-                  updateOperation(op.id, "assetIssuer", e.target.value)
+                onChange={(val) =>
+                  updateOperation(op.id, "assetIssuer", val)
                 }
-                placeholder="G... issuer address"
+                placeholder="G... issuer address (or name*domain)"
                 style={textInputStyle(hasErrors)}
+                network={network}
+                hasError={hasErrors}
               />
             </LabeledField>
             <LabeledField label="Limit (optional)">
@@ -488,13 +630,15 @@ export default function TransactionBuilder() {
       case "accountMerge":
         return (
           <LabeledField label="Destination">
-            <input
+            <FederatedAddressInput
               value={op.params.destination || ""}
-              onChange={(e) =>
-                updateOperation(op.id, "destination", e.target.value)
+              onChange={(val) =>
+                updateOperation(op.id, "destination", val)
               }
-              placeholder="G... merge destination"
+              placeholder="G... merge destination (or name*domain)"
               style={textInputStyle(hasErrors)}
+              network={network}
+              hasError={hasErrors}
             />
           </LabeledField>
         );
@@ -983,11 +1127,13 @@ export default function TransactionBuilder() {
       <Panel title="Transaction Settings" subtitle="Configure source account and transaction parameters">
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: "14px" }}>
           <LabeledField label="Source Account">
-            <input
+            <FederatedAddressInput
               value={sourceAccount}
-              onChange={(e) => setSourceAccount(e.target.value)}
-              placeholder={connectedAddress || "G... source account"}
+              onChange={(val) => setSourceAccount(val)}
+              placeholder={connectedAddress || "G... source account (or name*domain)"}
               style={textInputStyle(!sourceAccount && !feeBumpOnly)}
+              network={network}
+              hasError={!sourceAccount && !feeBumpOnly}
             />
             {feeBumpOnly && (
               <div style={{ fontSize: "11px", color: "var(--text-muted)", marginTop: "6px" }}>
@@ -1011,9 +1157,10 @@ export default function TransactionBuilder() {
               type="number"
               value={timeout}
               onChange={(e) => setTimeout(e.target.value)}
-              placeholder="180"
+              placeholder="300"
               style={textInputStyle()}
             />
+            <TimeboundsPreset timeout={timeout} setTimeout={setTimeout} />
           </LabeledField>
 
           <LabeledField label="Memo Type">

--- a/src/components/dashboard/TransactionSigner.tsx
+++ b/src/components/dashboard/TransactionSigner.tsx
@@ -3,7 +3,8 @@ import type { ReactNode } from 'react'
 import { useStore } from '../../lib/store'
 import { signTransactionWithFreighter } from '../../lib/wallet/freighter'
 import { signXdrWithLedger, isLedgerSupported, getActiveLedgerSession } from '../../lib/wallet/ledger'
-import { NETWORKS } from '../../lib/stellar'
+import { NETWORKS, fetchAccount } from '../../lib/stellar'
+import * as StellarSdk from '@stellar/stellar-sdk'
 import { measureAsync } from '../../lib/performanceMonitoring'
 import { loadPreferences, DEFAULT_PREFERENCES } from '../../lib/userPreferences'
 import type { UserPreferences } from '../../lib/userPreferences'
@@ -27,6 +28,8 @@ export default function TransactionSigner() {
   // ─── Behavioral Biometrics ─────────────────────────────────────────────────
   const bio = useBehavioralBiometrics(walletPublicKey)
 
+  const [accountInfo, setAccountInfo] = useState<any>(null)
+
   useEffect(() => {
     async function fetchPreferences() {
       const prefs = await loadPreferences()
@@ -34,6 +37,33 @@ export default function TransactionSigner() {
     }
     fetchPreferences()
   }, [])
+
+  const networkPassphrase: string = NETWORKS[network]?.passphrase || NETWORKS.testnet.passphrase
+
+  useEffect(() => {
+    async function loadAccountInfo() {
+      if (!xdr.trim()) {
+        setAccountInfo(null);
+        return;
+      }
+      try {
+        const tx = StellarSdk.TransactionBuilder.fromXDR(xdr.trim(), networkPassphrase) as any;
+        const sourceAccount = tx.source || tx.sourceAccount?.accountId?.();
+        if (sourceAccount) {
+          const account = await fetchAccount(sourceAccount, network);
+          setAccountInfo({
+            sourceAccount,
+            thresholds: account.thresholds,
+            signers: account.signers
+          });
+        }
+      } catch (e) {
+        setAccountInfo(null);
+      }
+    }
+    const t = setTimeout(loadAccountInfo, 500);
+    return () => clearTimeout(t);
+  }, [xdr, network, networkPassphrase])
 
   // Start collecting behavior as soon as user interacts with the XDR textarea
   const handleXdrChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -43,8 +73,7 @@ export default function TransactionSigner() {
     }
   }, [bio])
 
-  const networkPassphrase: string = NETWORKS[network]?.passphrase || NETWORKS.testnet.passphrase
-
+  // networkPassphrase moved up
   const handleSign = async () => {
     if (!xdr.trim()) {
       setError('Please enter a transaction XDR to sign')
@@ -298,6 +327,40 @@ export default function TransactionSigner() {
             }}
           />
         </div>
+
+        {accountInfo && (
+          <div style={{ padding: '12px', background: 'var(--bg-elevated)', borderRadius: 'var(--radius-md)', border: '1px solid var(--border)' }}>
+            <div style={{ fontSize: '11px', fontWeight: 600, color: 'var(--text-secondary)', marginBottom: '8px', textTransform: 'uppercase' }}>
+              Signer Requirements
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '8px', marginBottom: '12px' }}>
+              <div style={{ background: 'var(--bg-base)', padding: '8px', borderRadius: '4px', textAlign: 'center' }}>
+                <div style={{ fontSize: '10px', color: 'var(--text-muted)' }}>LOW</div>
+                <div style={{ fontSize: '14px', fontWeight: 'bold' }}>{accountInfo.thresholds?.low_threshold}</div>
+              </div>
+              <div style={{ background: 'var(--bg-base)', padding: '8px', borderRadius: '4px', textAlign: 'center' }}>
+                <div style={{ fontSize: '10px', color: 'var(--text-muted)' }}>MED</div>
+                <div style={{ fontSize: '14px', fontWeight: 'bold' }}>{accountInfo.thresholds?.med_threshold}</div>
+              </div>
+              <div style={{ background: 'var(--bg-base)', padding: '8px', borderRadius: '4px', textAlign: 'center' }}>
+                <div style={{ fontSize: '10px', color: 'var(--text-muted)' }}>HIGH</div>
+                <div style={{ fontSize: '14px', fontWeight: 'bold' }}>{accountInfo.thresholds?.high_threshold}</div>
+              </div>
+            </div>
+            
+            <div style={{ fontSize: '11px', fontWeight: 600, color: 'var(--text-secondary)', marginBottom: '4px' }}>
+              Current Signers
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', maxHeight: '150px', overflowY: 'auto' }}>
+              {accountInfo.signers?.map((s: any) => (
+                <div key={s.key} style={{ display: 'flex', justifyContent: 'space-between', fontSize: '11px', fontFamily: 'var(--font-mono)', padding: '4px 8px', background: 'var(--bg-base)', borderRadius: '4px' }}>
+                  <span>{s.key.slice(0, 8)}...{s.key.slice(-8)}</span>
+                  <span style={{ color: 'var(--cyan)' }}>Weight: {s.weight}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         <button
           onClick={handleSign}


### PR DESCRIPTION
## Summary

- Enforced JavaScript chunk budgets (`check-bundle-budgets.mjs`) during the CI build process.
- Replaced standard address fields in `TransactionBuilder.tsx` with a new `FederatedAddressInput` component to support SEP-0002 federation resolution with explicit user confirmation.
- Added a `TimeboundsPreset` component in `TransactionBuilder.tsx` to provide quick expiration presets (5m, 15m, 1h, 1d) and visual warnings for short/expired timeouts. Default timeout was updated to 300s (5 minutes).
- Enhanced `TransactionSigner.tsx` to automatically decode unsigned XDR payloads, fetching and displaying the source account's signer requirements (LOW/MED/HIGH thresholds) and current signers.

## Why

This PR closes multiple feature gaps in a single batch to improve overall safety, performance, and user experience:
- Performance budgets prevent silent increases in bundle size from regressions.
- SEP-0002 federation addresses allow users to interact with human-readable aliases instead of raw G-addresses, conforming to ecosystem standards.
- Timebound presets and warnings prevent users from accidentally broadcasting transactions that expire too quickly or linger in the mempool indefinitely.
- Signer threshold previews enhance security by letting users explicitly verify exactly what weights and signers exist on an account prior to approving a transaction signature.

## Implementation

- **Budgets (`package.json`, `scripts/check-bundle-budgets.mjs`)**: Included a script using standard `fs` and `zlib` to calculate the `.gz` size of chunked assets inside `dist/assets/`, throwing an error if sizes exceed thresholds (150KB for default, 500KB for vendor). Integrated sequentially into the `npm run build` process.
- **Federated Resolution (`TransactionBuilder.tsx`)**: Created the `FederatedAddressInput` to transparently manage `<input>` changes and invoke `resolveFederatedAddress` when `*` is detected. Displays a confirmation box requiring the user to explicitly "Confirm" the translated G-address before overwriting the underlying operation target.
- **Timebounds (`TransactionBuilder.tsx`)**: The `timeout` state default was updated to `300`. `TimeboundsPreset` takes this timeout and calculates the absolute future timestamp based on `Date.now()`, rendering immediate warnings if it's already expired or shorter than 60 seconds.
- **Signer Previews (`TransactionSigner.tsx`)**: Added a debounced `useEffect` tracking the raw `xdr` input. When detected, it parses the envelope via `StellarSdk.TransactionBuilder.fromXDR`, determines the ultimate source account, and calls `fetchAccount` (from `stellar.ts`). Resulting `thresholds` and `signers` are previewed safely above the signing button.

## Testing

- `git status`
- Verified code changes and structure logic manually via `view_file` and code inspection.

Not tested:
- Full automated test suite (e.g. `npm run test`, `npm run build`) was not run because the Node environment natively available to the workspace execution lacked `npm` and `vite` configurations in path.

## Scope / Risk

- **Affected Areas:** Transaction Builder UI, Transaction Signer UI, and Build CI.
- **Risk:** No breaking changes introduced. Safe degradation exists; if the SEP-0002 resolution fails or XDR parsing fails, standard address validation and signer flow will respectively continue.

## Issue

Closes #743
Closes #752
Closes #755
Closes #757
