### PR TITLE
New fixes for #915 #916 #918 #760

### DIFF
--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -1,279 +1,134 @@
-# Pull Request Summary: Comprehensive Portfolio Analytics
+# Pull Request Summary: Wallet Sessions, API Versioning, Alert Templates & Webhook Signatures
 
-## 🎯 Issue Reference
+## Summary
 
-This PR implements a comprehensive analytics view showing portfolio composition, performance, and allocation as requested in the project requirements.
+This PR implements four 2026 roadmap items: global Freighter wallet session handling, explicit public API versioning with deprecation headers, starter alert rule templates for common developer incidents, and secure HMAC webhook signature verification.
 
-## 📊 What's New
-
-A complete **Portfolio Analytics Dashboard** with the following features:
-
-### Core Visualizations
-- **📊 Asset Allocation Pie Chart** - Interactive visualization showing percentage distribution of all portfolio assets
-- **📈 Portfolio Value Line Chart** - Historical value tracking with multiple time ranges (7D, 30D, 90D, 1Y)
-- **📊 Asset Performance Bar Chart** - 24-hour performance comparison across all assets
-- **📋 Detailed Holdings Table** - Complete breakdown with balance, price, value, and allocation percentages
-
-### Performance Metrics
-- **Total Portfolio Value** - Real-time USD value
-- **24h Change** - Percentage and absolute value change
-- **Diversification Score** - 0-100 scale using Herfindahl-Hirschman Index
-- **Risk Level** - Low/Medium/High assessment
-- **Volatility** - Standard deviation of returns
-- **Sharpe Ratio** - Risk-adjusted return metric
-
-### Advanced Analytics
-- **Risk Assessment Panel** - Multi-factor analysis with detailed risk factors
-- **Concentration Risk Detection** - Identifies over-allocated assets (>25%)
-- **Account History Comparison** - Period start vs current value analysis
-- **Real-Time Updates** - Auto-refresh every 60 seconds with manual override
-
-### User Experience
-- **Mobile Responsive** - Touch-friendly charts with pinch-to-zoom and pan gestures
-- **Time Range Selector** - Quick switching between different time periods
-- **Auto-Refresh Toggle** - Control over automatic data updates
-- **Loading States** - Clear visual feedback during data fetching
-- **Empty States** - Helpful messages when no data is available
-
-## ✅ Acceptance Criteria
-
-All requirements have been fully implemented:
-
-| Requirement | Status | Implementation |
-|------------|--------|----------------|
-| Pie chart of asset allocation | ✅ | Recharts PieChart with color-coded segments and tooltips |
-| Line chart of portfolio value over time | ✅ | AreaChart with gradient fill, multiple time ranges |
-| Performance metrics (ROI, volatility) | ✅ | Complete dashboard with 6+ metrics |
-| Comparison with account history | ✅ | Period comparison panel with start/end values |
-| Charts render correctly with various account sizes | ✅ | Responsive design adapts to all screen sizes |
-| Data updates in real-time | ✅ | 60-second auto-refresh + manual refresh |
-| Mobile responsive design | ✅ | Touch gestures, responsive grids, adaptive layouts |
-
-## 🏗️ Technical Implementation
-
-### Files Changed
-
-#### New Files (1)
-- `src/components/dashboard/PortfolioAnalytics.tsx` (650+ lines)
-  - Complete analytics dashboard component
-  - TypeScript with proper type definitions
-  - Mobile-responsive with useResponsive hook
-  - Real-time data updates with auto-refresh
-
-#### Modified Files (3)
-- `src/App.tsx`
-  - Added portfolioAnalytics route to TABS
-  - Lazy-loaded for code splitting
-  
-- `src/components/layout/Sidebar.tsx`
-  - Added "Portfolio Analytics" navigation link
-  - Positioned under existing Portfolio section
-
-- `package-lock.json`
-  - Updated after dependency installation
-
-### Architecture
-
-```
-PortfolioAnalytics Component
-├── State Management (Zustand)
-│   ├── Account data
-│   ├── Price data
-│   └── Network configuration
-├── Data Fetching
-│   ├── Price updates (CoinGecko)
-│   ├── Historical performance (Horizon API)
-│   └── Account effects
-├── Analytics Calculations
-│   ├── Asset allocation
-│   ├── Diversification score
-│   ├── Risk assessment
-│   ├── Volatility
-│   └── Performance metrics
-└── Visualizations
-    ├── Pie Chart (Recharts)
-    ├── Area Chart (Recharts)
-    ├── Bar Chart (Recharts)
-    └── Data Tables
-```
-
-### Dependencies
-
-**No new dependencies added!** Uses existing packages:
-- `recharts` ^2.12.7 - Chart visualizations
-- `lucide-react` - Icons
-- `zustand` - State management
-- `@stellar/stellar-sdk` - Blockchain integration
-
-### Code Quality
-
-- ✅ TypeScript with strict typing
-- ✅ React hooks best practices
-- ✅ Memoization for performance
-- ✅ Effect cleanup to prevent memory leaks
-- ✅ Error boundaries and error handling
-- ✅ Accessibility (ARIA labels, keyboard navigation)
-- ✅ Mobile-first responsive design
-- ✅ Consistent with codebase patterns
-
-## 🎨 Design
-
-Follows the existing Stellar Dev Dashboard design system:
-- Color palette: Cyan, Green, Red, Amber, Purple
-- Typography: Syne (display), Space Mono (monospace)
-- CSS variables for theming
-- Consistent spacing and radius values
-- Dark/Light theme support
-
-## 📱 Mobile Optimization
-
-- Responsive grid layouts (2 cols mobile, 3 tablet, 4 desktop)
-- Touch-friendly charts with MobileChartContainer
-- Pinch-to-zoom and pan gestures
-- Reduced font sizes for mobile (9px vs 11px)
-- Stacked layouts on small screens
-- Horizontal scrolling for wide tables
-- Safe area insets for notched devices
-
-## 🔄 Real-Time Features
-
-- **Auto-refresh**: Updates prices every 60 seconds
-- **Manual refresh**: Immediate update button
-- **Last update timestamp**: Shows when data was last fetched
-- **Loading indicators**: Visual feedback during updates
-- **Optimistic updates**: Smooth user experience
-
-## 📈 Performance
-
-- Lazy loading via React.lazy
-- Memoized calculations with useMemo
-- Stable callbacks with useCallback
-- Effect cleanup for cancellation
-- Debounced API calls
-- Responsive only when needed
-
-## 🧪 Testing Suggestions
-
-### Manual Testing
-
-1. Connect account with multiple Stellar assets
-2. Navigate to "Portfolio Analytics" in sidebar
-3. Verify pie chart renders with correct percentages
-4. Test time range selector (7D, 30D, 90D, 1Y)
-5. Toggle auto-refresh on/off
-6. Test manual refresh button
-7. Check mobile responsive layout on different devices
-8. Verify touch gestures on mobile (pinch, pan)
-9. Test with single asset portfolio
-10. Test with highly diversified portfolio
-
-### Edge Cases Handled
-- No balances: Shows empty state
-- Missing price data: Displays 'N/A'
-- Single asset: Diversification score = 0
-- Network errors: Error messages
-- Loading states: Spinner animations
-
-## 📚 Documentation
-
-Comprehensive implementation documentation included:
-- `PORTFOLIO_ANALYTICS_IMPLEMENTATION.md` (635 lines)
-  - Feature overview
-  - Technical architecture
-  - Chart configurations
-  - Risk assessment logic
-  - Performance metrics explanations
-  - Usage guide
-  - Testing recommendations
-  - Future enhancements
-  - Troubleshooting guide
-
-## 🚀 Deployment
-
-The feature is:
-- ✅ Production-ready
-- ✅ Type-safe
-- ✅ Well-tested manually
-- ✅ Fully documented
-- ✅ Mobile-optimized
-- ✅ Accessible
-- ✅ Performant
-
-## 📸 Screenshots
-
-*Note: Screenshots would be added here in the actual PR showing:*
-- Desktop view of the analytics dashboard
-- Asset allocation pie chart
-- Portfolio value line chart
-- Mobile responsive layout
-- Risk assessment panel
-- Holdings table
-
-## 🔗 Links
-
-- **Branch**: `feature/comprehensive-portfolio-analytics`
-- **Repository**: https://github.com/coderolisa/stellar-dev-dashboard
-- **Live Demo**: (Would be deployed to preview environment)
-
-## 🎯 Impact
-
-This feature provides users with:
-- **Complete visibility** into portfolio composition
-- **Data-driven insights** for decision making
-- **Risk awareness** through multi-factor assessment
-- **Performance tracking** over time
-- **Professional-grade analytics** matching industry standards
-
-## 🔄 Next Steps
-
-After merge, potential enhancements:
-1. Export functionality (PDF, CSV, PNG)
-2. Advanced correlation analysis
-3. Rebalancing recommendations
-4. Cost basis tracking for P&L
-5. WebSocket integration for real-time prices
-6. Alerts and notifications
-7. Comparison with benchmarks
-
-## 👥 Review Checklist
-
-For reviewers to verify:
-- [ ] Code follows project conventions
-- [ ] TypeScript types are properly defined
-- [ ] Mobile responsive design works on all breakpoints
-- [ ] Charts render correctly with various data sets
-- [ ] Auto-refresh functionality works
-- [ ] Error handling is robust
-- [ ] Accessibility standards are met
-- [ ] Performance is acceptable
-- [ ] Documentation is clear and complete
-- [ ] No new dependencies were added unnecessarily
-
-## 💬 Notes
-
-- All analytics calculations use the existing `portfolioAnalytics.js` library
-- Historical data is reconstructed from account effects via Horizon API
-- Price data sourced from CoinGecko API (existing integration)
-- Component follows the same patterns as `PortfolioValue.tsx`
-- Mobile optimization uses existing `MobileChartContainer` and `useResponsive` hook
-
-## 🙏 Acknowledgments
-
-- Built on top of excellent existing codebase architecture
-- Uses well-established libraries (Recharts, Stellar SDK)
-- Follows design system established in the project
-- Leverages existing utility functions and components
+closes #760
+closes #918
+closes #916
+closes #915
 
 ---
 
-## 🎉 Summary
+## #760 — Wallet session revocation and account-change listeners
 
-This PR delivers a **complete, production-ready portfolio analytics dashboard** that provides users with comprehensive insights into their Stellar portfolio. All acceptance criteria have been met, the code is well-architected and documented, and the feature is fully responsive across all devices.
+### Changes
+- Added `useWalletSessionListeners` hook mounted in `DashboardLayout` so session events are handled app-wide (not only on the wallet tab)
+- Added `revokeWalletSession(reason)` to the Zustand store to atomically clear wallet identity and account state
+- Enhanced Freighter connector with:
+  - Network normalization (`PUBLIC` → mainnet, `TESTNET` → testnet, etc.)
+  - DOM event listeners for lock, account change, and network change
+  - Polling fallback via `subscribeFreighterSession` when the extension does not emit events
+- Added `src/lib/wallet/sessionListeners.ts` to coordinate lock, disconnect, account reload, and network sync
 
-Ready for review and merge! 🚀
+### Documentation
+- Updated `docs-site/docs/getting-started/authentication.md` with session lifecycle, security, and migration notes
 
-**Branch**: `feature/comprehensive-portfolio-analytics`
-**Commits**: 2 (feature implementation + documentation)
-**Lines Added**: ~1,550
-**Files Changed**: 4
-**New Dependencies**: 0
+### Tests
+- `tests/unit/lib/wallet/freighter.test.js` — normalization, events, polling, disconnect
+- `tests/unit/lib/wallet/sessionListeners.test.js` — lock revocation, account reload, unsupported network
+- `tests/unit/lib/store.test.js` — `revokeWalletSession` behavior
+
+---
+
+## #918 — Version public dashboard API responses with deprecation headers
+
+### Changes
+- Added `api/middleware/apiVersioning.js` with:
+  - `API-Version` and `X-API-Version` headers on every response
+  - `Deprecation`, `Sunset`, `Link`, and `Warning` headers for deprecated routes
+  - `Accept-Version` validation (returns `400` for unsupported versions)
+- Applied middleware globally in `api/server.js`
+- Updated `/api/docs` to expose `apiVersion: 1.0.0`
+
+### Documentation
+- Added `docs/api/API_VERSIONING.md`
+- Updated `docs/api/VERSION_HISTORY.md`
+
+### Tests
+- `tests/api/middleware/apiVersioning.test.js` — version headers, deprecation headers, invalid `Accept-Version`, payload wrapper
+
+---
+
+## #916 — Alert rule templates for common developer incidents
+
+### Changes
+- Added `src/lib/alertRuleTemplates.ts` with starter templates:
+  - **Fee Spike** — base fees exceed recent baseline by a multiplier
+  - **Failed Submissions** — failed tx count exceeds threshold in a window
+  - **RPC Latency Regression** — API/RPC p50/p95/p99 latency exceeds threshold
+- Extended `src/types/alerts.ts` with `fee_spike`, `submission_failures`, and `rpc_latency` rule types
+- Extended `src/lib/alertRuleEngine.ts` with metric-driven evaluators
+- Added metric window helpers to `src/utils/metricsCollector.ts`:
+  - `getMetricPointsInWindow`
+  - `countMetricEventsInWindow`
+  - `recordFeeObservation`
+
+### Documentation
+- Updated `docs/features/alert-rules.md` with template usage and metric instrumentation notes
+
+### Tests
+- `src/lib/__tests__/alertRuleTemplates.test.ts` — template creation, primary flow, boundary case (insufficient samples), failure paths
+
+---
+
+## #915 — Webhook signature verification helpers for inbound events
+
+### Changes
+- Added `src/lib/webhookSignatures.ts` with:
+  - `signWebhookPayload` / `verifyWebhookSignature`
+  - `parseWebhookSignatureHeader`
+  - HMAC-SHA256 via Web Crypto API
+  - Timestamp replay tolerance (default 300s)
+  - Constant-time signature comparison
+- Replaced placeholder `btoa(body + secret)` signing in `src/lib/webhooks.ts` with real HMAC signatures (`t=<timestamp>,v1=<hex>`)
+
+### Documentation
+- Added `docs/features/webhook-signatures.md` with signing, verification, failure codes, and migration notes
+
+### Tests
+- `src/lib/__tests__/webhookSignatures.test.ts` — sign/verify round-trip, tampering, malformed headers, replay tolerance
+
+---
+
+## Other fixes
+
+- Fixed invalid JSON in `package.json` (`optionalDependencies` duplicate entry) that blocked `npm install`
+
+---
+
+## Test plan
+
+- [x] `tests/unit/lib/wallet/freighter.test.js` (6 tests)
+- [x] `tests/unit/lib/wallet/sessionListeners.test.js` (3 tests)
+- [x] `tests/unit/lib/store.test.js` — includes `revokeWalletSession` (22 tests)
+- [x] `tests/api/middleware/apiVersioning.test.js` (4 tests)
+- [x] `src/lib/__tests__/alertRuleTemplates.test.ts` (7 tests)
+- [x] `src/lib/__tests__/webhookSignatures.test.ts` (5 tests)
+
+**47 tests passing** across the new and updated test files.
+
+---
+
+## Migration / compatibility notes
+
+| Area | Note |
+| --- | --- |
+| **Wallet** | Session listeners now run globally; move any tab-scoped handling to `useWalletSessionListeners` |
+| **API** | Existing `/api/v1/*` clients continue to work; `/api/v1/behavior/*` includes sunset headers pointing to `/api/v2/behavior` |
+| **Webhooks** | Outbound signatures changed from placeholder digests to `t=<timestamp>,v1=<hmac>`; receivers must verify raw body bytes before JSON parsing |
+| **Alerts** | Metric templates require instrumentation via `recordTransactionSubmitted`, `recordApiCall`, and `recordFeeObservation` |
+
+---
+
+## Files changed (key)
+
+| Area | Files |
+| --- | --- |
+| Wallet | `src/lib/wallet/freighter.js`, `src/lib/wallet/sessionListeners.ts`, `src/hooks/useWalletSessionListeners.ts`, `src/lib/store.ts`, `src/routes/DashboardLayout.tsx` |
+| API | `api/middleware/apiVersioning.js`, `api/server.js` |
+| Alerts | `src/lib/alertRuleTemplates.ts`, `src/types/alerts.ts`, `src/lib/alertRuleEngine.ts`, `src/utils/metricsCollector.ts` |
+| Webhooks | `src/lib/webhookSignatures.ts`, `src/lib/webhooks.ts` |
+| Docs | `docs/api/API_VERSIONING.md`, `docs/features/webhook-signatures.md`, `docs/features/alert-rules.md`, `docs-site/docs/getting-started/authentication.md` |
+| Tests | 6 new/updated test files (see Test plan above) |

--- a/api/middleware/apiVersioning.js
+++ b/api/middleware/apiVersioning.js
@@ -1,0 +1,73 @@
+/**
+ * Public dashboard API versioning and deprecation headers.
+ */
+
+export const CURRENT_API_VERSION = '1.0.0';
+
+export const SUPPORTED_API_VERSIONS = ['1.0', '1.0.0', 'v1'];
+
+/**
+ * Routes scheduled for removal. Prefix matching is applied to req.path.
+ */
+export const DEPRECATED_ROUTES = [
+  {
+    prefix: '/api/v1/behavior',
+    deprecatedAt: 'Sat, 01 Jun 2026 00:00:00 GMT',
+    sunset: 'Thu, 31 Dec 2026 00:00:00 GMT',
+    successor: '/api/v2/behavior',
+    message: 'Behavior endpoints are deprecated; migrate to /api/v2/behavior.',
+  },
+];
+
+function findDeprecatedRoute(pathname) {
+  if (typeof pathname !== 'string' || !pathname) {
+    return null;
+  }
+
+  return DEPRECATED_ROUTES.find((route) => pathname.startsWith(route.prefix)) || null;
+}
+
+/**
+ * Attach version metadata and deprecation headers to every API response.
+ */
+export function apiVersioningMiddleware(req, res, next) {
+  res.setHeader('API-Version', CURRENT_API_VERSION);
+  res.setHeader('X-API-Version', CURRENT_API_VERSION);
+
+  const acceptVersion = req.headers['accept-version'];
+  if (acceptVersion && !SUPPORTED_API_VERSIONS.includes(String(acceptVersion))) {
+    return res.status(400).json({
+      error: 'Unsupported API version',
+      message: `Accept-Version "${acceptVersion}" is not supported.`,
+      supportedVersions: SUPPORTED_API_VERSIONS,
+      currentVersion: CURRENT_API_VERSION,
+    });
+  }
+
+  const deprecatedRoute = findDeprecatedRoute(req.path);
+  if (deprecatedRoute) {
+    res.setHeader('Deprecation', deprecatedRoute.deprecatedAt);
+    res.setHeader('Sunset', deprecatedRoute.sunset);
+    res.setHeader('Link', `<${deprecatedRoute.successor}>; rel="successor-version"`);
+    res.setHeader('Warning', `299 - "${deprecatedRoute.message}"`);
+  }
+
+  return next();
+}
+
+/**
+ * Wrap JSON payloads with explicit API version metadata.
+ */
+export function withApiVersion(payload, options = {}) {
+  const response = {
+    apiVersion: CURRENT_API_VERSION,
+    ...payload,
+  };
+
+  if (options.deprecated) {
+    response.deprecated = true;
+    response.successor = options.successor;
+  }
+
+  return response;
+}

--- a/api/server.js
+++ b/api/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { createServer } from 'http';
 import { WebSocketServer } from 'ws';
 import { rateLimiter } from './middleware/rateLimiter.js';
+import { apiVersioningMiddleware } from './middleware/apiVersioning.js';
 import { oauthAuth } from './middleware/auth.js';
 import { router as accountsRouter } from './routes/accounts.js';
 import { router as transactionsRouter } from './routes/transactions.js';
@@ -16,6 +17,7 @@ const server = createServer(app);
 const wss = new WebSocketServer({ server });
 
 app.use(express.json());
+app.use(apiVersioningMiddleware);
 app.use(rateLimiter);
 
 // Public API routes
@@ -30,6 +32,7 @@ app.use('/api/v1', gasPredictionRouter);
 // Documentation endpoint
 app.get('/api/docs', (req, res) => {
   res.json({
+    apiVersion: '1.0.0',
     version: '1.0',
     description: 'Stellar Dev Dashboard Public API',
     endpoints: {

--- a/docs-site/docs/getting-started/authentication.md
+++ b/docs-site/docs/getting-started/authentication.md
@@ -56,6 +56,31 @@ const { network, networkPassphrase } = await freighter.getNetwork();
 | Testnet | `Test SDF Network ; September 2015` |
 | Futurenet | `Test SDF Future Network ; October 2022` |
 
+## Freighter session lifecycle
+
+The dashboard mounts global Freighter session listeners at the layout level (not only on the wallet tab). The app reacts when Freighter:
+
+- **Locks** — wallet session is revoked and connected account data is cleared.
+- **Disconnects** — same as lock; stale signing state is removed.
+- **Changes account** — both `walletPublicKey` and `connectedAddress` update and account data is refetched.
+- **Changes network** — the dashboard network switches when the Freighter network maps to a supported value (`PUBLIC` → mainnet, `TESTNET` → testnet, etc.). Unsupported networks revoke the session.
+
+Implementation:
+
+- Connector: `src/lib/wallet/freighter.js`
+- Session listener: `src/lib/wallet/sessionListeners.ts`
+- Store action: `revokeWalletSession(reason)`
+
+### Security and compatibility
+
+- Session revocation clears wallet identity **and** cached account state to prevent signing or displaying stale data.
+- Freighter custom DOM events are supported, with polling fallback when the extension does not emit events.
+- This does **not** revoke Freighter extension permissions; users must disconnect from the extension separately if required.
+
+### Migration notes
+
+Integrations that only listened inside `WalletConnect` should move session handling to the global listener hook (`useWalletSessionListeners`) so behavior remains consistent across tabs.
+
 ## Biometric authentication (dashboard feature)
 
 The dashboard supports WebAuthn-based biometric authentication for session management. This is handled by `src/lib/biometricAuth.ts`:

--- a/docs/api/API_VERSIONING.md
+++ b/docs/api/API_VERSIONING.md
@@ -1,0 +1,60 @@
+# Public Dashboard API Versioning
+
+The public dashboard API uses explicit path versioning and response headers aligned with the public contract.
+
+## Current version
+
+- Path prefix: `/api/v1`
+- Response headers: `API-Version` and `X-API-Version` (currently `1.0.0`)
+
+Every API response includes these headers so clients can detect the active contract version without parsing the body.
+
+## Client negotiation
+
+Clients may send an optional `Accept-Version` header. Supported values:
+
+- `1.0`
+- `1.0.0`
+- `v1`
+
+Unsupported values receive `400 Bad Request`:
+
+```json
+{
+  "error": "Unsupported API version",
+  "supportedVersions": ["1.0", "1.0.0", "v1"],
+  "currentVersion": "1.0.0"
+}
+```
+
+## Deprecation policy
+
+Deprecated routes include:
+
+| Header | Purpose |
+| --- | --- |
+| `Deprecation` | HTTP-date when the route was marked deprecated |
+| `Sunset` | HTTP-date when the route will be removed |
+| `Link` | Successor route (`rel="successor-version"`) |
+| `Warning` | Human-readable migration guidance |
+
+Currently deprecated:
+
+- `/api/v1/behavior/*` → successor `/api/v2/behavior`
+- Sunset: `Thu, 31 Dec 2026 00:00:00 GMT`
+
+## Migration notes
+
+1. Read `API-Version` on every response and log breaking changes during integration tests.
+2. When `Deprecation` is present, schedule migration before the `Sunset` date.
+3. Prefer the `Link` successor route for new integrations.
+4. Do not rely on undocumented response fields; versioned payloads include `apiVersion` where applicable.
+
+## Security
+
+Version headers are informational only. Authentication, rate limits, and authorization remain enforced by existing middleware.
+
+## Compatibility
+
+- Existing `/api/v1/*` clients continue to work without changes.
+- Clients that ignore deprecation headers remain functional until the published sunset date.

--- a/docs/api/VERSION_HISTORY.md
+++ b/docs/api/VERSION_HISTORY.md
@@ -4,6 +4,7 @@ This document tracks released API documentation versions and the repo package ve
 
 | Version | Notes |
 | --- | --- |
+| 1.0.0 | Added explicit `API-Version` / deprecation headers for public dashboard routes. See [API_VERSIONING.md](./API_VERSIONING.md). |
 | 0.1.0 | Initial API reference generator and runnable example assets.
 
 ## Current Package Version

--- a/docs/features/alert-rules.md
+++ b/docs/features/alert-rules.md
@@ -303,6 +303,31 @@ To contribute to the Alert Rules system:
 5. Add tests for new functionality
 6. Update this documentation
 
+## Starter templates (developer incidents)
+
+Use `src/lib/alertRuleTemplates.ts` to create rules from predefined templates:
+
+| Template | Trigger |
+| --- | --- |
+| **Fee Spike** | Observed base fees exceed recent baseline by a multiplier |
+| **Failed Submissions** | Failed transaction submissions exceed a threshold in a time window |
+| **RPC Latency Regression** | API/RPC latency percentile exceeds a threshold |
+
+Example:
+
+```ts
+import { createAlertRuleFromTemplate } from '@/lib/alertRuleTemplates';
+
+const rule = createAlertRuleFromTemplate({
+  templateId: 'submission_failures',
+  userId: connectedAddress,
+  accountAddress: connectedAddress,
+  overrides: { failureCountThreshold: 5, windowSeconds: 600 },
+});
+```
+
+Metric-driven templates read from `src/utils/metricsCollector.ts`. Instrument submission and RPC calls with `recordTransactionSubmitted`, `recordApiCall`, and `recordFeeObservation` so evaluations have data to analyze.
+
 ## Support
 
 For issues or questions:

--- a/docs/features/webhook-signatures.md
+++ b/docs/features/webhook-signatures.md
@@ -1,0 +1,68 @@
+# Webhook Signature Verification
+
+Inbound automation webhooks from the Stellar Dev Dashboard are signed with HMAC-SHA256.
+
+## Signature format
+
+Header: `X-Webhook-Signature`
+
+Value format:
+
+```text
+t=<unix-seconds>,v1=<hex-hmac>
+```
+
+The signed payload is:
+
+```text
+${timestamp}.${rawBody}
+```
+
+Verify the **raw request body bytes** before JSON parsing. Re-stringifying parsed JSON can change field order and break signatures.
+
+## Signing (outbound)
+
+```ts
+import { signWebhookPayload } from '@/lib/webhookSignatures';
+
+const rawBody = JSON.stringify(payload);
+const signature = await signWebhookPayload(rawBody, endpointSecret);
+```
+
+## Verification (inbound)
+
+```ts
+import { verifyWebhookSignature } from '@/lib/webhookSignatures';
+
+const rawBody = await readRawBody(request);
+const signature = request.headers.get('x-webhook-signature');
+const result = await verifyWebhookSignature(rawBody, signature, sharedSecret, {
+  toleranceSeconds: 300,
+});
+
+if (!result.valid) {
+  throw new Error(`Invalid webhook signature: ${result.reason}`);
+}
+```
+
+## Failure handling
+
+| Reason | Meaning |
+| --- | --- |
+| `missing_signature` | Header absent or empty |
+| `malformed_signature` | Header missing `t=` or `v1=` parts |
+| `invalid_timestamp` | Timestamp is not a positive integer |
+| `timestamp_out_of_tolerance` | Possible replay attack or clock skew |
+| `signature_mismatch` | Secret mismatch or body tampering |
+| `unsupported_environment` | Web Crypto unavailable |
+
+## Security notes
+
+- Use a unique secret per webhook endpoint.
+- Rotate secrets by accepting both old and new secrets during a overlap window.
+- Reject requests outside the replay tolerance (default 300 seconds).
+- Compare signatures in constant time (handled by the helper).
+
+## Migration from legacy signatures
+
+Earlier builds used a placeholder `btoa(body + secret)` digest. Receivers should upgrade to the `t=...,v1=...` format documented above. Outbound delivery now uses the HMAC helper in `src/lib/webhookSignatures.ts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sentry/react": "8.54.0",
         "@stellar/stellar-sdk": "^12.3.0",
         "@tensorflow/tfjs": "^4.22.0",
-        "@tensorflow/tfjs-node": "4.22.0",
+        "@tensorflow/tfjs-node": "^4.22.0",
         "d3-array": "^3.2.4",
         "d3-force-3d": "^3.0.6",
         "d3-scale": "^4.0.2",
@@ -83,7 +83,6 @@
       },
       "optionalDependencies": {
         "@ledgerhq/hw-transport-webhid": "^6.29.4",
-        "@ledgerhq/hw-transport-webusb": "^6.29.4"
         "@ledgerhq/hw-transport-webusb": "^6.29.4",
         "@stellar/ledger": "^1.0.0",
         "ioredis": "^5.4.0"
@@ -162,25 +161,25 @@
       "license": "MIT"
     },
     "node_modules/@axe-core/playwright": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
-      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.12.1"
+        "axe-core": "~4.13.0"
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@axe-core/react": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.12.1.tgz",
-      "integrity": "sha512-8tZysxguMYomHHFA1iPSpJfWiHX0LPSXdHxboR1YKPs+taNOG8wiEqLaGdgXaFDZ2WKyX/+bzvlLcqdNsR/Gdg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/react/-/react-4.13.0.tgz",
+      "integrity": "sha512-/4l+CSBS/VJ2VGtdohuQMqK3NfQoZgDHsXsRt4pAZzZTFhwXs9KQCBinVmPAgTF3wIYK0qvXYAfbmUQ1QT4GJQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.12.1",
+        "axe-core": "~4.13.0",
         "requestidlecallback": "^0.3.0"
       }
     },
@@ -241,14 +240,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -533,13 +532,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1217,16 +1216,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
-      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.8.tgz",
+      "integrity": "sha512-6iSnEK0zlkLKU4heofK/AdmRD4e2SHVpJMtrwnTCzhnaM98ria4rTrOXBBi45BTTYnJtO8txnPsX4fChYXkmeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/traverse": "^7.29.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1556,9 +1555,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
-      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.8.tgz",
+      "integrity": "sha512-0UpIXPtdDtMXfnV2OJAVMLpj3H/92vmkA6lpSRakmycJvj3VUy6Xs1dM8tXRugupykr5WB+LpiVl0J8LMVg2mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1621,9 +1620,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
-      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.8.tgz",
+      "integrity": "sha512-4S9ksMGVWUshvgK0mKfvZky7leuG5/uoFVwMpAomJ8bMoDJiNHRVmc1EglwW/CmGVSqqWpEbXm9FmbRit22qoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1939,18 +1938,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1958,9 +1957,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1992,9 +1991,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
-      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
       "dev": true,
       "funding": [
         {
@@ -2036,9 +2035,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
-      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.1.tgz",
+      "integrity": "sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==",
       "dev": true,
       "funding": [
         {
@@ -2052,7 +2051,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/color-helpers": "^6.1.1",
         "@csstools/css-calc": "^3.3.0"
       },
       "engines": {
@@ -2087,9 +2086,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
-      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.9.tgz",
+      "integrity": "sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==",
       "dev": true,
       "funding": [
         {
@@ -2631,9 +2630,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2729,9 +2728,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2753,9 +2752,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -3264,9 +3263,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3501,9 +3500,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3679,9 +3678,9 @@
       }
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3787,6 +3786,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
     "node_modules/@open-draft/deferred-promise": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
@@ -3831,13 +3847,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
-      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4010,9 +4026,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
+      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -4049,9 +4065,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
-      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
       "cpu": [
         "arm"
       ],
@@ -4063,9 +4079,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
-      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
       "cpu": [
         "arm64"
       ],
@@ -4077,9 +4093,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
-      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
       "cpu": [
         "arm64"
       ],
@@ -4091,9 +4107,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
-      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
       "cpu": [
         "x64"
       ],
@@ -4105,9 +4121,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
-      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
       "cpu": [
         "arm64"
       ],
@@ -4119,9 +4135,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
-      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
       "cpu": [
         "x64"
       ],
@@ -4133,9 +4149,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
-      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
       "cpu": [
         "arm"
       ],
@@ -4147,9 +4163,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
-      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
       "cpu": [
         "arm"
       ],
@@ -4161,9 +4177,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
-      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
       "cpu": [
         "arm64"
       ],
@@ -4175,9 +4191,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
-      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
       "cpu": [
         "arm64"
       ],
@@ -4189,9 +4205,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
-      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
       "cpu": [
         "loong64"
       ],
@@ -4203,9 +4219,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
-      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
       "cpu": [
         "loong64"
       ],
@@ -4217,9 +4233,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
-      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
       "cpu": [
         "ppc64"
       ],
@@ -4231,9 +4247,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
-      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
       "cpu": [
         "ppc64"
       ],
@@ -4245,9 +4261,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
-      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
       "cpu": [
         "riscv64"
       ],
@@ -4259,9 +4275,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
-      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
       "cpu": [
         "riscv64"
       ],
@@ -4273,9 +4289,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
-      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
       "cpu": [
         "s390x"
       ],
@@ -4287,9 +4303,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
-      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
       "cpu": [
         "x64"
       ],
@@ -4301,9 +4317,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
-      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
       "cpu": [
         "x64"
       ],
@@ -4315,9 +4331,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
-      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
       "cpu": [
         "x64"
       ],
@@ -4329,9 +4345,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
-      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
       "cpu": [
         "arm64"
       ],
@@ -4343,9 +4359,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
-      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
       "cpu": [
         "arm64"
       ],
@@ -4357,9 +4373,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
-      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
       "cpu": [
         "ia32"
       ],
@@ -4371,9 +4387,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
-      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
       "cpu": [
         "x64"
       ],
@@ -4385,9 +4401,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
-      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
       "cpu": [
         "x64"
       ],
@@ -4410,118 +4426,6 @@
       "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.54.0.tgz",
       "integrity": "sha512-DKWCqb4YQosKn6aD45fhKyzhkdG7N6goGFDeyTaJFREJDFVDXiNDsYZu30nJ6BxMM7uQIaARhPAC5BXfoED3pQ==",
       "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "8.54.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/core": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.54.0.tgz",
-      "integrity": "sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.54.0.tgz",
-      "integrity": "sha512-nQqRacOXoElpE0L0ADxUUII0I3A94niqG9Z4Fmsw6057QvyrV/LvTiMQBop6r5qLjwMqK+T33iR4/NQI5RhsXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "8.54.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/feedback/node_modules/@sentry/core": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.54.0.tgz",
-      "integrity": "sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.54.0.tgz",
-      "integrity": "sha512-8xuBe06IaYIGJec53wUC12tY2q4z2Z0RPS2s1sLtbA00EvK1YDGuXp96IDD+HB9mnDMrQ/jW5f97g9TvPsPQUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "8.54.0",
-        "@sentry/core": "8.54.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.54.0.tgz",
-      "integrity": "sha512-K/On3OAUBeq/TV2n+1EvObKC+WMV9npVXpVyJqCCyn8HYMm8FUGzuxeajzm0mlW4wDTPCQor6mK9/IgOquUzCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/replay": "8.54.0",
-        "@sentry/core": "8.54.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/core": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.54.0.tgz",
-      "integrity": "sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/replay/node_modules/@sentry/core": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.54.0.tgz",
-      "integrity": "sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/browser": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.54.0.tgz",
-      "integrity": "sha512-BgUtvxFHin0fS0CmJVKTLXXZcke0Av729IVfi+2fJ4COX8HO7/HAP02RKaSQGmL2HmvWYTfNZ7529AnUtrM4Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "8.54.0",
-        "@sentry-internal/feedback": "8.54.0",
-        "@sentry-internal/replay": "8.54.0",
-        "@sentry-internal/replay-canvas": "8.54.0",
-        "@sentry/core": "8.54.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/browser/node_modules/@sentry/core": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.54.0.tgz",
-      "integrity": "sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
-      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@sentry/core": "8.54.0"
       },
@@ -4734,15 +4638,6 @@
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
-    "node_modules/@sentry/react/node_modules/@sentry/core": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.54.0.tgz",
-      "integrity": "sha512-03bWf+D1j28unOocY/5FDB6bUHtYlm6m6ollVejhg45ZmK9iPjdtxNWbrLsjT1WRym0Tjzowu+A3p+eebYEv0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
     "node_modules/@sentry/types": {
       "version": "6.19.7",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
@@ -4798,6 +4693,9 @@
       "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
       "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@stellar/ledger": {
+      "optional": true
     },
     "node_modules/@stellar/stellar-base": {
       "version": "12.1.1",
@@ -5759,9 +5657,9 @@
       "license": "MIT"
     },
     "node_modules/@testing-library/react": {
-      "version": "16.3.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
-      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5787,9 +5685,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5929,9 +5827,9 @@
       }
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -5976,9 +5874,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
-      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.3.tgz",
+      "integrity": "sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6246,16 +6144,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
-      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
+      "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/typescript-estree": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/scope-manager": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/typescript-estree": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6271,14 +6169,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
-      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
+      "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.65.0",
-        "@typescript-eslint/types": "^8.65.0",
+        "@typescript-eslint/tsconfig-utils": "^8.68.0",
+        "@typescript-eslint/types": "^8.68.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6293,14 +6191,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
-      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
+      "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0"
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6311,9 +6209,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
-      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
+      "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6328,9 +6226,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
-      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
+      "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6342,16 +6240,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
-      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
+      "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.65.0",
-        "@typescript-eslint/tsconfig-utils": "8.65.0",
-        "@typescript-eslint/types": "8.65.0",
-        "@typescript-eslint/visitor-keys": "8.65.0",
+        "@typescript-eslint/project-service": "8.68.0",
+        "@typescript-eslint/tsconfig-utils": "8.68.0",
+        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/visitor-keys": "8.68.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -6380,9 +6278,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6393,13 +6291,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6422,13 +6320,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.65.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
-      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "version": "8.68.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
+      "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/types": "8.68.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -6765,9 +6663,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7123,22 +7021,22 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
-      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -7251,9 +7149,9 @@
       }
     },
     "node_modules/bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.2.tgz",
+      "integrity": "sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -7266,9 +7164,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
-      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.1.tgz",
+      "integrity": "sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7279,7 +7177,7 @@
         "fast-fifo": "^1.3.2"
       },
       "engines": {
-        "bare": ">=1.16.0"
+        "bare": ">=1.28.0"
       },
       "peerDependencies": {
         "bare-buffer": "*"
@@ -7323,9 +7221,9 @@
       "optional": true
     },
     "node_modules/bare-stream": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
-      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.4.tgz",
+      "integrity": "sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7351,9 +7249,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
-      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
+      "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7390,9 +7288,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz",
-      "integrity": "sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7512,9 +7410,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7541,9 +7439,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.28.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
-      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -7561,11 +7459,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.44",
-        "caniuse-lite": "^1.0.30001806",
-        "electron-to-chromium": "^1.5.393",
-        "node-releases": "^2.0.51",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7695,9 +7593,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001806",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
-      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -7799,9 +7697,9 @@
       }
     },
     "node_modules/chrome-launcher/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8171,13 +8069,16 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
-      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.50.0.tgz",
+      "integrity": "sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1"
+        "browserslist": "^4.28.7"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8852,9 +8753,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.396",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
-      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "version": "1.5.416",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.416.tgz",
+      "integrity": "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -9245,6 +9146,7 @@
       "version": "9.39.5",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9355,9 +9257,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9466,9 +9368,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9939,9 +9841,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {
@@ -10120,9 +10022,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
-      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -10554,9 +10456,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11256,9 +11158,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
-      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11441,25 +11343,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
-    "node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
     "node_modules/is-document.all": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
@@ -12393,9 +12276,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12860,15 +12743,15 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.2.0.tgz",
-      "integrity": "sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.4.1.tgz",
+      "integrity": "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.5",
+        "picomatch": "^4.0.7",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.2.4"
+        "tinyexec": "^1.3.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -13356,14 +13239,14 @@
       }
     },
     "node_modules/msw/node_modules/@inquirer/confirm": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
-      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
+      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.2.1",
-        "@inquirer/type": "^4.0.7"
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -13378,15 +13261,15 @@
       }
     },
     "node_modules/msw/node_modules/@inquirer/core": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
-      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.7",
-        "@inquirer/figures": "^2.0.7",
-        "@inquirer/type": "^4.0.7",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -13405,9 +13288,9 @@
       }
     },
     "node_modules/msw/node_modules/@inquirer/figures": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
-      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13415,9 +13298,9 @@
       }
     },
     "node_modules/msw/node_modules/@inquirer/type": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
-      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
+      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13634,9 +13517,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -13741,9 +13624,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14288,9 +14171,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14301,13 +14184,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
-      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14320,9 +14203,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
-      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -14342,9 +14225,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -14362,7 +14245,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -14371,9 +14254,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.29.7",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
-      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -14437,9 +14320,9 @@
       "license": "MIT"
     },
     "node_modules/pretty-ms": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
-      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.1.tgz",
+      "integrity": "sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14814,12 +14697,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
+      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "@remix-run/router": "1.23.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -14829,13 +14712,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
+      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "@remix-run/router": "1.23.4",
+        "react-router": "6.30.6"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -14891,9 +14774,9 @@
       }
     },
     "node_modules/recast": {
-      "version": "0.23.12",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.12.tgz",
-      "integrity": "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==",
+      "version": "0.23.21",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.21.tgz",
+      "integrity": "sha512-mFAyJq9vUbSTARLZUvAEf1z3YxlvAwswbmxMx2mPA/MSm4KmpwvwvhsH/NIrZhyOuwD60Lzyw2qh83uCbgTPYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15246,9 +15129,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -15299,9 +15182,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.62.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
-      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15315,31 +15198,32 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.3",
-        "@rollup/rollup-android-arm64": "4.62.3",
-        "@rollup/rollup-darwin-arm64": "4.62.3",
-        "@rollup/rollup-darwin-x64": "4.62.3",
-        "@rollup/rollup-freebsd-arm64": "4.62.3",
-        "@rollup/rollup-freebsd-x64": "4.62.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
-        "@rollup/rollup-linux-arm64-musl": "4.62.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
-        "@rollup/rollup-linux-loong64-musl": "4.62.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
-        "@rollup/rollup-linux-x64-gnu": "4.62.3",
-        "@rollup/rollup-linux-x64-musl": "4.62.3",
-        "@rollup/rollup-openbsd-x64": "4.62.3",
-        "@rollup/rollup-openharmony-arm64": "4.62.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
-        "@rollup/rollup-win32-x64-gnu": "4.62.3",
-        "@rollup/rollup-win32-x64-msvc": "4.62.3",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -16128,9 +16012,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.1.tgz",
+      "integrity": "sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16432,9 +16316,9 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
-      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.5.1.tgz",
+      "integrity": "sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",
@@ -16498,9 +16382,9 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.1.tgz",
+      "integrity": "sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16573,9 +16457,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16586,13 +16470,13 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -16645,9 +16529,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16702,13 +16586,13 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.9",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
-      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.9"
+        "tldts-core": "^7.4.11"
       },
       "bin": {
         "tldts": "bin/cli.js"
@@ -16732,9 +16616,9 @@
       }
     },
     "node_modules/tldts/node_modules/tldts-core": {
-      "version": "7.4.9",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
-      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
       "dev": true,
       "license": "MIT"
     },
@@ -17249,9 +17133,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {
@@ -18397,12 +18281,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
   },
   "optionalDependencies": {
     "@ledgerhq/hw-transport-webhid": "^6.29.4",
-    "@ledgerhq/hw-transport-webusb": "^6.29.4"
     "@ledgerhq/hw-transport-webusb": "^6.29.4",
     "@stellar/ledger": "^1.0.0",
     "ioredis": "^5.4.0"

--- a/src/hooks/useWalletSessionListeners.ts
+++ b/src/hooks/useWalletSessionListeners.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react'
+import { startWalletSessionListeners } from '../lib/wallet/sessionListeners'
+
+/**
+ * Mount global wallet session listeners for the dashboard lifetime.
+ */
+export function useWalletSessionListeners(): void {
+  useEffect(() => startWalletSessionListeners(), [])
+}

--- a/src/lib/__tests__/alertRuleTemplates.test.ts
+++ b/src/lib/__tests__/alertRuleTemplates.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createAlertRuleFromTemplate,
+  getAlertRuleTemplate,
+  listAlertRuleTemplates,
+} from '../alertRuleTemplates'
+import {
+  evaluateFeeSpike,
+  evaluateRpcLatency,
+  evaluateSubmissionFailures,
+} from '../alertRuleEngine'
+import {
+  clearMetric,
+  incrementCounter,
+  recordApiCall,
+  recordFeeObservation,
+  recordMetric,
+} from '../../utils/metricsCollector'
+
+describe('alertRuleTemplates', () => {
+  beforeEach(() => {
+    clearMetric('business.fee.stroops')
+    clearMetric('business.tx.failure')
+    clearMetric('technical.api.latency_ms')
+  })
+
+  it('lists starter templates for common developer incidents', () => {
+    const templates = listAlertRuleTemplates()
+    expect(templates.map((template) => template.id)).toEqual([
+      'fee_spike',
+      'submission_failures',
+      'rpc_latency',
+    ])
+  })
+
+  it('creates a fee spike rule from template defaults', () => {
+    const template = getAlertRuleTemplate('fee_spike')
+    expect(template).not.toBeNull()
+
+    const rule = createAlertRuleFromTemplate({
+      templateId: 'fee_spike',
+      userId: 'GUSER',
+      accountAddress: 'GACCOUNT',
+    })
+
+    expect(rule.type).toBe('fee_spike')
+    expect(rule.config).toMatchObject({ multiplier: 2, windowSeconds: 900 })
+  })
+
+  it('rejects invalid template input', () => {
+    expect(() =>
+      createAlertRuleFromTemplate({
+        templateId: 'fee_spike',
+        userId: '',
+        accountAddress: 'GACCOUNT',
+      }),
+    ).toThrow(/required/)
+  })
+
+  it('triggers fee spike evaluation when latest fee exceeds baseline', () => {
+    const rule = createAlertRuleFromTemplate({
+      templateId: 'fee_spike',
+      userId: 'GUSER',
+      accountAddress: 'GACCOUNT',
+      overrides: { minSamples: 3, multiplier: 2, windowSeconds: 3600 },
+    })
+
+    recordFeeObservation(100)
+    recordFeeObservation(110)
+    recordFeeObservation(100)
+    recordFeeObservation(250)
+
+    expect(evaluateFeeSpike(rule)).toBe(true)
+  })
+
+  it('does not trigger submission failures below threshold', () => {
+    const rule = createAlertRuleFromTemplate({
+      templateId: 'submission_failures',
+      userId: 'GUSER',
+      accountAddress: 'GACCOUNT',
+      overrides: { failureCountThreshold: 3, windowSeconds: 3600 },
+    })
+
+    incrementCounter('business.tx.failure', 1)
+    incrementCounter('business.tx.failure', 1)
+
+    expect(evaluateSubmissionFailures(rule)).toBe(false)
+  })
+
+  it('triggers rpc latency regression when percentile exceeds threshold', () => {
+    const rule = createAlertRuleFromTemplate({
+      templateId: 'rpc_latency',
+      userId: 'GUSER',
+      accountAddress: 'GACCOUNT',
+      overrides: {
+        endpoint: 'horizon',
+        thresholdMs: 1000,
+        minSamples: 3,
+        percentile: 95,
+        windowSeconds: 3600,
+      },
+    })
+
+    recordApiCall('horizon', 400, 200)
+    recordApiCall('horizon', 500, 200)
+    recordApiCall('horizon', 1800, 200)
+
+    expect(evaluateRpcLatency(rule)).toBe(true)
+  })
+
+  it('handles insufficient metric samples as a boundary case', () => {
+    const rule = createAlertRuleFromTemplate({
+      templateId: 'rpc_latency',
+      userId: 'GUSER',
+      accountAddress: 'GACCOUNT',
+      overrides: { minSamples: 10, windowSeconds: 3600 },
+    })
+
+    recordMetric('technical.api.latency_ms', 2000, { endpoint: 'horizon' })
+    expect(evaluateRpcLatency(rule)).toBe(false)
+  })
+})

--- a/src/lib/__tests__/webhookSignatures.test.ts
+++ b/src/lib/__tests__/webhookSignatures.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseWebhookSignatureHeader,
+  signWebhookPayload,
+  verifyWebhookSignature,
+} from '../webhookSignatures'
+
+describe('webhookSignatures', () => {
+  const secret = 'test-secret-key'
+  const rawBody = JSON.stringify({ event: 'payment', amount: '10' })
+
+  it('signs and verifies a webhook payload', async () => {
+    const timestamp = 1_700_000_000
+    const signature = await signWebhookPayload(rawBody, secret, timestamp)
+
+    const result = await verifyWebhookSignature(rawBody, signature, secret, {
+      now: timestamp,
+      toleranceSeconds: 300,
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.timestamp).toBe(timestamp)
+  })
+
+  it('rejects tampered payloads', async () => {
+    const timestamp = 1_700_000_000
+    const signature = await signWebhookPayload(rawBody, secret, timestamp)
+
+    const result = await verifyWebhookSignature(`${rawBody}tampered`, signature, secret, {
+      now: timestamp,
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.reason).toBe('signature_mismatch')
+  })
+
+  it('rejects malformed signature headers', async () => {
+    const result = await verifyWebhookSignature(rawBody, 'invalid-header', secret)
+    expect(result.valid).toBe(false)
+    expect(result.reason).toBe('malformed_signature')
+  })
+
+  it('rejects signatures outside replay tolerance', async () => {
+    const timestamp = 1_700_000_000
+    const signature = await signWebhookPayload(rawBody, secret, timestamp)
+
+    const result = await verifyWebhookSignature(rawBody, signature, secret, {
+      now: timestamp + 600,
+      toleranceSeconds: 300,
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.reason).toBe('timestamp_out_of_tolerance')
+  })
+
+  it('parses signature headers with version prefix', () => {
+    const parsed = parseWebhookSignatureHeader('t=1700000000,v1=abc123')
+    expect(parsed.ok).toBe(true)
+    if (parsed.ok) {
+      expect(parsed.timestamp).toBe(1700000000)
+      expect(parsed.signature).toBe('abc123')
+    }
+  })
+})

--- a/src/lib/alertRuleEngine.ts
+++ b/src/lib/alertRuleEngine.ts
@@ -3,11 +3,24 @@
  * Polls Horizon for account data and evaluates rules
  */
 
-import type { AlertRule, BalanceThresholdConfig, OperationTypeConfig, CounterpartyConfig } from '../types/alerts'
+import type {
+  AlertRule,
+  BalanceThresholdConfig,
+  OperationTypeConfig,
+  CounterpartyConfig,
+  FeeSpikeConfig,
+  SubmissionFailuresConfig,
+  RpcLatencyConfig,
+} from '../types/alerts'
 import type { NetworkName } from './stellar'
 import { fetchAccount, fetchOperations, isValidPublicKey } from './stellar'
 import { getEnabledRules, updateRuleEvaluationTime } from './alertRulesDb'
 import { deliverNotification, createAlertNotification } from './alertNotifications'
+import {
+  countMetricEventsInWindow,
+  getMetricPointsInWindow,
+  getPercentile,
+} from '../utils/metricsCollector'
 
 // Evaluation loop state
 let evaluationInterval: ReturnType<typeof setInterval> | null = null
@@ -129,6 +142,12 @@ async function evaluateRule(rule: AlertRule, network: NetworkName): Promise<bool
       return evaluateOperationType(rule, network)
     case 'counterparty':
       return evaluateCounterparty(rule, network)
+    case 'fee_spike':
+      return evaluateFeeSpike(rule)
+    case 'submission_failures':
+      return evaluateSubmissionFailures(rule)
+    case 'rpc_latency':
+      return evaluateRpcLatency(rule)
     default:
       return false
   }
@@ -255,6 +274,58 @@ async function evaluateCounterparty(
   }
 }
 
+export function evaluateFeeSpike(rule: AlertRule): boolean {
+  const config = rule.config as FeeSpikeConfig
+  if (!Number.isFinite(config.multiplier) || config.multiplier <= 1) {
+    return false
+  }
+
+  const windowMs = Math.max(1, config.windowSeconds) * 1000
+  const points = getMetricPointsInWindow('business.fee.stroops', windowMs)
+  if (points.length < Math.max(1, config.minSamples)) {
+    return false
+  }
+
+  const values = points.map((point) => point.value)
+  const baseline = values.slice(0, -1)
+  if (!baseline.length) {
+    return false
+  }
+
+  const baselineMean = baseline.reduce((sum, value) => sum + value, 0) / baseline.length
+  const latest = values[values.length - 1]
+  return latest >= baselineMean * config.multiplier
+}
+
+export function evaluateSubmissionFailures(rule: AlertRule): boolean {
+  const config = rule.config as SubmissionFailuresConfig
+  if (!Number.isFinite(config.failureCountThreshold) || config.failureCountThreshold <= 0) {
+    return false
+  }
+
+  const windowMs = Math.max(1, config.windowSeconds) * 1000
+  const failures = countMetricEventsInWindow('business.tx.failure', windowMs)
+  return failures >= config.failureCountThreshold
+}
+
+export function evaluateRpcLatency(rule: AlertRule): boolean {
+  const config = rule.config as RpcLatencyConfig
+  if (!Number.isFinite(config.thresholdMs) || config.thresholdMs <= 0) {
+    return false
+  }
+
+  const windowMs = Math.max(1, config.windowSeconds) * 1000
+  const labels = config.endpoint ? { endpoint: config.endpoint } : undefined
+  const points = getMetricPointsInWindow('technical.api.latency_ms', windowMs, labels)
+  if (points.length < Math.max(1, config.minSamples)) {
+    return false
+  }
+
+  const values = points.map((point) => point.value)
+  const observed = getPercentile(values, config.percentile)
+  return observed >= config.thresholdMs
+}
+
 /**
  * Check if an operation matches counterparty criteria
  */
@@ -330,6 +401,24 @@ function createNotificationForRule(rule: AlertRule): any {
       const shortAddr = `${config.counterpartyAddress.slice(0, 6)}...${config.counterpartyAddress.slice(-6)}`
       title = 'Counterparty Alert'
       message = `${config.direction === 'incoming' ? 'Incoming' : config.direction === 'outgoing' ? 'Outgoing' : 'New'} transaction with ${shortAddr}`
+      break
+    }
+    case 'fee_spike': {
+      const config = rule.config as FeeSpikeConfig
+      title = 'Fee Spike Alert'
+      message = `Observed fees exceeded ${config.multiplier}x the recent baseline`
+      break
+    }
+    case 'submission_failures': {
+      const config = rule.config as SubmissionFailuresConfig
+      title = 'Submission Failure Alert'
+      message = `${config.failureCountThreshold}+ failed submissions detected in ${config.windowSeconds}s`
+      break
+    }
+    case 'rpc_latency': {
+      const config = rule.config as RpcLatencyConfig
+      title = 'RPC Latency Alert'
+      message = `p${config.percentile} latency exceeded ${config.thresholdMs}ms`
       break
     }
   }

--- a/src/lib/alertRuleTemplates.ts
+++ b/src/lib/alertRuleTemplates.ts
@@ -1,0 +1,110 @@
+/**
+ * Starter alert rule templates for common developer incidents.
+ */
+
+import type {
+  AlertRule,
+  ExecutionFrequency,
+  FeeSpikeConfig,
+  RpcLatencyConfig,
+  SubmissionFailuresConfig,
+} from '../types/alerts'
+
+export type AlertRuleTemplateId = 'fee_spike' | 'submission_failures' | 'rpc_latency'
+
+export interface AlertRuleTemplate {
+  id: AlertRuleTemplateId
+  name: string
+  description: string
+  type: AlertRule['type']
+  defaultConfig: FeeSpikeConfig | SubmissionFailuresConfig | RpcLatencyConfig
+  defaultFrequency: ExecutionFrequency
+  requiredMetrics: string[]
+}
+
+export const ALERT_RULE_TEMPLATES: Record<AlertRuleTemplateId, AlertRuleTemplate> = {
+  fee_spike: {
+    id: 'fee_spike',
+    name: 'Fee Spike',
+    description: 'Alert when observed base fees exceed the recent baseline by a configured multiplier.',
+    type: 'fee_spike',
+    defaultConfig: {
+      multiplier: 2,
+      windowSeconds: 900,
+      minSamples: 5,
+    },
+    defaultFrequency: 60,
+    requiredMetrics: ['business.fee.stroops'],
+  },
+  submission_failures: {
+    id: 'submission_failures',
+    name: 'Failed Submissions',
+    description: 'Alert when failed transaction submissions exceed a threshold within a time window.',
+    type: 'submission_failures',
+    defaultConfig: {
+      failureCountThreshold: 3,
+      windowSeconds: 300,
+    },
+    defaultFrequency: 60,
+    requiredMetrics: ['business.tx.failure'],
+  },
+  rpc_latency: {
+    id: 'rpc_latency',
+    name: 'RPC Latency Regression',
+    description: 'Alert when RPC/API latency percentile exceeds a threshold.',
+    type: 'rpc_latency',
+    defaultConfig: {
+      endpoint: 'horizon',
+      percentile: 95,
+      thresholdMs: 1500,
+      windowSeconds: 600,
+      minSamples: 10,
+    },
+    defaultFrequency: 60,
+    requiredMetrics: ['technical.api.latency_ms'],
+  },
+}
+
+export function listAlertRuleTemplates(): AlertRuleTemplate[] {
+  return Object.values(ALERT_RULE_TEMPLATES)
+}
+
+export function getAlertRuleTemplate(templateId: AlertRuleTemplateId): AlertRuleTemplate | null {
+  return ALERT_RULE_TEMPLATES[templateId] ?? null
+}
+
+export interface CreateAlertRuleFromTemplateInput {
+  templateId: AlertRuleTemplateId
+  userId: string
+  accountAddress: string
+  overrides?: Partial<FeeSpikeConfig | SubmissionFailuresConfig | RpcLatencyConfig>
+  executionFrequency?: ExecutionFrequency
+}
+
+export function createAlertRuleFromTemplate(input: CreateAlertRuleFromTemplateInput): AlertRule {
+  const template = getAlertRuleTemplate(input.templateId)
+  if (!template) {
+    throw new Error(`Unknown alert rule template: ${input.templateId}`)
+  }
+
+  if (!input.userId?.trim() || !input.accountAddress?.trim()) {
+    throw new Error('userId and accountAddress are required')
+  }
+
+  return {
+    id: `template-${input.templateId}-${Date.now()}`,
+    userId: input.userId.trim(),
+    accountAddress: input.accountAddress.trim(),
+    type: template.type,
+    config: {
+      ...template.defaultConfig,
+      ...input.overrides,
+    },
+    executionFrequency: input.executionFrequency ?? template.defaultFrequency,
+    enabled: true,
+    createdAt: Date.now(),
+    lastEvaluatedAt: null,
+    lastTriggeredAt: null,
+    notificationChannels: ['in_app'],
+  }
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -239,8 +239,10 @@ export interface StoreState {
   walletConnected: boolean
   walletType: string | null
   walletPublicKey: string | null
+  walletSessionRevokedReason: string | null
   setWalletConnected: (connected: boolean, type?: string | null, publicKey?: string | null) => void
   disconnectWallet: () => void
+  revokeWalletSession: (reason?: string) => void
 
   notifications: Notification[]
   notificationHistory: Notification[]
@@ -570,9 +572,32 @@ export const useStore = create<StoreState>((set) => ({
   walletConnected: false,
   walletType: null,
   walletPublicKey: null,
+  walletSessionRevokedReason: null,
   setWalletConnected: (connected, type = null, publicKey = null) =>
-    set({ walletConnected: connected, walletType: type, walletPublicKey: publicKey }),
-  disconnectWallet: () => set({ walletConnected: false, walletType: null, walletPublicKey: null }),
+    set({
+      walletConnected: connected,
+      walletType: type,
+      walletPublicKey: publicKey,
+      walletSessionRevokedReason: connected ? null : get().walletSessionRevokedReason,
+    }),
+  disconnectWallet: () =>
+    set({
+      walletConnected: false,
+      walletType: null,
+      walletPublicKey: null,
+      walletSessionRevokedReason: null,
+    }),
+  revokeWalletSession: (reason = 'session_revoked') =>
+    set({
+      walletConnected: false,
+      walletType: null,
+      walletPublicKey: null,
+      walletSessionRevokedReason: reason,
+      connectedAddress: null,
+      accountData: null,
+      accountLoading: false,
+      accountError: null,
+    }),
 
   notifications: [],
   notificationHistory: [],

--- a/src/lib/wallet/freighter.js
+++ b/src/lib/wallet/freighter.js
@@ -7,6 +7,10 @@ const FREIGHTER_API_URL = 'https://cdn.jsdelivr.net/npm/@stellar/freighter-api/d
 
 let freighterApi = null
 
+export function __resetFreighterApiCacheForTests() {
+  freighterApi = null
+}
+
 async function getFreighterApi() {
   if (freighterApi) return freighterApi
   if (typeof window !== 'undefined' && window.freighterApi) {
@@ -87,6 +91,50 @@ export async function getFreighterNetwork() {
   }
 }
 
+export async function getFreighterAddress() {
+  const api = await getFreighterApi()
+  if (!api) return null
+  try {
+    const result = await api.getAddress()
+    if (result.error) return null
+    return result.address || null
+  } catch {
+    return null
+  }
+}
+
+export async function isFreighterAllowed() {
+  const api = await getFreighterApi()
+  if (!api || typeof api.isAllowed !== 'function') return null
+  try {
+    const result = await api.isAllowed()
+    return result.isAllowed === true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Map Freighter network identifiers to dashboard network names.
+ */
+export function normalizeFreighterNetwork(network) {
+  if (typeof network !== 'string') return null
+  const value = network.trim().toUpperCase()
+  switch (value) {
+    case 'PUBLIC':
+    case 'MAINNET':
+      return 'mainnet'
+    case 'TESTNET':
+      return 'testnet'
+    case 'FUTURENET':
+      return 'futurenet'
+    case 'LOCAL':
+      return 'local'
+    default:
+      return null
+  }
+}
+
 /**
  * Listen for account changes from Freighter.
  * Not all versions of Freighter natively broadcast this, but we handle it if fired.
@@ -122,4 +170,95 @@ export function onFreighterLock(callback) {
     return () => window.removeEventListener('freighterLock', handler);
   }
   return () => {};
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 5000
+
+/**
+ * Poll Freighter for lock, disconnect, account, and network changes.
+ * Supplements custom DOM events for environments where Freighter does not emit them.
+ * @param {object} [options]
+ * @param {() => void} [options.onLock]
+ * @param {() => void} [options.onDisconnect]
+ * @param {(publicKey: string) => void} [options.onAccountChange]
+ * @param {(network: string) => void} [options.onNetworkChange]
+ * @param {number} [options.pollIntervalMs]
+ */
+export function subscribeFreighterSession({
+  onLock,
+  onDisconnect,
+  onAccountChange,
+  onNetworkChange,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+} = {}) {
+  if (typeof window === 'undefined') {
+    return () => {}
+  }
+
+  let stopped = false
+  let lastAddress = null
+  let lastNetwork = null
+
+  const poll = async () => {
+    if (stopped) return
+
+    const api = await getFreighterApi()
+    if (!api) {
+      onDisconnect?.()
+      return
+    }
+
+    try {
+      const allowed = await isFreighterAllowed()
+      if (allowed === false) {
+        onLock?.()
+        return
+      }
+
+      const connected = await api.isConnected()
+      if (!connected?.isConnected) {
+        onDisconnect?.()
+        return
+      }
+
+      const address = await getFreighterAddress()
+      if (!address) {
+        onLock?.()
+        return
+      }
+
+      if (lastAddress !== null && address !== lastAddress) {
+        onAccountChange?.(address)
+      }
+      lastAddress = address
+
+      const network = await getFreighterNetwork()
+      if (network && lastNetwork !== null && network !== lastNetwork) {
+        onNetworkChange?.(network)
+      }
+      if (network) {
+        lastNetwork = network
+      }
+    } catch {
+      onDisconnect?.()
+    }
+  }
+
+  void poll()
+  const intervalId = window.setInterval(() => {
+    void poll()
+  }, pollIntervalMs)
+
+  const onVisibility = () => {
+    if (document.visibilityState === 'visible') {
+      void poll()
+    }
+  }
+  document.addEventListener('visibilitychange', onVisibility)
+
+  return () => {
+    stopped = true
+    window.clearInterval(intervalId)
+    document.removeEventListener('visibilitychange', onVisibility)
+  }
 }

--- a/src/lib/wallet/sessionListeners.ts
+++ b/src/lib/wallet/sessionListeners.ts
@@ -1,0 +1,122 @@
+/**
+ * Global wallet session listeners for Freighter.
+ * Mounted at the app layout level so events are handled even when the wallet tab is unmounted.
+ */
+
+import { useStore } from '../store'
+import type { NetworkName } from '../stellar'
+import { fetchAccount } from '../stellar'
+import {
+  onFreighterAccountChange,
+  onFreighterLock,
+  onFreighterNetworkChange,
+  subscribeFreighterSession,
+  normalizeFreighterNetwork,
+} from './freighter'
+
+let accountFetchGeneration = 0
+
+function revokeSession(reason: string): void {
+  accountFetchGeneration += 1
+  useStore.getState().revokeWalletSession(reason)
+}
+
+async function reloadAccountForKey(publicKey: string): Promise<void> {
+  const generation = ++accountFetchGeneration
+  const state = useStore.getState()
+
+  if (!state.walletConnected || state.walletType !== 'freighter') {
+    return
+  }
+
+  state.setWalletConnected(true, 'freighter', publicKey)
+  state.setConnectedAddress(publicKey)
+  state.setAccountLoading(true)
+  state.setAccountError(null)
+
+  try {
+    const account = await fetchAccount(publicKey, useStore.getState().network)
+    if (generation !== accountFetchGeneration) return
+    useStore.getState().setAccountData(account)
+  } catch (error) {
+    if (generation !== accountFetchGeneration) return
+    const message = error instanceof Error ? error.message : String(error)
+    useStore.getState().setAccountError(message)
+  } finally {
+    if (generation === accountFetchGeneration) {
+      useStore.getState().setAccountLoading(false)
+    }
+  }
+}
+
+function handleAccountChange(publicKey: unknown): void {
+  if (typeof publicKey !== 'string' || !publicKey.trim()) {
+    revokeSession('invalid_account_change')
+    return
+  }
+
+  const { walletConnected, walletType, walletPublicKey } = useStore.getState()
+  if (!walletConnected || walletType !== 'freighter') {
+    return
+  }
+
+  if (publicKey === walletPublicKey) {
+    return
+  }
+
+  void reloadAccountForKey(publicKey)
+}
+
+function handleNetworkChange(network: unknown): void {
+  if (typeof network !== 'string' || !network.trim()) {
+    revokeSession('invalid_network_change')
+    return
+  }
+
+  const { walletConnected, walletType, network: dashboardNetwork } = useStore.getState()
+  if (!walletConnected || walletType !== 'freighter') {
+    return
+  }
+
+  const normalized = normalizeFreighterNetwork(network)
+  if (!normalized) {
+    revokeSession('unsupported_network')
+    return
+  }
+
+  if (normalized !== dashboardNetwork) {
+    useStore.getState().setNetwork(normalized as NetworkName)
+    const { walletPublicKey } = useStore.getState()
+    if (walletPublicKey) {
+      void reloadAccountForKey(walletPublicKey)
+    }
+  }
+}
+
+/**
+ * Start Freighter session listeners. Returns a cleanup function.
+ */
+export function startWalletSessionListeners(): () => void {
+  if (typeof window === 'undefined') {
+    return () => {}
+  }
+
+  const cleanups: Array<() => void> = []
+
+  cleanups.push(onFreighterLock(() => revokeSession('wallet_locked')))
+  cleanups.push(onFreighterAccountChange(handleAccountChange))
+  cleanups.push(onFreighterNetworkChange(handleNetworkChange))
+
+  cleanups.push(
+    subscribeFreighterSession({
+      onLock: () => revokeSession('wallet_locked'),
+      onDisconnect: () => revokeSession('wallet_disconnected'),
+      onAccountChange: handleAccountChange,
+      onNetworkChange: handleNetworkChange,
+    }),
+  )
+
+  return () => {
+    cleanups.forEach((cleanup) => cleanup())
+  }
+}

--- a/src/lib/webhookSignatures.ts
+++ b/src/lib/webhookSignatures.ts
@@ -1,0 +1,149 @@
+/**
+ * HMAC signature helpers for inbound automation webhooks.
+ *
+ * Signatures use the format: t=<unix-seconds>,v1=<hex-hmac>
+ * The signed payload is `${timestamp}.${rawBody}`.
+ */
+
+const SIGNATURE_PREFIX = 't=';
+const VERSION_PREFIX = ',v1=';
+const DEFAULT_TOLERANCE_SECONDS = 300;
+
+interface VerifyWebhookSignatureOptions {
+  toleranceSeconds?: number;
+  now?: number;
+}
+
+type ParsedSignature =
+  | { ok: false; reason: string }
+  | { ok: true; timestamp: number; signature: string };
+
+function encodeUtf8(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function timingSafeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  let mismatch = 0;
+  for (let i = 0; i < left.length; i += 1) {
+    mismatch |= left.charCodeAt(i) ^ right.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+async function hmacSha256Hex(secret: string, payload: string): Promise<string> {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('Web Crypto API is not available in this environment');
+  }
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encodeUtf8(secret) as BufferSource,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  const signature = await crypto.subtle.sign('HMAC', key, encodeUtf8(payload) as BufferSource);
+  return toHex(signature);
+}
+
+export function parseWebhookSignatureHeader(headerValue: string): ParsedSignature {
+  if (typeof headerValue !== 'string' || !headerValue.trim()) {
+    return { ok: false, reason: 'missing_signature' };
+  }
+
+  const timestampPart = headerValue.match(/(?:^|,|\s)t=(\d+)/)?.[1];
+  const signaturePart = headerValue.match(/(?:^|,|\s)v1=([a-f0-9]+)/i)?.[1];
+
+  if (!timestampPart || !signaturePart) {
+    return { ok: false, reason: 'malformed_signature' };
+  }
+
+  const timestamp = Number.parseInt(timestampPart, 10);
+  if (!Number.isFinite(timestamp) || timestamp <= 0) {
+    return { ok: false, reason: 'invalid_timestamp' };
+  }
+
+  return {
+    ok: true,
+    timestamp,
+    signature: signaturePart.toLowerCase(),
+  };
+}
+
+export async function signWebhookPayload(
+  rawBody: string,
+  secret: string,
+  timestamp?: number,
+): Promise<string> {
+  if (typeof rawBody !== 'string') {
+    throw new TypeError('rawBody must be a string');
+  }
+  if (typeof secret !== 'string' || !secret) {
+    throw new TypeError('secret must be a non-empty string');
+  }
+
+  const ts = timestamp ?? Math.floor(Date.now() / 1000);
+  const signedPayload = `${ts}.${rawBody}`;
+  const digest = await hmacSha256Hex(secret, signedPayload);
+  return `${SIGNATURE_PREFIX}${ts}${VERSION_PREFIX}${digest}`;
+}
+
+export async function verifyWebhookSignature(
+  rawBody: string,
+  signatureHeader: string,
+  secret: string,
+  options: VerifyWebhookSignatureOptions = {},
+): Promise<{ valid: boolean; reason?: string; timestamp?: number }> {
+  if (typeof rawBody !== 'string') {
+    return { valid: false, reason: 'invalid_body' };
+  }
+  if (typeof secret !== 'string' || !secret) {
+    return { valid: false, reason: 'invalid_secret' };
+  }
+
+  const parsed = parseWebhookSignatureHeader(signatureHeader);
+  if (!parsed.ok) {
+    return { valid: false, reason: parsed.reason };
+  }
+
+  const toleranceSeconds = options.toleranceSeconds ?? DEFAULT_TOLERANCE_SECONDS;
+  const now = options.now ?? Math.floor(Date.now() / 1000);
+  if (Math.abs(now - parsed.timestamp) > toleranceSeconds) {
+    return { valid: false, reason: 'timestamp_out_of_tolerance' };
+  }
+
+  const signedPayload = `${parsed.timestamp}.${rawBody}`;
+  let expected;
+  try {
+    expected = await hmacSha256Hex(secret, signedPayload);
+  } catch {
+    return { valid: false, reason: 'unsupported_environment' };
+  }
+
+  if (!timingSafeEqual(expected, parsed.signature)) {
+    return { valid: false, reason: 'signature_mismatch' };
+  }
+
+  return { valid: true, timestamp: parsed.timestamp };
+}
+
+export async function signWebhookPayloadObject(
+  payload: Record<string, unknown>,
+  secret: string,
+  timestamp?: number,
+): Promise<{ rawBody: string; signature: string }> {
+  const rawBody = JSON.stringify(payload);
+  const signature = await signWebhookPayload(rawBody, secret, timestamp);
+  return { rawBody, signature };
+}

--- a/src/lib/webhooks.ts
+++ b/src/lib/webhooks.ts
@@ -4,6 +4,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
+import { signWebhookPayload, verifyWebhookSignature } from './webhookSignatures';
 
 export type WebhookEventType = 'payment' | 'trust' | 'contract' | 'account_merge' | 'all';
 export type WebhookProvider = 'custom' | 'zapier' | 'make';
@@ -211,7 +212,8 @@ class WebhookManager {
     event.lastAttempt = new Date().toISOString();
 
     try {
-      const signature = this.generateSignature(event.payload, endpoint.secret);
+      const body = JSON.stringify(event.payload);
+      const signature = await signWebhookPayload(body, endpoint.secret);
       const response = await fetch(endpoint.url, {
         method: 'POST',
         headers: {
@@ -221,7 +223,7 @@ class WebhookManager {
           'X-Webhook-Event-Id': event.id,
           'X-Automation-Provider': endpoint.provider || 'custom',
         },
-        body: JSON.stringify(event.payload),
+        body,
       });
 
       const responseTime = Date.now() - startTime;
@@ -265,23 +267,6 @@ class WebhookManager {
     return INITIAL_RETRY_DELAY * Math.pow(2, attempts - 1);
   }
 
-  // Signature Generation & Verification
-  private generateSignature(payload: Record<string, unknown>, secret: string): string {
-    const payloadString = JSON.stringify(payload);
-    return this.hmacSha256(payloadString, secret);
-  }
-
-  private hmacSha256(data: string, secret: string): string {
-    // Using Web Crypto API for HMAC-SHA256
-    const encoder = new TextEncoder();
-    const dataBuffer = encoder.encode(data);
-    const keyBuffer = encoder.encode(secret);
-
-    // For browser compatibility, we'll use a simple hash
-    // In production, use proper HMAC-SHA256 implementation
-    return btoa(data + secret).slice(0, 64);
-  }
-
   async verifySignature(
     payload: Record<string, unknown>,
     signature: string,
@@ -290,8 +275,9 @@ class WebhookManager {
     const endpoint = await this.getEndpoint(endpointId);
     if (!endpoint) return false;
 
-    const expectedSignature = this.generateSignature(payload, endpoint.secret);
-    return signature === expectedSignature;
+    const rawBody = JSON.stringify(payload);
+    const result = await verifyWebhookSignature(rawBody, signature, endpoint.secret);
+    return result.valid;
   }
 
   // Event Storage
@@ -325,7 +311,9 @@ class WebhookManager {
 
       request.onsuccess = () => {
         const events = request.result;
-        events.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+        events.sort((a: WebhookEvent, b: WebhookEvent) =>
+          new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+        );
         resolve(events.slice(0, limit));
       };
       request.onerror = () => reject(request.error);

--- a/src/routes/DashboardLayout.tsx
+++ b/src/routes/DashboardLayout.tsx
@@ -43,6 +43,7 @@ import DebugAssistantButton from '../components/debug/DebugAssistantButton';
 import DebugAssistantPanel from '../components/debug/DebugAssistantPanel';
 import ConversationPanel from '../components/conversation/ConversationPanel';
 import { useRouteFocus } from '../hooks/useRouteFocus';
+import { useWalletSessionListeners } from '../hooks/useWalletSessionListeners';
 
 interface SearchResult {
   type?: string;
@@ -248,6 +249,7 @@ export default function DashboardLayout() {
   const preferencesTriggerRef = React.useRef<HTMLButtonElement>(null);
 
   useRouteFocus(activeTab);
+  useWalletSessionListeners();
 
   useEffect(() => {
     // v2: full multi-layer cache initialization (warm, prune, SW bridge)

--- a/src/types/alerts.ts
+++ b/src/types/alerts.ts
@@ -2,7 +2,13 @@
  * Type definitions for the Alert Rules and Notifications System
  */
 
-export type AlertRuleType = 'balance_threshold' | 'operation_type' | 'counterparty'
+export type AlertRuleType =
+  | 'balance_threshold'
+  | 'operation_type'
+  | 'counterparty'
+  | 'fee_spike'
+  | 'submission_failures'
+  | 'rpc_latency'
 export type NotificationChannel = 'in_app' | 'browser'
 export type BalanceDirection = 'below' | 'above'
 export type CounterpartyDirection = 'incoming' | 'outgoing' | 'any'
@@ -24,10 +30,32 @@ export interface CounterpartyConfig {
   direction: CounterpartyDirection
 }
 
-export type AlertRuleConfig = 
-  | BalanceThresholdConfig 
-  | OperationTypeConfig 
+export interface FeeSpikeConfig {
+  multiplier: number
+  windowSeconds: number
+  minSamples: number
+}
+
+export interface SubmissionFailuresConfig {
+  failureCountThreshold: number
+  windowSeconds: number
+}
+
+export interface RpcLatencyConfig {
+  endpoint?: string
+  percentile: 50 | 95 | 99
+  thresholdMs: number
+  windowSeconds: number
+  minSamples: number
+}
+
+export type AlertRuleConfig =
+  | BalanceThresholdConfig
+  | OperationTypeConfig
   | CounterpartyConfig
+  | FeeSpikeConfig
+  | SubmissionFailuresConfig
+  | RpcLatencyConfig
 
 export interface AlertRule {
   id: string

--- a/src/utils/metricsCollector.ts
+++ b/src/utils/metricsCollector.ts
@@ -98,6 +98,13 @@ export function recordApiCall(endpoint: string, durationMs: number, statusCode: 
   incrementCounter('technical.api.calls', 1, { endpoint })
 }
 
+export function recordFeeObservation(feeStroops: number): void {
+  if (!Number.isFinite(feeStroops) || feeStroops < 0) {
+    return
+  }
+  recordMetric('business.fee.stroops', feeStroops)
+}
+
 export function recordCacheOperation(hit: boolean): void {
   incrementCounter(hit ? 'technical.cache.hits' : 'technical.cache.misses')
 }
@@ -184,6 +191,51 @@ export function getMetric(name: string): MetricSeries | undefined {
   return registry.get(name)
 }
 
+export function getMetricPointsInWindow(
+  name: string,
+  windowMs: number,
+  labels?: Record<string, string>,
+): MetricPoint[] {
+  const series = registry.get(name)
+  if (!series || !series.points.length) {
+    return []
+  }
+
+  const cutoff = Date.now() - windowMs
+  return series.points.filter((point) => {
+    const timestamp = Date.parse(point.timestamp)
+    if (!Number.isFinite(timestamp) || timestamp < cutoff) {
+      return false
+    }
+
+    if (!labels) {
+      return true
+    }
+
+    return Object.entries(labels).every(([key, value]) => point.labels?.[key] === value)
+  })
+}
+
+export function countMetricEventsInWindow(
+  counterName: string,
+  windowMs: number,
+  labels?: Record<string, string>,
+): number {
+  const points = getMetricPointsInWindow(counterName, windowMs, labels)
+  if (!points.length) {
+    return 0
+  }
+
+  const series = registry.get(counterName)
+  if (series?.kind === 'counter') {
+    return points.length
+  }
+
+  const first = points[0]?.value ?? 0
+  const last = points[points.length - 1]?.value ?? 0
+  return Math.max(0, last - first)
+}
+
 export function clearMetric(name: string): void {
   const series = registry.get(name)
   if (series) {
@@ -199,6 +251,7 @@ export function clearMetric(name: string): void {
   ['business.tx.success', 'counter', 'ops', 'Successful transaction submissions'],
   ['business.tx.failure', 'counter', 'ops', 'Failed transaction submissions'],
   ['business.tx.duration_ms', 'histogram', 'ms', 'Transaction submission duration'],
+  ['business.fee.stroops', 'histogram', 'stroops', 'Observed transaction base fees'],
   ['technical.api.latency_ms', 'histogram', 'ms', 'API call latency'],
   ['technical.api.calls', 'counter', 'ops', 'Total API calls'],
   ['technical.api.errors', 'counter', 'ops', 'API error count'],

--- a/tests/api/middleware/apiVersioning.test.js
+++ b/tests/api/middleware/apiVersioning.test.js
@@ -1,0 +1,87 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  apiVersioningMiddleware,
+  CURRENT_API_VERSION,
+  withApiVersion,
+} from '../../../api/middleware/apiVersioning.js'
+
+function mockReq(overrides = {}) {
+  return {
+    path: '/api/v1/accounts/GABC',
+    headers: {},
+    ...overrides,
+  }
+}
+
+function mockRes() {
+  const res = {
+    statusCode: null,
+    body: null,
+    _headers: {},
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(data) {
+      this.body = data
+      return this
+    },
+    set(field, value) {
+      this._headers[field.toLowerCase()] = value
+      return this
+    },
+    setHeader(field, value) {
+      this._headers[field.toLowerCase()] = value
+      return this
+    },
+  }
+  return res
+}
+
+describe('apiVersioningMiddleware', () => {
+  it('adds version headers on every response', () => {
+    const req = mockReq()
+    const res = mockRes()
+    let nextCalled = false
+
+    apiVersioningMiddleware(req, res, () => {
+      nextCalled = true
+    })
+
+    expect(nextCalled).toBe(true)
+    expect(res._headers['api-version']).toBe(CURRENT_API_VERSION)
+    expect(res._headers['x-api-version']).toBe(CURRENT_API_VERSION)
+  })
+
+  it('adds deprecation headers for deprecated routes', () => {
+    const req = mockReq({ path: '/api/v1/behavior/profile' })
+    const res = mockRes()
+
+    apiVersioningMiddleware(req, res, () => {})
+
+    expect(res._headers.deprecation).toBeTruthy()
+    expect(res._headers.sunset).toBeTruthy()
+    expect(res._headers.link).toContain('/api/v2/behavior')
+    expect(res._headers.warning).toContain('deprecated')
+  })
+
+  it('rejects unsupported Accept-Version values', () => {
+    const req = mockReq({ headers: { 'accept-version': '9.9' } })
+    const res = mockRes()
+
+    apiVersioningMiddleware(req, res, () => {})
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body.error).toBe('Unsupported API version')
+    expect(res.body.supportedVersions).toContain('1.0.0')
+  })
+
+  it('wraps payloads with explicit version metadata', () => {
+    const payload = withApiVersion({ data: [] })
+    expect(payload.apiVersion).toBe(CURRENT_API_VERSION)
+    expect(payload.data).toEqual([])
+  })
+})

--- a/tests/unit/lib/store.test.js
+++ b/tests/unit/lib/store.test.js
@@ -99,6 +99,25 @@ describe('useStore', () => {
     expect(walletPublicKey).toBeNull();
   });
 
+  it('revokeWalletSession clears wallet and account state with reason', () => {
+    useStore.setState({
+      walletConnected: true,
+      walletType: 'freighter',
+      walletPublicKey: 'GPUB',
+      connectedAddress: 'GPUB',
+      accountData: { id: 'GPUB' },
+      accountError: 'stale',
+    }, false);
+
+    useStore.getState().revokeWalletSession('wallet_locked');
+    const state = useStore.getState();
+    expect(state.walletConnected).toBe(false);
+    expect(state.connectedAddress).toBeNull();
+    expect(state.accountData).toBeNull();
+    expect(state.accountError).toBeNull();
+    expect(state.walletSessionRevokedReason).toBe('wallet_locked');
+  });
+
   // ─── Notifications ─────────────────────────────────────────────────────────
 
   it('addNotification appends to list', () => {

--- a/tests/unit/lib/wallet/freighter.test.js
+++ b/tests/unit/lib/wallet/freighter.test.js
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  normalizeFreighterNetwork,
+  onFreighterAccountChange,
+  onFreighterLock,
+  subscribeFreighterSession,
+  __resetFreighterApiCacheForTests,
+} from '../../../../src/lib/wallet/freighter.js'
+
+describe('freighter connector', () => {
+  beforeEach(() => {
+    window.freighterApi = {
+      isConnected: vi.fn(async () => ({ isConnected: true })),
+      isAllowed: vi.fn(async () => ({ isAllowed: true })),
+      getAddress: vi.fn(async () => ({ address: 'GOLD123' })),
+      getNetwork: vi.fn(async () => ({ network: 'TESTNET' })),
+    }
+  })
+
+  afterEach(() => {
+    delete window.freighterApi
+    __resetFreighterApiCacheForTests()
+    vi.restoreAllMocks()
+  })
+
+  it('normalizes supported Freighter networks', () => {
+    expect(normalizeFreighterNetwork('PUBLIC')).toBe('mainnet')
+    expect(normalizeFreighterNetwork('TESTNET')).toBe('testnet')
+    expect(normalizeFreighterNetwork('FUTURENET')).toBe('futurenet')
+  })
+
+  it('returns null for invalid network input', () => {
+    expect(normalizeFreighterNetwork('')).toBeNull()
+    expect(normalizeFreighterNetwork('UNKNOWN')).toBeNull()
+    expect(normalizeFreighterNetwork(null)).toBeNull()
+  })
+
+  it('handles account change events', () => {
+    const callback = vi.fn()
+    const cleanup = onFreighterAccountChange(callback)
+
+    window.dispatchEvent(new CustomEvent('freighterAccountChange', { detail: 'GNEW123' }))
+    expect(callback).toHaveBeenCalledWith('GNEW123')
+
+    cleanup()
+    window.dispatchEvent(new CustomEvent('freighterAccountChange', { detail: 'GOTHER' }))
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles lock events', () => {
+    const callback = vi.fn()
+    const cleanup = onFreighterLock(callback)
+
+    window.dispatchEvent(new CustomEvent('freighterLock'))
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    cleanup()
+  })
+
+  it('polls for account changes when Freighter updates outside DOM events', async () => {
+    const onAccountChange = vi.fn()
+    const cleanup = subscribeFreighterSession({
+      onAccountChange,
+      pollIntervalMs: 20,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(onAccountChange).not.toHaveBeenCalled()
+
+    window.freighterApi.getAddress = vi.fn(async () => ({ address: 'GNEW456' }))
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    expect(onAccountChange).toHaveBeenCalledWith('GNEW456')
+    cleanup()
+  })
+
+  it('reports disconnect when Freighter is no longer available', async () => {
+    const onDisconnect = vi.fn()
+    const cleanup = subscribeFreighterSession({
+      onDisconnect,
+      pollIntervalMs: 20,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 25))
+
+    delete window.freighterApi
+    __resetFreighterApiCacheForTests()
+
+    await vi.waitFor(
+      () => {
+        expect(onDisconnect).toHaveBeenCalled()
+      },
+      { timeout: 200 },
+    )
+
+    cleanup()
+  })
+})

--- a/tests/unit/lib/wallet/sessionListeners.test.js
+++ b/tests/unit/lib/wallet/sessionListeners.test.js
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../../../../src/lib/storage', () => ({
+  getStoredValue: vi.fn().mockResolvedValue(null),
+  setStoredValue: vi.fn(),
+}))
+
+vi.mock('../../../../src/utils/stateSync', () => ({
+  broadcastStateChange: vi.fn(),
+  onStateChange: vi.fn(),
+  syncState: vi.fn().mockResolvedValue(undefined),
+  loadSyncedState: vi.fn().mockResolvedValue(null),
+  resolveStateConflict: vi.fn((local) => local),
+  getTabId: vi.fn().mockReturnValue('test-tab'),
+}))
+
+vi.mock('../../../../src/lib/stellar', () => ({
+  fetchAccount: vi.fn(async () => ({ id: 'GNEW123', balances: [] })),
+}))
+
+vi.mock('../../../../src/lib/wallet/freighter', () => ({
+  onFreighterAccountChange: vi.fn((callback) => {
+    window.__accountChangeCallback = callback
+    return () => {}
+  }),
+  onFreighterLock: vi.fn((callback) => {
+    window.__lockCallback = callback
+    return () => {}
+  }),
+  onFreighterNetworkChange: vi.fn((callback) => {
+    window.__networkChangeCallback = callback
+    return () => {}
+  }),
+  subscribeFreighterSession: vi.fn(() => () => {}),
+  normalizeFreighterNetwork: vi.fn((network) => {
+    if (network === 'TESTNET') return 'testnet'
+    if (network === 'PUBLIC') return 'mainnet'
+    return null
+  }),
+}))
+
+import { useStore } from '../../../../src/lib/store'
+import { startWalletSessionListeners } from '../../../../src/lib/wallet/sessionListeners'
+import { fetchAccount } from '../../../../src/lib/stellar'
+
+describe('wallet session listeners', () => {
+  beforeEach(() => {
+    useStore.setState({
+      walletConnected: true,
+      walletType: 'freighter',
+      walletPublicKey: 'GOLD123',
+      connectedAddress: 'GOLD123',
+      accountData: { id: 'GOLD123' },
+      accountLoading: false,
+      accountError: null,
+      network: 'testnet',
+      walletSessionRevokedReason: null,
+    }, false)
+  })
+
+  it('revokes the wallet session when Freighter locks', () => {
+    startWalletSessionListeners()
+    window.__lockCallback()
+
+    const state = useStore.getState()
+    expect(state.walletConnected).toBe(false)
+    expect(state.connectedAddress).toBeNull()
+    expect(state.accountData).toBeNull()
+    expect(state.walletSessionRevokedReason).toBe('wallet_locked')
+  })
+
+  it('reloads account data when the active account changes', async () => {
+    startWalletSessionListeners()
+    window.__accountChangeCallback('GNEW123')
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const state = useStore.getState()
+    expect(fetchAccount).toHaveBeenCalledWith('GNEW123', 'testnet')
+    expect(state.walletPublicKey).toBe('GNEW123')
+    expect(state.connectedAddress).toBe('GNEW123')
+    expect(state.accountData).toEqual({ id: 'GNEW123', balances: [] })
+  })
+
+  it('revokes session for unsupported network changes', () => {
+    startWalletSessionListeners()
+    window.__networkChangeCallback('CUSTOM-UNKNOWN')
+
+    const state = useStore.getState()
+    expect(state.walletConnected).toBe(false)
+    expect(state.walletSessionRevokedReason).toBe('unsupported_network')
+  })
+})


### PR DESCRIPTION
# Pull Request Summary: Wallet Sessions, API Versioning, Alert Templates & Webhook Signatures

## Summary

This PR implements four 2026 roadmap items: global Freighter wallet session handling, explicit public API versioning with deprecation headers, starter alert rule templates for common developer incidents, and secure HMAC webhook signature verification.

closes #760
closes #918
closes #916
closes #915

---

## #760 — Wallet session revocation and account-change listeners

### Changes
- Added `useWalletSessionListeners` hook mounted in `DashboardLayout` so session events are handled app-wide (not only on the wallet tab)
- Added `revokeWalletSession(reason)` to the Zustand store to atomically clear wallet identity and account state
- Enhanced Freighter connector with:
  - Network normalization (`PUBLIC` → mainnet, `TESTNET` → testnet, etc.)
  - DOM event listeners for lock, account change, and network change
  - Polling fallback via `subscribeFreighterSession` when the extension does not emit events
- Added `src/lib/wallet/sessionListeners.ts` to coordinate lock, disconnect, account reload, and network sync

### Documentation
- Updated `docs-site/docs/getting-started/authentication.md` with session lifecycle, security, and migration notes

### Tests
- `tests/unit/lib/wallet/freighter.test.js` — normalization, events, polling, disconnect
- `tests/unit/lib/wallet/sessionListeners.test.js` — lock revocation, account reload, unsupported network
- `tests/unit/lib/store.test.js` — `revokeWalletSession` behavior

---

## #918 — Version public dashboard API responses with deprecation headers

### Changes
- Added `api/middleware/apiVersioning.js` with:
  - `API-Version` and `X-API-Version` headers on every response
  - `Deprecation`, `Sunset`, `Link`, and `Warning` headers for deprecated routes
  - `Accept-Version` validation (returns `400` for unsupported versions)
- Applied middleware globally in `api/server.js`
- Updated `/api/docs` to expose `apiVersion: 1.0.0`

### Documentation
- Added `docs/api/API_VERSIONING.md`
- Updated `docs/api/VERSION_HISTORY.md`

### Tests
- `tests/api/middleware/apiVersioning.test.js` — version headers, deprecation headers, invalid `Accept-Version`, payload wrapper

---

## #916 — Alert rule templates for common developer incidents

### Changes
- Added `src/lib/alertRuleTemplates.ts` with starter templates:
  - **Fee Spike** — base fees exceed recent baseline by a multiplier
  - **Failed Submissions** — failed tx count exceeds threshold in a window
  - **RPC Latency Regression** — API/RPC p50/p95/p99 latency exceeds threshold
- Extended `src/types/alerts.ts` with `fee_spike`, `submission_failures`, and `rpc_latency` rule types
- Extended `src/lib/alertRuleEngine.ts` with metric-driven evaluators
- Added metric window helpers to `src/utils/metricsCollector.ts`:
  - `getMetricPointsInWindow`
  - `countMetricEventsInWindow`
  - `recordFeeObservation`

### Documentation
- Updated `docs/features/alert-rules.md` with template usage and metric instrumentation notes

### Tests
- `src/lib/__tests__/alertRuleTemplates.test.ts` — template creation, primary flow, boundary case (insufficient samples), failure paths

---

## #915 — Webhook signature verification helpers for inbound events

### Changes
- Added `src/lib/webhookSignatures.ts` with:
  - `signWebhookPayload` / `verifyWebhookSignature`
  - `parseWebhookSignatureHeader`
  - HMAC-SHA256 via Web Crypto API
  - Timestamp replay tolerance (default 300s)
  - Constant-time signature comparison
- Replaced placeholder `btoa(body + secret)` signing in `src/lib/webhooks.ts` with real HMAC signatures (`t=<timestamp>,v1=<hex>`)

### Documentation
- Added `docs/features/webhook-signatures.md` with signing, verification, failure codes, and migration notes

### Tests
- `src/lib/__tests__/webhookSignatures.test.ts` — sign/verify round-trip, tampering, malformed headers, replay tolerance

---

## Other fixes

- Fixed invalid JSON in `package.json` (`optionalDependencies` duplicate entry) that blocked `npm install`

---

## Test plan

- [x] `tests/unit/lib/wallet/freighter.test.js` (6 tests)
- [x] `tests/unit/lib/wallet/sessionListeners.test.js` (3 tests)
- [x] `tests/unit/lib/store.test.js` — includes `revokeWalletSession` (22 tests)
- [x] `tests/api/middleware/apiVersioning.test.js` (4 tests)
- [x] `src/lib/__tests__/alertRuleTemplates.test.ts` (7 tests)
- [x] `src/lib/__tests__/webhookSignatures.test.ts` (5 tests)

**47 tests passing** across the new and updated test files.

---

## Migration / compatibility notes

| Area | Note |
| --- | --- |
| **Wallet** | Session listeners now run globally; move any tab-scoped handling to `useWalletSessionListeners` |
| **API** | Existing `/api/v1/*` clients continue to work; `/api/v1/behavior/*` includes sunset headers pointing to `/api/v2/behavior` |
| **Webhooks** | Outbound signatures changed from placeholder digests to `t=<timestamp>,v1=<hmac>`; receivers must verify raw body bytes before JSON parsing |
| **Alerts** | Metric templates require instrumentation via `recordTransactionSubmitted`, `recordApiCall`, and `recordFeeObservation` |

---

## Files changed (key)

| Area | Files |
| --- | --- |
| Wallet | `src/lib/wallet/freighter.js`, `src/lib/wallet/sessionListeners.ts`, `src/hooks/useWalletSessionListeners.ts`, `src/lib/store.ts`, `src/routes/DashboardLayout.tsx` |
| API | `api/middleware/apiVersioning.js`, `api/server.js` |
| Alerts | `src/lib/alertRuleTemplates.ts`, `src/types/alerts.ts`, `src/lib/alertRuleEngine.ts`, `src/utils/metricsCollector.ts` |
| Webhooks | `src/lib/webhookSignatures.ts`, `src/lib/webhooks.ts` |
| Docs | `docs/api/API_VERSIONING.md`, `docs/features/webhook-signatures.md`, `docs/features/alert-rules.md`, `docs-site/docs/getting-started/authentication.md` |
| Tests | 6 new/updated test files (see Test plan above) |
