### PR TITLE
fix: decimal-safe stroop conversion (issue #754)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ npm run test:integration
 npm run test -w src/lib/feePredictor.ts -w src/lib/feePredictionIntegration.ts
 ```
 
+## Decimal-Safe Stroop Conversion
+
+All XLM and asset amount conversions now use the decimal-safe stroop utilities in `src/utils/stroopConversion.ts`. These functions use native `bigint` arithmetic to eliminate floating-point rounding errors.
+
+### Available Functions
+
+- `stroopsToXLM(stroops: bigint | number): string` - converts stroops to XLM string with 7 decimal places
+- `xlmToStroops(xlm: string | number): bigint` - converts XLM string/number to stroops bigint
+- `formatStroops(stroops: bigint | number): string` - formats stroops as "X.X XLM (Y stroops)"
+- `parseStroops(stroopsStr: string): bigint` - parses strings like "1.5 XLM" or "15000000" into stroops bigint
+
+### Migration Notes
+
+Replace all inline stroop conversions like `amount / 10000000` or `amount * 10000000` with the appropriate utility function. This ensures consistent rounding behavior across the application.
+
 ## Development
 
 ### Adding New Prediction Models

--- a/docs-site/CONTRIBUTING.md
+++ b/docs-site/CONTRIBUTING.md
@@ -66,6 +66,10 @@ npm run gen-api-docs
 
 This regenerates the interactive endpoint pages from the spec.
 
+## Decimal-safe stroop conversion
+
+Use the utilities in `src/utils/stroopConversion.ts` for all XLM and asset amount conversions. Do not use inline division or multiplication by 10000000, as floating-point arithmetic can introduce rounding errors.
+
 ## Style guide
 
 - Use `:::tip`, `:::caution`, and `:::danger` admonitions sparingly for important callouts

--- a/mobile/src/services/stellar.ts
+++ b/mobile/src/services/stellar.ts
@@ -241,9 +241,11 @@ export async function fetchXLMPrice(): Promise<{ usd: number }> {
   return result
 }
 
+import { stroopsToXLM } from '../utils/stroopConversion'
+
 export function calculateAccountReserves(accountData: any, networkStats: any, offerCount = 0) {
   const baseReserveStroops = Number(networkStats?.latestLedger?.base_reserve) || 10000000
-  const baseReserve = baseReserveStroops / 10000000
+  const baseReserve = Number(stroopsToXLM(baseReserveStroops))
 
   const assetCount = accountData.balances?.filter((b: any) => b.asset_type !== 'native').length || 0
   const signerCount =

--- a/mobile/src/utils/formatters.ts
+++ b/mobile/src/utils/formatters.ts
@@ -1,14 +1,15 @@
+import { stroopsToXLM } from './stroopConversion'
+
 export function shortAddress(addr: string | null | undefined, chars = 6): string {
   if (!addr) return ''
   return `${addr.slice(0, chars)}\u2026${addr.slice(-chars)}`
 }
 
 export function formatXLM(amount: string | number): string {
-  const num = typeof amount === 'string' ? parseFloat(amount) : amount
-  return num.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 7,
-  })
+  if (typeof amount === 'number') {
+    return stroopsToXLM(BigInt(Math.trunc(amount)))
+  }
+  return stroopsToXLM(BigInt(amount))
 }
 
 export function formatDate(dateStr: string): string {

--- a/mobile/src/utils/stroopConversion.ts
+++ b/mobile/src/utils/stroopConversion.ts
@@ -1,0 +1,50 @@
+export const STROOPS_PER_XLM = 10_000_000n
+
+export function stroopsToXLM(stroops: bigint | number): string {
+  const stroopsBigInt = typeof stroops === 'number' ? BigInt(Math.trunc(stroops)) : stroops
+  if (stroopsBigInt < 0n) {
+    throw new Error('Stroop value cannot be negative')
+  }
+  const whole = stroopsBigInt / STROOPS_PER_XLM
+  const remainder = stroopsBigInt % STROOPS_PER_XLM
+  const remainderStr = remainder.toString().padStart(7, '0')
+  return `${whole.toString()}.${remainderStr}`
+}
+
+export function xlmToStroops(xlm: string | number): bigint {
+  const xlmStr = typeof xlm === 'number' ? xlm.toString() : xlm
+  if (!xlmStr || typeof xlmStr !== 'string') {
+    throw new Error('Invalid XLM value: input must be a string or number')
+  }
+  const trimmed = xlmStr.trim()
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    throw new Error(`Invalid XLM value: "${xlmStr}" is not numeric`)
+  }
+  const parts = trimmed.split('.')
+  if (parts[1]?.length > 7) {
+    throw new Error(`Invalid XLM value: "${xlmStr}" has more than 7 decimal places`)
+  }
+  const wholePart = BigInt(parts[0] || '0')
+  let fractionalPart = parts[1] || ''
+  while (fractionalPart.length < 7) {
+    fractionalPart += '0'
+  }
+  fractionalPart = fractionalPart.slice(0, 7)
+  const fractionalBigInt = BigInt(fractionalPart)
+  return wholePart * STROOPS_PER_XLM + fractionalBigInt
+}
+
+export function formatStroops(stroops: bigint | number): string {
+  const stroopsBigInt = typeof stroops === 'number' ? BigInt(Math.trunc(stroops)) : stroops
+  const xlm = stroopsToXLM(stroopsBigInt)
+  return `${xlm} XLM (${stroopsBigInt.toLocaleString()} stroops)`
+}
+
+export function parseStroops(stroopsStr: string): bigint {
+  const trimmed = stroopsStr.trim()
+  const match = trimmed.match(/^([\d.]+)\s*(?:XLM)?$/i)
+  if (!match) {
+    throw new Error(`Invalid stroops format: "${stroopsStr}"`)
+  }
+  return xlmToStroops(match[1])
+}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "build-storybook": "storybook build",
     "docs:validate-drift": "node scripts/validate-docs-drift.mjs",
     "docs:api:generate": "node scripts/generate-api-docs.mjs",
-    "docs:validate-drift": "node scripts/validate-docs-drift.mjs",
     "api:start": "node api/server.js"
   },
   "dependencies": {
@@ -56,7 +55,6 @@
     "@sentry/react": "8.54.0",
     "@stellar/stellar-sdk": "^12.3.0",
     "@tensorflow/tfjs": "^4.22.0",
-    "@tensorflow/tfjs-node": "4.22.0",
     "@tensorflow/tfjs-node": "^4.22.0",
     "d3-array": "^3.2.4",
     "d3-force-3d": "^3.0.6",
@@ -86,7 +84,6 @@
   },
   "optionalDependencies": {
     "@ledgerhq/hw-transport-webhid": "^6.29.4",
-    "@ledgerhq/hw-transport-webusb": "^6.29.4"
     "@ledgerhq/hw-transport-webusb": "^6.29.4",
     "@stellar/ledger": "^1.0.0",
     "ioredis": "^5.4.0"
@@ -117,6 +114,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "@vitest/coverage-v8": "^2.1.9",
     "@vitest/ui": "^2.1.9",
+    "esbuild": "^0.21.5",
     "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/src/components/charts/D3VisualizationSuite.jsx
+++ b/src/components/charts/D3VisualizationSuite.jsx
@@ -19,6 +19,7 @@ import { Download, FileJson, Focus, GitBranch, Layers, Route, Share2 } from 'luc
 import { useResponsive } from '../../hooks/useResponsive'
 import { useStore } from '../../lib/store'
 import Card from '../dashboard/Card'
+import { stroopsToXLM } from '../../utils/stroopConversion.js'
 
 const COLORS = {
   cyan: '#00e5ff',
@@ -170,7 +171,7 @@ function useVisualizationData(metric, density) {
     slicedOps.forEach((operation, index) => {
       const [source, target] = operationEndpoints(operation, centralAddress)
       const amount = operationAmount(operation)
-      const fee = toNumber(operation?.fee_charged, 0) / 10000000
+      const fee = stroopsToXLM(toNumber(operation?.fee_charged, 0))
       const type = operation?.type || 'operation'
       const asset = operationAsset(operation)
       const time = operationTime(operation, index)
@@ -211,7 +212,7 @@ function useVisualizationData(metric, density) {
     sourceTransactions.forEach((transaction, index) => {
       const time = operationTime(transaction, index)
       const dayKey = timeFormat('%Y-%m-%d')(time)
-      const fee = toNumber(transaction?.fee_charged, 0) / 10000000
+      const fee = stroopsToXLM(toNumber(transaction?.fee_charged, 0))
       const point = timelineMap.get(dayKey) || { date: new Date(dayKey), count: 0, volume: 0, fee: 0, failures: 0 }
       point.count += 1
       point.fee += fee

--- a/src/components/dashboard/TransactionBuilder.tsx
+++ b/src/components/dashboard/TransactionBuilder.tsx
@@ -11,6 +11,7 @@ import { fetchContractData } from "../../lib/stellar";
 import { useTransactionHistory } from "../../lib/txHistory";
 import { Copy, Play, Download, AlertCircle, CheckCircle, ArrowDown, GripVertical, Trash2, Plus, Zap } from "lucide-react";
 import { useExpertise } from "../../context/ExpertiseContext";
+import { stroopsToXLM } from "../../utils/stroopConversion.js";
 
 function Panel({ title, subtitle, children }) {
   return (
@@ -1493,7 +1494,7 @@ export default function TransactionBuilder() {
                   {simulation.fee.toLocaleString()}
                 </div>
                 <div style={{ fontSize: "11px", color: "var(--text-muted)", marginTop: "2px" }}>
-                  stroops ({(simulation.fee / 10000000).toFixed(7)} XLM)
+                  stroops ({stroopsToXLM(simulation.fee)} XLM)
                 </div>
               </div>
 

--- a/src/components/deployment/ContractDeployer.jsx
+++ b/src/components/deployment/ContractDeployer.jsx
@@ -6,6 +6,7 @@ import DeploymentTracker from './DeploymentTracker';
 import { ContractDeployer } from '../../lib/deployment/ContractDeployer';
 import { CostEstimator } from '../../lib/deployment/CostEstimator';
 import { getContractUrl, getTransactionUrl } from '../../lib/externalExplorers';
+import { stroopsToXLM } from '../../utils/stroopConversion.js';
 
 const STEPS = [
   { id: 1, label: 'Upload WASM', icon: '📦', description: 'Select the contract artifact' },
@@ -291,11 +292,11 @@ export default function ContractDeployerView() {
             <div style={costPanelStyle}>
               <div style={{ fontSize: '12px', fontWeight: 700 }}>Estimated Cost Breakdown</div>
               <div style={costGridStyle}>
-                <div>Base Fee: {(cost.baseStorageFee / 10000000).toFixed(7)} XLM</div>
-                <div>Per KB: {(cost.perKbFee / 10000000).toFixed(7)} XLM</div>
-                <div>Per Arg: {(cost.perArgFee / 10000000).toFixed(7)} XLM</div>
+                <div>Base Fee: {stroopsToXLM(cost.baseStorageFee)} XLM</div>
+                <div>Per KB: {stroopsToXLM(cost.perKbFee)} XLM</div>
+                <div>Per Arg: {stroopsToXLM(cost.perArgFee)} XLM</div>
                 <div style={{ fontWeight: 700, color: 'var(--cyan)' }}>
-                  Total: {(cost.estimatedFeeStroops / 10000000).toFixed(7)} XLM
+                  Total: {stroopsToXLM(cost.estimatedFeeStroops)} XLM
                 </div>
               </div>
             </div>
@@ -335,7 +336,7 @@ export default function ContractDeployerView() {
               <div>• WASM Size: {wasmFile ? `${wasmFile.sizeMb.toFixed(2)} MB` : '0 MB'}</div>
               <div>• Constructor Params: {normalizedArgs.length}</div>
               <div>• Network: {network}</div>
-              {cost && <div>• Estimated Fee: {(cost.estimatedFeeStroops / 10000000).toFixed(7)} XLM</div>}
+              {cost && <div>• Estimated Fee: {stroopsToXLM(cost.estimatedFeeStroops)} XLM</div>}
             </div>
           </div>
 

--- a/src/lib/deployment/CostEstimator.ts
+++ b/src/lib/deployment/CostEstimator.ts
@@ -1,3 +1,5 @@
+import { stroopsToXLM, xlmToStroops, formatStroops, parseStroops } from '../../utils/stroopConversion.js';
+
 export interface CostEstimate {
   estimatedFeeStroops: number;
   footprintKb: number;
@@ -10,12 +12,10 @@ export interface CostEstimate {
 }
 
 export class CostEstimator {
-  // Estimated fee parameters for Soroban contracts
-  private static readonly BASE_FEE_STROOPS = 100000; // 0.01 XLM
-  private static readonly PER_KB_FEE_STROOPS = 2000; // Fee per KB of WASM
-  private static readonly PER_ARG_FEE_STROOPS = 1500; // Fee per constructor argument
-  private static readonly MARGIN_PERCENTAGE = 0.15; // 15% safety margin
-  private static readonly XLM_RATE_STROOPS = 10000000; // 1 XLM = 10,000,000 stroops
+  private static readonly BASE_FEE_STROOPS = 100000;
+  private static readonly PER_KB_FEE_STROOPS = 2000;
+  private static readonly PER_ARG_FEE_STROOPS = 1500;
+  private static readonly MARGIN_PERCENTAGE = 0.15;
 
   static async estimate(
     wasmBytes: Uint8Array,
@@ -43,8 +43,7 @@ export class CostEstimator {
     const marginFee = Math.ceil(subtotal * CostEstimator.MARGIN_PERCENTAGE);
     const estimatedFeeStroops = subtotal + marginFee;
 
-    // Estimate USD value (assuming 1 XLM ≈ $0.10, but this should come from price feed)
-    const estimatedUsd = (estimatedFeeStroops / CostEstimator.XLM_RATE_STROOPS) * 0.10;
+    const estimatedUsd = Number(stroopsToXLM(estimatedFeeStroops)) * 0.10;
 
     return {
       estimatedFeeStroops,
@@ -59,16 +58,10 @@ export class CostEstimator {
   }
 
   static formatStroops(stroops: number): string {
-    const xlm = stroops / CostEstimator.XLM_RATE_STROOPS;
-    return `${xlm.toFixed(7)} XLM (${stroops.toLocaleString()} stroops)`;
+    return formatStroops(BigInt(stroops));
   }
 
   static parseStroops(stroopsStr: string): number {
-    const match = stroopsStr.match(/(\d+(?:\.\d+)?)\s*(?:XLM)?/);
-    if (!match) {
-      throw new Error('Invalid stroops format');
-    }
-    const xlm = parseFloat(match[1]);
-    return Math.floor(xlm * CostEstimator.XLM_RATE_STROOPS);
+    return Number(parseStroops(stroopsStr));
   }
 }

--- a/src/lib/errorExplanation/mlSuggestionEngine.ts
+++ b/src/lib/errorExplanation/mlSuggestionEngine.ts
@@ -5,6 +5,7 @@
 
 import * as tf from '@tensorflow/tfjs';
 import { getErrorExplanation, ErrorExplanation } from './errorDatabase';
+import { stroopsToXLM } from '../../utils/stroopConversion.js';
 
 export interface ErrorContext {
   errorCode: string;
@@ -275,7 +276,7 @@ class MLSuggestionEngine {
     // Add context-specific suggestions
     if (context.accountState) {
       if (explanation.code === 'tx_insufficient_balance' || explanation.code === 'insufficient balance') {
-        const balanceXLM = context.accountState.balance / 10000000; // Convert stroops to XLM
+        const balanceXLM = stroopsToXLM(context.accountState.balance);
         enhanced.unshift(`Your current balance is ${balanceXLM.toFixed(2)} XLM. You need at least 2 XLM minimum reserve.`);
       }
       

--- a/src/lib/networkMonitoring.js
+++ b/src/lib/networkMonitoring.js
@@ -31,6 +31,7 @@
  */
 
 import { NetworkOptimizer } from './networkOptimizer.ts';
+import { stroopsToXLM } from '../utils/stroopConversion.js';
 
 // Instantiate the global network optimizer
 export const networkOptimizer = new NetworkOptimizer();
@@ -149,7 +150,7 @@ export function predictFees(feeStats, congestionRatio = 0.1) {
   const stdStroops = Math.max(lowStroops + 10, Math.round(median * multiplier));
   const highStroops = Math.max(stdStroops + 50, Math.round(p90 * multiplier));
 
-  const toXLM = (stroops) => (stroops / 10000000).toFixed(7);
+  const toXLM = (stroops) => stroopsToXLM(stroops);
 
   return {
     low: {

--- a/src/lib/stellar.ts
+++ b/src/lib/stellar.ts
@@ -1,4 +1,5 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
+import { stroopsToXLM } from '../utils/stroopConversion.js';
 import { Cache, TTL } from './cache.js';
 import { rateLimiter } from './rateLimiter.js';
 import auditTrail from './auditTrail.js';
@@ -738,7 +739,7 @@ export function calculateAccountReserves(
   // Get base reserve from ledger (in stroops, convert to XLM)
   // Default to 1 XLM if not available (current Stellar default)
   const baseReserveStroops = Number(networkStats?.latestLedger?.base_reserve) || 10000000;
-  const baseReserve = baseReserveStroops / 10000000; // Convert stroops to XLM
+  const baseReserve = Number(stroopsToXLM(baseReserveStroops));
 
   // Count non-native assets (trustlines)
   const assetCount = accountData.balances?.filter((b) => b.asset_type !== 'native').length || 0;

--- a/src/utils/__tests__/stroopConversion.test.ts
+++ b/src/utils/__tests__/stroopConversion.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { stroopsToXLM, xlmToStroops, formatStroops, parseStroops, STROOPS_PER_XLM } from '../stroopConversion'
+
+describe('stroopConversion', () => {
+  it('converts stroops to XLM string with 7 decimal places', () => {
+    expect(stroopsToXLM(15000000)).toBe('1.5000000')
+  })
+
+  it('converts 1 stroop to XLM', () => {
+    expect(stroopsToXLM(1n)).toBe('0.0000001')
+  })
+
+  it('converts XLM string to stroops bigint', () => {
+    expect(xlmToStroops('1')).toBe(10000000n)
+  })
+
+  it('converts 0.0000001 XLM to stroops', () => {
+    expect(xlmToStroops('0.0000001')).toBe(1n)
+  })
+
+  it('formats stroops as "X.X XLM (Y stroops)"', () => {
+    expect(formatStroops(15000000n)).toBe('1.5000000 XLM (15,000,000 stroops)')
+  })
+
+  it('parses "1.5 XLM" into stroops', () => {
+    expect(parseStroops('1.5 XLM')).toBe(15000000n)
+  })
+
+  it('parses "15000000" into stroops', () => {
+    expect(parseStroops('15000000')).toBe(15000000n * STROOPS_PER_XLM)
+  })
+
+  it('handles maximum valid XLM value (max supply)', () => {
+    const maxXlm = '100000000000'
+    expect(xlmToStroops(maxXlm)).toBe(100000000000n * STROOPS_PER_XLM)
+    expect(stroopsToXLM(100000000000n * STROOPS_PER_XLM)).toBe(maxXlm)
+  })
+
+  it('throws on invalid string input', () => {
+    expect(() => xlmToStroops('abc')).toThrow('Invalid XLM value: "abc" is not numeric')
+  })
+
+  it('throws on negative values', () => {
+    expect(() => stroopsToXLM(-1n)).toThrow('Stroop value cannot be negative')
+  })
+
+  it('throws on too many decimal places', () => {
+    expect(() => xlmToStroops('0.00000001')).toThrow('has more than 7 decimal places')
+  })
+
+  it('throws on invalid stroops format', () => {
+    expect(() => parseStroops('invalid')).toThrow('Invalid stroops format')
+  })
+})

--- a/src/utils/stroopConversion.ts
+++ b/src/utils/stroopConversion.ts
@@ -1,0 +1,50 @@
+export const STROOPS_PER_XLM = 10_000_000n
+
+export function stroopsToXLM(stroops: bigint | number): string {
+  const stroopsBigInt = typeof stroops === 'number' ? BigInt(Math.trunc(stroops)) : stroops
+  if (stroopsBigInt < 0n) {
+    throw new Error('Stroop value cannot be negative')
+  }
+  const whole = stroopsBigInt / STROOPS_PER_XLM
+  const remainder = stroopsBigInt % STROOPS_PER_XLM
+  const remainderStr = remainder.toString().padStart(7, '0')
+  return `${whole.toString()}.${remainderStr}`
+}
+
+export function xlmToStroops(xlm: string | number): bigint {
+  const xlmStr = typeof xlm === 'number' ? xlm.toString() : xlm
+  if (!xlmStr || typeof xlmStr !== 'string') {
+    throw new Error('Invalid XLM value: input must be a string or number')
+  }
+  const trimmed = xlmStr.trim()
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    throw new Error(`Invalid XLM value: "${xlmStr}" is not numeric`)
+  }
+  const parts = trimmed.split('.')
+  if (parts[1]?.length > 7) {
+    throw new Error(`Invalid XLM value: "${xlmStr}" has more than 7 decimal places`)
+  }
+  const wholePart = BigInt(parts[0] || '0')
+  let fractionalPart = parts[1] || ''
+  while (fractionalPart.length < 7) {
+    fractionalPart += '0'
+  }
+  fractionalPart = fractionalPart.slice(0, 7)
+  const fractionalBigInt = BigInt(fractionalPart)
+  return wholePart * STROOPS_PER_XLM + fractionalBigInt
+}
+
+export function formatStroops(stroops: bigint | number): string {
+  const stroopsBigInt = typeof stroops === 'number' ? BigInt(Math.trunc(stroops)) : stroops
+  const xlm = stroopsToXLM(stroopsBigInt)
+  return `${xlm} XLM (${stroopsBigInt.toLocaleString()} stroops)`
+}
+
+export function parseStroops(stroopsStr: string): bigint {
+  const trimmed = stroopsStr.trim()
+  const match = trimmed.match(/^([\d.]+)\s*(?:XLM)?$/i)
+  if (!match) {
+    throw new Error(`Invalid stroops format: "${stroopsStr}"`)
+  }
+  return xlmToStroops(match[1])
+}


### PR DESCRIPTION
Closes #754

Eliminates floating-point rounding from XLM and asset amount conversion by introducing decimal-safe stroop conversion utilities using bigint arithmetic.

Changes:
- Added src/utils/stroopConversion.ts with stroopsToXLM, xlmToStroops, ormatStroops, and parseStroops using bigint math
- Replaced all inline / 10000000 conversions across the codebase
- Updated CostEstimator, stellar.ts, 
etworkMonitoring.js, mlSuggestionEngine.ts, TransactionBuilder.tsx, D3VisualizationSuite.jsx, ContractDeployer.jsx, mobile formatters
- Added comprehensive tests and documentation