### PR TITLE
Add Freighter & Ledger wallet connection troubleshooting runbook

### DIFF
--- a/docs-site/docs/guides/wallet-connection-troubleshooting.md
+++ b/docs-site/docs/guides/wallet-connection-troubleshooting.md
@@ -1,0 +1,108 @@
+---
+id: wallet-connection-troubleshooting
+title: Wallet Connection Troubleshooting Runbook
+sidebar_label: Wallet Troubleshooting
+---
+
+# Wallet Connection Troubleshooting Runbook
+
+This runbook helps diagnose and resolve the most common **Freighter** (browser
+extension) and **Ledger** (hardware) connection failures. It mirrors the
+classifier implemented in `src/lib/wallet/diagnostics.js`, so the diagnostics
+described here are the same ones the dashboard surfaces.
+
+Each failure lists:
+
+- **Symptom** — what the user sees or the error text.
+- **Diagnosis** — why it happens.
+- **Remediation** — the concrete next step.
+
+> If a diagnosis below does not match your case, the failure falls into the
+> generic **unknown** bucket. Open the browser developer console, reproduce the
+> failure, and capture the raw error message or Ledger status code.
+
+## 1. Freighter
+
+| Classification | Symptom / Error | Diagnosis | Remediation |
+|---|---|---|---|
+| Not installed | `Freighter is not installed` / `Freighter wallet not found` | The extension is missing, disabled, blocked, or not injected into the page. | Install from [https://freighter.app](https://freighter.app), then refresh. Disable any privacy blocking, and confirm the extension is enabled for this site. |
+| Locked | `Freighter is locked` | The wallet session is locked and cannot sign or expose the account. | Open Freighter and unlock it, then reconnect from the dashboard. |
+| Access denied | `User declined access` | The user dismissed or rejected the access request in the Freighter popup. | Click the wallet button again and **approve** the request. If no popup appears, check that popups are not blocked. |
+| Network mismatch | `You must first turn off account network` / `network` | The network selected in Freighter differs from the one the dashboard is using. | Open the Freighter network selector and match it to the dashboard network (Testnet or Mainnet), then reconnect. |
+| Invalid response | `Failed to get public key` / `Failed to sign` | Freighter could not return a valid address or signature (e.g. no active account). | Confirm an account is funded and selected in Freighter on the target network, then retry. |
+
+### Success criteria for Freighter
+
+The primary flow is considered healthy when Freighter returns a valid `G...`
+public key and the account loads on the selected network. If the extension is
+present but reports `isConnected: false`, treat it as **not installed / not
+allowed** and follow the installed remediation above.
+
+## 2. Ledger (hardware)
+
+| Classification | Symptom / Error | Diagnosis | Remediation |
+|---|---|---|---|
+| Browser unsupported | `WebUSB/WebHID is not supported in this browser` | Firefox and Safari do not expose the WebUSB/WebHID APIs Ledger relies on. | Use Chrome, Edge, or a Chromium-based browser. |
+| Dependency missing | `Optional dependency "@ledgerhq/hw-transport-webusb" is not installed` | The app was built without the optional Ledger transports. | Install `@ledgerhq/hw-transport-webusb` and `@stellar/ledger`, then rebuild. |
+| Device not connected | `No device selected` / `Device not found` | Ledger is not plugged in / paired, or the browser cannot enumerate it. | Plug the device in (or pair over Bluetooth). Use a USB port that the OS permits the browser to access. |
+| Device locked | `Ledger is locked` (status `0x6b0c`) | The device needs its PIN to unlock. | Enter the PIN on the device, then retry. |
+| App not open | `Stellar app is not open` (status `0x6d00`) | The Stellar app is closed on the device. | Navigate to and open the **Stellar** app on the Ledger. |
+| Request rejected | Transaction `rejected` (status `0x6985`) | The user rejected the operation on the device screen. | Re-attempt and **approve** on the device when you intend to continue. |
+
+### Ledger status codes reference
+
+| Code | Meaning | Action |
+|---|---|---|
+| `0x6985` | Request rejected / user declined | Approve on device; retry if unintended |
+| `0x6b0c` | Device locked | Unlock with PIN |
+| `0x6d00` | Instruction / app not found | Open the correct app (Stellar) |
+| `0x6511` | App / data not present | Reinstall or update the Stellar app on the device |
+
+### Common Ledger pitfalls
+
+- Browser must be a secure context (HTTPS or `localhost`); WebUSB/WebHID are not
+  available on plain HTTP.
+- If multiple USB devices are attached, the browser may prompt which device to
+  use — select the Ledger.
+- After a firmware or app update, reconnect the device and start a fresh browser
+  session.
+
+## 3. Compatibility & security notes
+
+- **Freighter** supports Chrome, Firefox, Brave, and Edge as a browser
+  extension. It is the simplest path for development.
+- **Ledger** support depends on **WebUSB/WebHID**, which is only available in
+  Chrome/Chromium browsers. See the compatibility table above.
+- Never handle a user's **secret key** in a browser-facing deployment. Secret
+  key signing is for local development only.
+- Always verify the **network** shown in the wallet matches the network the
+  dashboard is configured for; mismatches are the single most common cause of
+  "connection succeeded but data is wrong" confusion.
+
+## 4. Migration / upgrade notes
+
+- When upgrading ledger-js or the Stellar SDK, confirm the optional
+  `@ledgerhq/hw-transport-*` packages are still present in `package.json`.
+- If Freighter changes its injected API surface, refresh the page after
+  upgrading the extension — the cached connector state can be stale.
+
+## 5. Diagnostic helpers
+
+The classifier exported by `src/lib/wallet/diagnostics.js` returns a stable
+shape you can log or render:
+
+```js
+import { diagnoseWalletConnection } from '@/lib/wallet/diagnostics';
+
+try {
+  // ... connect flow ...
+} catch (err) {
+  const diagnostic = diagnoseWalletConnection('freighter', err);
+  console.table(diagnostic);
+  // { category, message, remediation, severity, matched }
+}
+```
+
+See [Error Handling](./error-handling) and the general
+[Troubleshooting](./troubleshooting) guide for related transaction and network
+diagnostics.

--- a/docs-site/sidebars.js
+++ b/docs-site/sidebars.js
@@ -93,6 +93,7 @@ const sidebars = {
         'guides/rate-limiting',
         'guides/offline-support',
         'guides/advanced-tutorials',
+        'guides/wallet-connection-troubleshooting',
         'guides/troubleshooting',
       ],
     },

--- a/src/lib/wallet/__tests__/diagnostics.test.js
+++ b/src/lib/wallet/__tests__/diagnostics.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  WALLET_DIAGNOSTIC_CATEGORIES,
+  diagnoseFreighterError,
+  diagnoseLedgerError,
+  diagnoseWalletConnection,
+} from '../diagnostics';
+
+describe('wallet connection diagnostics', () => {
+  // ─── Primary flow ────────────────────────────────────────────────────────────
+  describe('diagnoseWalletConnection primary flow', () => {
+    it('classifies a Freighter "not installed" error and returns a remediation', () => {
+      const d = diagnoseWalletConnection(
+        'freighter',
+        new Error('Freighter wallet extension is not installed. Please install it from https://freighter.app')
+      );
+      expect(d.matched).toBe(true);
+      expect(d.category).toBe(WALLET_DIAGNOSTIC_CATEGORIES.EXTENSION_NOT_INSTALLED);
+      expect(d.severity).toBe('error');
+      expect(d.remediation).toContain('https://freighter.app');
+    });
+
+    it('routes unknown wallet types to a generic diagnostic (unsupported environment)', () => {
+      const d = diagnoseWalletConnection('trezor', new Error('boom'));
+      expect(d.matched).toBe(false);
+      expect(d.category).toBe(WALLET_DIAGNOSTIC_CATEGORIES.UNKNOWN);
+      expect(d.message).toContain('unsupported wallet type');
+    });
+  });
+
+  // ─── Freighter failure cases ────────────────────────────────────────────────
+  describe('diagnoseFreighterError', () => {
+    it.each([
+      ['not installed', 'Freighter is not installed. Get it at https://freighter.app', WALLET_DIAGNOSTIC_CATEGORIES.EXTENSION_NOT_INSTALLED],
+      ['not found', 'Freighter wallet not found', WALLET_DIAGNOSTIC_CATEGORIES.EXTENSION_NOT_INSTALLED],
+      ['locked', 'Freighter is locked. Unlock it to continue.', WALLET_DIAGNOSTIC_CATEGORIES.EXTENSION_LOCKED],
+      ['denied', 'User declined access.', WALLET_DIAGNOSTIC_CATEGORIES.ACCESS_DENIED],
+      ['network', 'You must first turn off account network.', WALLET_DIAGNOSTIC_CATEGORIES.NETWORK_MISMATCH],
+    ])('maps "%s" to the right category', (_label, message, category) => {
+      const d = diagnoseFreighterError(new Error(message));
+      expect(d.category).toBe(category);
+      expect(d.matched).toBe(true);
+    });
+  });
+
+  // ─── Ledger failure cases ───────────────────────────────────────────────────
+  describe('diagnoseLedgerError', () => {
+    it.each([
+      ['browser unsupported', 'WebUSB/WebHID is not supported in this browser. Please use Chrome or a Chromium-based browser.', WALLET_DIAGNOSTIC_CATEGORIES.BROWSER_UNSUPPORTED],
+      ['locked device', 'Ledger device is locked. Unlock it and open the Stellar app.', WALLET_DIAGNOSTIC_CATEGORIES.HARDWARE_LOCKED],
+      ['app not open', 'Stellar app is not open on the Ledger device.', WALLET_DIAGNOSTIC_CATEGORIES.STELLAR_APP_NOT_OPEN],
+      ['rejected', 'Transaction was rejected on the Ledger device.', WALLET_DIAGNOSTIC_CATEGORIES.ACCESS_DENIED],
+      ['dependency missing', 'Optional dependency "@ledgerhq/hw-transport-webusb" is not installed.', WALLET_DIAGNOSTIC_CATEGORIES.LEDGER_DEPENDENCY_MISSING],
+      ['device not found', 'No device selected. (0x6a80)', WALLET_DIAGNOSTIC_CATEGORIES.HARDWARE_NOT_CONNECTED],
+    ])('maps "%s" to the right category', (_label, message, category) => {
+      const d = diagnoseLedgerError(new Error(message));
+      expect(d.category).toBe(category);
+      expect(d.matched).toBe(true);
+    });
+  });
+
+  // ─── Boundary cases ─────────────────────────────────────────────────────────
+  describe('boundary cases', () => {
+    it('handles non-Error throw values (strings)', () => {
+      const d = diagnoseFreighterError('User declined access.');
+      expect(d.category).toBe(WALLET_DIAGNOSTIC_CATEGORIES.ACCESS_DENIED);
+    });
+
+    it('treats an empty error as an informational unknown, not error severity', () => {
+      const d = diagnoseFreighterError(null);
+      expect(d.matched).toBe(false);
+      expect(d.category).toBe(WALLET_DIAGNOSTIC_CATEGORIES.UNKNOWN);
+      expect(d.severity).toBe('warning');
+    });
+
+    it('is case-insensitive and strips a leading "Error:" prefix', () => {
+      const d = diagnoseLedgerError(new Error('Error: 0X6B0C LEDGER IS LOCKED'));
+      expect(d.category).toBe(WALLET_DIAGNOSTIC_CATEGORIES.HARDWARE_LOCKED);
+    });
+
+    it('reports unknown errors without matching, so they can be inspected', () => {
+      const d = diagnoseLedgerError(new Error('some surprising error text'));
+      expect(d.matched).toBe(false);
+      expect(d.category).toBe(WALLET_DIAGNOSTIC_CATEGORIES.UNKNOWN);
+      expect(d.severity).toBe('warning');
+    });
+  });
+});

--- a/src/lib/wallet/diagnostics.js
+++ b/src/lib/wallet/diagnostics.js
@@ -1,0 +1,261 @@
+/**
+ * Wallet connection diagnostics.
+ *
+ * Centralizes classification of common Freighter and Ledger connection and
+ * signing failures so that both the UI and the troubleshooting runbook can
+ * share a single source of truth for "what went wrong" + "how to fix it".
+ *
+ * Every recognized failure is mapped to:
+ *   - `category`   – coarse bucket (extension, network, browser, hardware, ...)
+ *   - `message`    – user-facing description of the failure
+ *   - `remediation`– concrete next step(s) to resolve it
+ *   - `severity`   – how severe the failure is (error | warning | info)
+ */
+
+export const WALLET_DIAGNOSTIC_CATEGORIES = Object.freeze({
+  EXTENSION_NOT_INSTALLED: 'extension_not_installed',
+  EXTENSION_LOCKED: 'extension_locked',
+  ACCESS_DENIED: 'access_denied',
+  NETWORK_MISMATCH: 'network_mismatch',
+  BROWSER_UNSUPPORTED: 'browser_unsupported',
+  HARDWARE_NOT_CONNECTED: 'hardware_not_connected',
+  HARDWARE_LOCKED: 'hardware_locked',
+  STELLAR_APP_NOT_OPEN: 'stellar_app_not_open',
+  LEDGER_DEPENDENCY_MISSING: 'ledger_dependency_missing',
+  INVALID_INPUT: 'invalid_input',
+  UNKNOWN: 'unknown',
+})
+
+/**
+ * @typedef {{
+ *   category: string,
+ *   message: string,
+ *   remediation: string,
+ *   severity: 'error'|'warning'|'info',
+ *   matched: boolean,
+ * }} ConnectionDiagnostic
+ */
+
+const SEVERITY_ERROR = 'error'
+const SEVERITY_WARNING = 'warning'
+
+/**
+ * Normalize a thrown/returned error into a stable lower-cased string so that
+ * matching is resilient to case and leading "Error:" prefixes.
+ * @param {unknown} err
+ * @returns {string}
+ */
+function normalizeError(err) {
+  if (!err) return ''
+  const raw = typeof err === 'string' ? err : err instanceof Error ? err.message : 'unknown error'
+  return String(raw)
+    .toLowerCase()
+    .replace(/^error:\s*/, '')
+    .trim()
+}
+
+/**
+ * Classify a Freighter error message into a diagnostic.
+ * @param {unknown} err
+ * @returns {ConnectionDiagnostic}
+ */
+export function diagnoseFreighterError(err) {
+  const msg = normalizeError(err)
+  const base = { severity: SEVERITY_ERROR, matched: true }
+
+  if (!msg) {
+    return {
+      category: WALLET_DIAGNOSTIC_CATEGORIES.UNKNOWN,
+      message: 'Freighter returned an empty error.',
+      remediation: 'Retry the connection. If it persists, reinstall the Freighter extension.',
+      severity: SEVERITY_WARNING,
+      matched: false,
+    }
+  }
+
+  if (
+    /not installed|not found|no freighter|freighter wallet extension is not installed|freighter wallet not found|isn't installed/i.test(msg)
+  ) {
+    return {
+      ...base,
+      category: WALLET_DIAGNOSTIC_CATEGORIES.EXTENSION_NOT_INSTALLED,
+      message: 'The Freighter browser extension is not installed, not injected, or was blocked.',
+      remediation:
+        'Install Freighter from https://freighter.app, then refresh the page. ' +
+        'The dashboard cannot detect the extension if it is disabled, pinned to another profile, ' +
+        'or blocked by a browser privacy setting.',
+    }
+  }
+
+  if (/locked|unlock|rejected|declined|denied|user declined|access.*denied/i.test(msg)) {
+    const isDenied = /declined|denied|rejected/i.test(msg)
+    if (isDenied) {
+      return {
+        ...base,
+        category: WALLET_DIAGNOSTIC_CATEGORIES.ACCESS_DENIED,
+        message: 'The connection request was declined.',
+        remediation:
+          'Click the wallet button again and approve the access request in the Freighter popup. ' +
+          'If the popup is not appearing, check that it is not blocked by the browser.',
+      }
+    }
+    return {
+      ...base,
+      category: WALLET_DIAGNOSTIC_CATEGORIES.EXTENSION_LOCKED,
+      message: 'The Freighter wallet is locked.',
+      remediation: 'Open Freighter and unlock your wallet, then reconnect from the dashboard.',
+    }
+  }
+
+  if (/network|passphrase|turned off|turn.*off|blocked/i.test(msg)) {
+    return {
+      ...base,
+      category: WALLET_DIAGNOSTIC_CATEGORIES.NETWORK_MISMATCH,
+      message:
+        'There is a network mismatch between the dashboard and Freighter, or the extension ' +
+        'cannot reach the network.',
+      remediation:
+        'In Freighter, switch to the same network as the dashboard (Testnet or Mainnet) using the ' +
+        'network selector in the extension, then reconnect.',
+    }
+  }
+
+  if (/sign|publickey|get address|getaddress|invalid/i.test(msg)) {
+    return {
+      ...base,
+      category: WALLET_DIAGNOSTIC_CATEGORIES.INVALID_INPUT,
+      message: 'Freighter could not produce a valid address or signature.',
+      remediation:
+        'Confirm the account is funded on the selected network and that Freighter has a valid ' +
+        'active account selected, then try again.',
+    }
+  }
+
+  return {
+    category: WALLET_DIAGNOSTIC_CATEGORIES.UNKNOWN,
+    message: `Unrecognized Freighter error: ${msg}`,
+    remediation: 'Enable developer tools, reproduce the failure, and inspect the console for details.',
+    severity: SEVERITY_WARNING,
+    matched: false,
+  }
+}
+
+/**
+ * Classify a Ledger hardware wallet error message into a diagnostic.
+ * @param {unknown} err
+ * @returns {ConnectionDiagnostic}
+ */
+export function diagnoseLedgerError(err) {
+  const msg = normalizeError(err)
+  const base = { severity: SEVERITY_ERROR, matched: true }
+
+  if (!msg) {
+    return {
+      category: WALLET_DIAGNOSTIC_CATEGORIES.UNKNOWN,
+      message: 'The Ledger device returned an empty error.',
+      remediation: 'Retry the connection. Confirm the device is plugged in and unlocked.',
+      severity: SEVERITY_WARNING,
+      matched: false,
+    }
+  }
+
+  if (/optional dependency|not installed|@ledgerhq|@stellar\/ledger|npm install|hw-transport/i.test(msg)) {
+    return {
+      ...base,
+      category: WALLET_DIAGNOSTIC_CATEGORIES.LEDGER_DEPENDENCY_MISSING,
+      message: 'Optional Ledger dependencies are not installed.',
+      remediation:
+        'Install the optional transports: `npm install @ledgerhq/hw-transport-webusb @stellar/ledger`, ' +
+        'then rebuild the application.',
+    }
+  }
+
+  if (/webusb|webhid|not supported in this browser|firefox|safari|cannot read property|usb is undefined|hid is undefined/i.test(msg)) {
+    return {
+      ...base,
+      category: WALLET_DIAGNOSTIC_CATEGORIES.BROWSER_UNSUPPORTED,
+      message: 'This browser does not support the WebUSB/WebHID transports required by Ledger.',
+      remediation:
+        'Use Chrome, Edge, or a Chromium-based browser. Firefox and Safari do not expose the ' +
+        'WebUSB/WebHID APIs that the Ledger Stellar connection relies on.',
+    }
+  }
+
+  if (/not connected|connect the device|no device|disconnected|device not found|no device selected/i.test(msg)) {
+    return {
+      ...base,
+      category: WALLET_DIAGNOSTIC_CATEGORIES.HARDWARE_NOT_CONNECTED,
+      message: 'No Ledger device was detected.',
+      remediation:
+        'Plug the Ledger into a USB port (or pair over Bluetooth), unlock it, and open the ' +
+        'Stellar app, then try connecting again.',
+    }
+  }
+
+  if (/(0x6985|denied|rejected|user rejected|declined)/i.test(msg)) {
+    return {
+      ...base,
+      category: WALLET_DIAGNOSTIC_CATEGORIES.ACCESS_DENIED,
+      message: 'The transaction/request was rejected on the Ledger device.',
+      remediation: 'Review the request shown on the device screen and approve it when you intend to continue.',
+    }
+  }
+
+  if (/(0x6b0c|locked|lock)/i.test(msg)) {
+    return {
+      ...base,
+      category: WALLET_DIAGNOSTIC_CATEGORIES.HARDWARE_LOCKED,
+      message: 'The Ledger device is locked.',
+      remediation: 'Enter the PIN to unlock the Ledger, then retry the connection or signing operation.',
+    }
+  }
+
+  if (/(0x6d00|not open|stellar app|is not open|0x6511)/i.test(msg)) {
+    return {
+      ...base,
+      category: WALLET_DIAGNOSTIC_CATEGORIES.STELLAR_APP_NOT_OPEN,
+      message: 'The Stellar app is not open on the Ledger device.',
+      remediation: 'On the Ledger, navigate to and open the Stellar app, then retry.',
+    }
+  }
+
+  return {
+    category: WALLET_DIAGNOSTIC_CATEGORIES.UNKNOWN,
+    message: `Unrecognized Ledger error: ${msg}`,
+    remediation: 'Inspect the device screen messages and the browser console for the raw error code.',
+    severity: SEVERITY_WARNING,
+    matched: false,
+  }
+}
+
+/**
+ * Diagnose a wallet connection failure. Delegates to the Freighter or Ledger
+ * classifier based on `walletType`.
+ *
+ * @param {string} walletType – 'freighter', 'ledger', or any other id
+ * @param {unknown} err
+ * @returns {ConnectionDiagnostic}
+ */
+export function diagnoseWalletConnection(walletType, err) {
+  const type = String(walletType || '').toLowerCase()
+
+  if (type === 'freighter') {
+    return diagnoseFreighterError(err)
+  }
+  if (type === 'ledger') {
+    return diagnoseLedgerError(err)
+  }
+
+  const msg = normalizeError(err)
+  return {
+    category: WALLET_DIAGNOSTIC_CATEGORIES.UNKNOWN,
+    message: msg
+      ? `Connection failed for unsupported wallet type "${walletType}": ${msg}`
+      : `Connection failed for an unsupported wallet type: "${walletType}".`,
+    remediation:
+      'Check the wallet\'s own documentation and confirm the wallet is supported ' +
+      '(Freighter and Ledger are supported).',
+    severity: SEVERITY_ERROR,
+    matched: false,
+  }
+}


### PR DESCRIPTION
closes #906 
Adds a wallet connection troubleshooting runbook covering common **Freighter** and **Ledger** failure modes with diagnostics and remediations, plus a tested diagnostics classifier that the runbook mirrors.
 closes #906