### PR TITLE
[codex] Surface liquidity-pool positions and withdrawal estimates

### DIFF
--- a/LIQUIDITY_POSITION_ESTIMATES.md
+++ b/LIQUIDITY_POSITION_ESTIMATES.md
@@ -1,0 +1,24 @@
+# Liquidity-pool position estimates
+
+The DEX Explorer's **Liquidity Pools** view turns an account's LP share balance into an estimated ownership percentage and underlying asset amounts. The **Manage → Withdraw** view also previews the assets returned, the percentage of pool reserves removed, and the position remaining after a proposed withdrawal.
+
+## Using the estimates
+
+1. Connect an account and select `DEX Explorer → Liquidity Pools`.
+2. Search for an asset pair and select a pool.
+3. Review **Your Position** for LP shares, pool ownership, reserves, and estimated underlying assets.
+4. Open **Manage → Withdraw** and enter an LP share amount to preview the withdrawal impact before copying transaction parameters.
+
+The preview is read-only. It does not submit or sign a transaction, and the displayed amounts are not slippage-protection minimums. Horizon reserve changes, ledger rounding, fees, and activity between preview and submission can change the final result. Set transaction minimum amounts based on the user's own tolerance and verify all values in a trusted signer.
+
+## Compatibility and failure states
+
+Estimates are available for Stellar mainnet, testnet, and futurenet. Local and custom environments are reported as unsupported because they are not guaranteed to expose Horizon liquidity-pool endpoints. Invalid pool data, malformed or excessive share input, missing positions, and Horizon/account request failures are shown explicitly instead of being rendered as zero balances.
+
+The calculation uses proportional constant-product pool ownership:
+
+- `ownership = account shares / total pool shares`
+- `estimated asset amount = reserve × ownership`
+- `pool reserve impact = withdrawal shares / total pool shares`
+
+These values are informational estimates only and should never be treated as guaranteed execution output.

--- a/src/components/dashboard/LiquidityPools.tsx
+++ b/src/components/dashboard/LiquidityPools.tsx
@@ -13,6 +13,7 @@ import {
   calculateImpermanentLoss,
   buildILCurve,
 } from "../../lib/defiAnalytics";
+import { estimateLiquidityPosition, isLiquidityPoolNetworkSupported } from "../../lib/liquidityPosition";
 import type { LiquidityPool, LiquidityPosition } from "./types";
 import {
   LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer, ReferenceLine,
@@ -224,7 +225,12 @@ function TabButton({ active, onClick, icon, label }: { active: boolean; onClick:
 
 // ─── Deposit Tab ──────────────────────────────────────────────────────────────
 
-function DepositWithdrawPanel({ pool, connectedAddress }: { pool: LiquidityPool | null; connectedAddress: string }) {
+function DepositWithdrawPanel({ pool, position, connectedAddress, network }: {
+  pool: LiquidityPool | null;
+  position?: LiquidityPosition;
+  connectedAddress: string;
+  network: string;
+}) {
   const [mode, setMode] = useState<"deposit" | "withdraw">("deposit");
   const [deposit, setDeposit] = useState<DepositForm>({
     maxAmountA: "",
@@ -240,6 +246,16 @@ function DepositWithdrawPanel({ pool, connectedAddress }: { pool: LiquidityPool 
     minAmountB: "0",
   });
   const [copied, setCopied] = useState(false);
+  const withdrawalEstimate = pool && position
+    ? estimateLiquidityPosition({
+        network,
+        positionShares: position.shares ?? position.balance ?? "0",
+        totalShares: pool.totalShares,
+        reserveA: pool.reserveA,
+        reserveB: pool.reserveB,
+        withdrawalShares: withdraw.shares,
+      })
+    : null;
 
   function buildDepositXDR(): string {
     if (!pool) return "";
@@ -254,7 +270,7 @@ function DepositWithdrawPanel({ pool, connectedAddress }: { pool: LiquidityPool 
   }
 
   function buildWithdrawXDR(): string {
-    if (!pool) return "";
+    if (!pool || !withdrawalEstimate?.ok) return "";
     return [
       `Operation: LiquidityPoolWithdraw`,
       `Pool ID: ${pool.id}`,
@@ -376,17 +392,59 @@ function DepositWithdrawPanel({ pool, connectedAddress }: { pool: LiquidityPool 
               placeholder="0"
             />
           </div>
+          {!position && (
+            <div style={{ color: "var(--amber)", fontSize: "12px", marginBottom: "12px" }}>
+              No LP share balance is available for this pool.
+            </div>
+          )}
+          {withdrawalEstimate && !withdrawalEstimate.ok && (
+            <div role="alert" style={{ color: "var(--red)", fontSize: "12px", marginBottom: "12px" }}>
+              {withdrawalEstimate.message}
+            </div>
+          )}
+          {withdrawalEstimate?.ok && (
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "10px", marginBottom: "12px" }}>
+              <Stat label={`Est. ${pool.assetCodeA} received`} value={formatNumber(withdrawalEstimate.value.withdrawalA)} />
+              <Stat label={`Est. ${pool.assetCodeB} received`} value={formatNumber(withdrawalEstimate.value.withdrawalB)} />
+              <Stat label="Pool reserve impact" value={`${formatNumber(withdrawalEstimate.value.poolReserveImpactPercent, 5)}%`} />
+              <Stat label="Remaining LP shares" value={formatNumber(withdrawalEstimate.value.remainingShares)} />
+              <Stat label={`Remaining ${pool.assetCodeA}`} value={formatNumber(withdrawalEstimate.value.remainingUnderlyingA)} />
+              <Stat label={`Remaining ${pool.assetCodeB}`} value={formatNumber(withdrawalEstimate.value.remainingUnderlyingB)} />
+            </div>
+          )}
           <div style={{ background: "var(--bg-elevated)", borderRadius: "var(--radius-sm)", padding: "12px", fontFamily: "var(--font-mono)", fontSize: "11px", color: "var(--text-secondary)", marginBottom: "12px", whiteSpace: "pre-wrap" }}>
             {buildWithdrawXDR()}
           </div>
           <div style={{ fontSize: "11px", color: "var(--text-muted)", marginBottom: "10px" }}>
             Copy the parameters above and use the Transaction Builder to submit your withdrawal.
           </div>
-          <button onClick={handleCopy} style={buttonStyle(false)}>
+          <button onClick={handleCopy} disabled={!withdrawalEstimate?.ok} style={buttonStyle(!withdrawalEstimate?.ok)}>
             {copied ? "Copied!" : "Copy Params"}
           </button>
         </div>
       )}
+    </div>
+  );
+}
+
+function PositionSummary({ pool, position, network }: { pool: LiquidityPool; position: LiquidityPosition; network: string }) {
+  const estimate = estimateLiquidityPosition({
+    network,
+    positionShares: position.shares ?? position.balance ?? "0",
+    totalShares: pool.totalShares,
+    reserveA: pool.reserveA,
+    reserveB: pool.reserveB,
+    withdrawalShares: 0,
+  });
+  if (!estimate.ok) {
+    return <div role="alert" style={{ color: "var(--amber)", fontSize: "12px" }}>{estimate.message}</div>;
+  }
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: "10px" }}>
+      <Stat label="LP Shares" value={formatNumber(position.shares ?? position.balance ?? "0", 7)} />
+      <Stat label="Pool Ownership" value={`${formatNumber(estimate.value.ownershipPercent, 5)}%`} />
+      <Stat label={`Est. ${pool.assetCodeA} owned`} value={formatNumber(estimate.value.underlyingA)} />
+      <Stat label={`Est. ${pool.assetCodeB} owned`} value={formatNumber(estimate.value.underlyingB)} />
     </div>
   );
 }
@@ -610,6 +668,7 @@ export default function LiquidityPools() {
   const [accountLoading, setAccountLoading] = useState(false);
   const [tradesLoading, setTradesLoading] = useState(false);
   const [error, setError] = useState("");
+  const [accountError, setAccountError] = useState("");
 
   const selectedPool = useMemo<LiquidityPool | null>(
     () => pools.find((pool) => pool.id === selectedPoolId) || pools[0] || null,
@@ -619,6 +678,13 @@ export default function LiquidityPools() {
   async function loadPools(nextA = assetA, nextB = assetB) {
     setLoading(true);
     setError("");
+    if (!isLiquidityPoolNetworkSupported(network)) {
+      setError(`Liquidity pools are not supported on the ${network} environment.`);
+      setPools([]);
+      setSelectedPoolId(null);
+      setLoading(false);
+      return;
+    }
     try {
       const records: LiquidityPool[] = await fetchLiquidityPoolsByAssetPair(nextA.trim(), nextB.trim(), network, 20);
       setPools(records);
@@ -633,9 +699,16 @@ export default function LiquidityPools() {
   }
 
   async function loadAccountPools(poolId?: string | null) {
+    setAccountError("");
     if (!connectedAddress) {
       setPositions([]);
       setHistory([]);
+      return;
+    }
+    if (!isLiquidityPoolNetworkSupported(network)) {
+      setPositions([]);
+      setHistory([]);
+      setAccountError(`Account liquidity positions are unavailable on the ${network} environment.`);
       return;
     }
     setAccountLoading(true);
@@ -646,9 +719,10 @@ export default function LiquidityPools() {
       ]);
       setPositions(nextPositions);
       setHistory(nextHistory);
-    } catch {
+    } catch (err: unknown) {
       setPositions([]);
       setHistory([]);
+      setAccountError(err instanceof Error ? err.message : "Failed to load account liquidity positions.");
     } finally {
       setAccountLoading(false);
     }
@@ -807,18 +881,14 @@ export default function LiquidityPools() {
 
                 <div style={{ borderTop: "1px solid var(--border)", paddingTop: "12px" }}>
                   <PanelHeader title="Your Position" detail={accountLoading ? "Refreshing" : connectedAddress ? "Connected" : "No wallet"} compact />
+                  {accountError && <div role="alert" style={{ color: "var(--red)", fontSize: "12px", marginBottom: "8px" }}>{accountError}</div>}
                   {!connectedAddress && <EmptyState text="Connect an account to show LP shares and history." />}
-                  {connectedAddress && positions.filter((p: LiquidityPosition) => p.poolId === selectedPool.id).length === 0 && (
+                  {connectedAddress && !accountError && positions.filter((p: LiquidityPosition) => p.poolId === selectedPool.id).length === 0 && (
                     <EmptyState text="No LP shares for this pool on the connected account." />
                   )}
                   {positions
                     .filter((p: LiquidityPosition) => p.poolId === selectedPool.id)
-                    .map((p: LiquidityPosition) => (
-                      <div key={p.poolId} style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "10px" }}>
-                        <Stat label="LP Shares" value={formatNumber(p.shares || p.balance || "0", 7)} />
-                        <Stat label="Pool Ownership" value={`${formatNumber(p.sharePercent, 5)}%`} />
-                      </div>
-                    ))}
+                    .map((p: LiquidityPosition) => <PositionSummary key={p.poolId} pool={selectedPool} position={p} network={network} />)}
                 </div>
               </div>
             )}
@@ -865,7 +935,12 @@ export default function LiquidityPools() {
       )}
 
       {activeTab === "manage" && (
-        <DepositWithdrawPanel pool={selectedPool} connectedAddress={connectedAddress || ""} />
+        <DepositWithdrawPanel
+          pool={selectedPool}
+          position={positions.find((position) => position.poolId === selectedPool?.id)}
+          connectedAddress={connectedAddress || ""}
+          network={network}
+        />
       )}
 
       {activeTab === "calculator" && (

--- a/src/components/dashboard/types.ts
+++ b/src/components/dashboard/types.ts
@@ -293,9 +293,9 @@ export interface LiquidityPool {
 /** User's LP position */
 export interface LiquidityPosition {
   poolId: string
-  shares?: string
+  shares?: string | number
   balance?: string
-  sharePercent: string
+  sharePercent: string | number
 }
 
 /** Validator status from network monitoring */

--- a/src/lib/__tests__/liquidityPosition.test.ts
+++ b/src/lib/__tests__/liquidityPosition.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { estimateLiquidityPosition } from "../liquidityPosition";
+
+describe("estimateLiquidityPosition", () => {
+  it("estimates owned assets and a partial withdrawal", () => {
+    const result = estimateLiquidityPosition({
+      network: "mainnet",
+      positionShares: "100",
+      totalShares: "1000",
+      reserveA: "5000",
+      reserveB: "2000",
+      withdrawalShares: "25",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        ownershipPercent: 10,
+        underlyingA: 500,
+        underlyingB: 200,
+        withdrawalShares: 25,
+        withdrawalA: 125,
+        withdrawalB: 50,
+        poolReserveImpactPercent: 2.5,
+        remainingShares: 75,
+        remainingUnderlyingA: 375,
+        remainingUnderlyingB: 150,
+      },
+    });
+  });
+
+  it("supports the zero-share boundary without dividing by the position", () => {
+    const result = estimateLiquidityPosition({
+      network: "testnet",
+      positionShares: 0,
+      totalShares: 100,
+      reserveA: 20,
+      reserveB: 40,
+      withdrawalShares: 0,
+    });
+    expect(result.ok && result.value.underlyingA).toBe(0);
+    expect(result.ok && result.value.poolReserveImpactPercent).toBe(0);
+  });
+
+  it("rejects invalid and excessive withdrawals", () => {
+    const base = { network: "mainnet", positionShares: 10, totalShares: 100, reserveA: 20, reserveB: 40 };
+    expect(estimateLiquidityPosition({ ...base, withdrawalShares: "abc" })).toMatchObject({ ok: false, error: "invalid-withdrawal" });
+    expect(estimateLiquidityPosition({ ...base, withdrawalShares: 11 })).toMatchObject({ ok: false, error: "insufficient-shares" });
+  });
+
+  it("reports unsupported environments", () => {
+    expect(estimateLiquidityPosition({
+      network: "custom",
+      positionShares: 1,
+      totalShares: 10,
+      reserveA: 20,
+      reserveB: 40,
+    })).toMatchObject({ ok: false, error: "unsupported-network" });
+  });
+});
+

--- a/src/lib/liquidityPosition.ts
+++ b/src/lib/liquidityPosition.ts
@@ -1,0 +1,93 @@
+export type LiquidityEstimateError =
+  | "unsupported-network"
+  | "invalid-pool"
+  | "invalid-position"
+  | "invalid-withdrawal"
+  | "insufficient-shares";
+
+export interface LiquidityPositionEstimate {
+  ownershipPercent: number;
+  underlyingA: number;
+  underlyingB: number;
+  withdrawalShares: number;
+  withdrawalA: number;
+  withdrawalB: number;
+  poolReserveImpactPercent: number;
+  remainingShares: number;
+  remainingUnderlyingA: number;
+  remainingUnderlyingB: number;
+}
+
+export type LiquidityEstimateResult =
+  | { ok: true; value: LiquidityPositionEstimate }
+  | { ok: false; error: LiquidityEstimateError; message: string };
+
+const SUPPORTED_NETWORKS = new Set(["mainnet", "testnet", "futurenet"]);
+
+export function isLiquidityPoolNetworkSupported(network: string): boolean {
+  return SUPPORTED_NETWORKS.has(network);
+}
+
+function amount(value: string | number | undefined): number {
+  if (value === "" || value === undefined) return Number.NaN;
+  return typeof value === "number" ? value : Number(value);
+}
+
+/**
+ * Produces read-only estimates from Horizon pool reserves. Values are estimates,
+ * not transaction minimums: ledger rounding and reserve changes can alter output.
+ */
+export function estimateLiquidityPosition(input: {
+  network: string;
+  positionShares: string | number;
+  totalShares: string | number;
+  reserveA: string | number;
+  reserveB: string | number;
+  withdrawalShares?: string | number;
+}): LiquidityEstimateResult {
+  if (!isLiquidityPoolNetworkSupported(input.network)) {
+    return {
+      ok: false,
+      error: "unsupported-network",
+      message: `Liquidity-pool estimates are unavailable on ${input.network || "this network"}.`,
+    };
+  }
+
+  const positionShares = amount(input.positionShares);
+  const totalShares = amount(input.totalShares);
+  const reserveA = amount(input.reserveA);
+  const reserveB = amount(input.reserveB);
+  if (![totalShares, reserveA, reserveB].every(Number.isFinite) || totalShares <= 0 || reserveA < 0 || reserveB < 0) {
+    return { ok: false, error: "invalid-pool", message: "Pool reserve or total-share data is invalid." };
+  }
+  if (!Number.isFinite(positionShares) || positionShares < 0) {
+    return { ok: false, error: "invalid-position", message: "The account LP share balance is invalid." };
+  }
+
+  const withdrawalShares = input.withdrawalShares === undefined ? positionShares : amount(input.withdrawalShares);
+  if (!Number.isFinite(withdrawalShares) || withdrawalShares < 0) {
+    return { ok: false, error: "invalid-withdrawal", message: "Enter a valid, non-negative share amount." };
+  }
+  if (withdrawalShares > positionShares) {
+    return { ok: false, error: "insufficient-shares", message: "Withdrawal shares exceed the connected account balance." };
+  }
+
+  const ownership = positionShares / totalShares;
+  const withdrawalRatio = withdrawalShares / totalShares;
+  const remainingShares = positionShares - withdrawalShares;
+  return {
+    ok: true,
+    value: {
+      ownershipPercent: ownership * 100,
+      underlyingA: reserveA * ownership,
+      underlyingB: reserveB * ownership,
+      withdrawalShares,
+      withdrawalA: reserveA * withdrawalRatio,
+      withdrawalB: reserveB * withdrawalRatio,
+      poolReserveImpactPercent: withdrawalRatio * 100,
+      remainingShares,
+      remainingUnderlyingA: reserveA * (remainingShares / totalShares),
+      remainingUnderlyingB: reserveB * (remainingShares / totalShares),
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Surfaces actionable Stellar liquidity-pool positions in the DEX Explorer. Connected users can now see the reserves represented by their LP shares and preview the estimated assets, reserve impact, and remaining position for a proposed withdrawal.

Closes #769.

## User impact

Previously, the pool view exposed only the raw LP share balance and ownership percentage. Users had to calculate the assets represented by those shares themselves, and the withdrawal form offered no indication of expected proceeds or effect on the position. Account lookup failures were also collapsed into an empty position, making a Horizon failure indistinguishable from having no LP shares.

The updated UI now shows:

- LP shares and percentage ownership;
- estimated underlying amount of each reserve asset;
- estimated assets returned for the entered withdrawal shares;
- percentage of pool reserves removed by that withdrawal;
- remaining LP shares and underlying assets after withdrawal;
- explicit errors for unsupported networks, malformed pool/share data, excessive withdrawals, missing positions, and account-fetch failures.

## Root cause

The existing position loader returned pool and balance data, but the presentation layer displayed only two raw fields. There was no shared calculation/validation boundary for translating share balances into reserve ownership. The account error path also cleared state without recording an error for the user.

## Implementation

- Added a pure, typed liquidity-position estimator based on proportional pool ownership.
- Restricted estimates to mainnet, testnet, and futurenet; local/custom environments receive a clear unsupported message.
- Integrated the estimator into both the selected-pool position card and withdrawal form.
- Prevented copying invalid withdrawal parameters when input is malformed or exceeds the connected account's balance.
- Preserved Horizon/account failure details in a visible account-position error state.
- Updated LP position types to match the numeric/string values returned by the existing data source.
- Added user/developer documentation covering calculations, compatibility, failure behavior, rounding, slippage, and signer safety.

## Validation

- `git diff --check` — passed.
- Added focused Vitest coverage for the primary partial-withdrawal flow, zero-share boundary, invalid/excessive withdrawal input, and unsupported environments.
- The focused tests were not executed because dependencies are not installed in the isolated worktree. Dependencies were intentionally not installed, and full CI/build/lint were not run because the upstream baseline is already failing as noted in the task.

## Security and compatibility notes

All calculations are read-only estimates and never sign or submit a transaction. The UI states that reserve movement, ledger rounding, fees, and slippage can change execution output; estimated amounts are not substituted for transaction minimums.
