### PR TITLE
[codex] Validate asset issuers and trustline authorization state

### DIFF
--- a/docs-site/docs/guides/working-with-assets.md
+++ b/docs-site/docs/guides/working-with-assets.md
@@ -100,6 +100,29 @@ const recommendations = await getTrustlineRecommendations('GABC...', 'testnet');
 | `auth_immutable` | Flags can never be changed again |
 | `auth_clawback_enabled` | Issuer can claw back tokens from any holder |
 
+## Validate issuers and trustline state
+
+The dashboard validates every non-native issuer as a checksummed Stellar ed25519 (`G...`)
+public key before requesting issuer metadata. A missing issuer and a malformed issuer are
+shown as separate blocking states; neither should be used to create a trustline. If public-key
+validation is unavailable or throws, validation fails closed and the issuer is treated as invalid.
+
+Authorization and clawback indicators have distinct meanings:
+
+| Dashboard state | Meaning |
+|---|---|
+| `VALID ISSUER` | The issuer is structurally valid; this does **not** imply the issuer is trusted or domain-verified |
+| `AUTHORIZATION REQUIRED` | A trustline must be approved by the issuer before it can receive the asset |
+| `AUTHORIZED` | Horizon reports that the trustline can transact normally |
+| `MAINTAIN LIABILITIES ONLY` | Existing offers/liabilities can remain, but the trustline cannot receive new funds |
+| `UNAUTHORIZED` | Horizon reports that the issuer has not authorized the trustline |
+| `CLAWBACK ENABLED` | The issuer can reclaim tokens from holder trustlines |
+
+Treat these indicators as transaction-safety context, not an endorsement. Verify the asset code,
+issuer, home domain, and expected network independently before creating a trustline. Older Horizon
+responses may omit trustline authorization fields; in that case the dashboard only reports the
+asset-level authorization requirement that is available.
+
 ```js
 const tx = new TransactionBuilder(issuerAccount, { fee: '100', networkPassphrase: Networks.TESTNET })
   .addOperation(Operation.setOptions({

--- a/src/components/assets/AssetCard.jsx
+++ b/src/components/assets/AssetCard.jsx
@@ -2,7 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { useResponsive } from '../../hooks/useResponsive';
 import { useErrorHandler } from '../../hooks/useErrorHandler';
 import { fetchIssuerInfo, fetchAssetMarketData, formatXLM, shortAddress } from '../../lib/stellar';
+import { getAssetTrustlineStatus } from '../../lib/assetTrustlineValidation';
 import CopyableValue from '../dashboard/CopyableValue';
+import AssetTrustStatus from './AssetTrustStatus';
 
 export default function AssetCard({ asset, network, onClick }) {
   const [issuerInfo, setIssuerInfo] = useState(null);
@@ -11,12 +13,20 @@ export default function AssetCard({ asset, network, onClick }) {
   const [expanded, setExpanded] = useState(false);
   const { isMobile } = useResponsive();
   const { handleError } = useErrorHandler('AssetCard');
+  const trustStatus = getAssetTrustlineStatus({ issuer: asset.issuer, flags: asset.flags });
 
   useEffect(() => {
     loadAssetDetails();
   }, [asset.issuer, network]);
 
   const loadAssetDetails = async () => {
+    if (trustStatus.issuer.state !== 'valid') {
+      setIssuerInfo(null);
+      setMarketData(null);
+      setLoading(false);
+      return;
+    }
+
     try {
       setLoading(true);
       
@@ -36,6 +46,12 @@ export default function AssetCard({ asset, network, onClick }) {
   };
 
   const getVerificationBadge = () => {
+    if (trustStatus.issuer.state === 'missing') {
+      return { icon: '⛔', text: 'Missing issuer', color: 'var(--red)' };
+    }
+    if (trustStatus.issuer.state === 'invalid') {
+      return { icon: '⛔', text: 'Invalid issuer', color: 'var(--red)' };
+    }
     if (asset.is_verified || issuerInfo?.verification_level === 'domain') {
       return {
         icon: '✅',
@@ -186,9 +202,13 @@ export default function AssetCard({ asset, network, onClick }) {
             color: 'var(--text-muted)',
             fontFamily: 'var(--font-mono)'
           }}>
-            <CopyableValue value={asset.issuer} title="Copy issuer address">
-              {shortAddress(asset.issuer, 4)}
-            </CopyableValue>
+            {asset.issuer ? (
+              <CopyableValue value={asset.issuer} title="Copy issuer address">
+                {shortAddress(asset.issuer, 4)}
+              </CopyableValue>
+            ) : (
+              <span style={{ color: 'var(--red)' }}>Issuer missing</span>
+            )}
             {(asset.domain || issuerInfo?.domain) && (
               <span style={{ marginLeft: '8px', color: 'var(--cyan)' }}>
                 🌐 {asset.domain || issuerInfo?.domain}
@@ -251,26 +271,14 @@ export default function AssetCard({ asset, network, onClick }) {
       </div>
 
       {/* Asset Flags */}
-      {asset.flags && (
-        <div style={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: '6px',
-          marginBottom: '12px'
-        }}>
-          {asset.flags.auth_required && (
-            <span style={{
-              fontSize: '10px',
-              padding: '2px 6px',
-              background: 'var(--amber-glow)',
-              color: 'var(--amber)',
-              borderRadius: 'var(--radius-sm)',
-              border: '1px solid var(--amber)'
-            }}>
-              AUTH_REQUIRED
-            </span>
-          )}
-          {asset.flags.auth_revocable && (
+      <div style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '6px',
+        marginBottom: '12px'
+      }}>
+        <AssetTrustStatus issuer={asset.issuer} flags={asset.flags} />
+          {asset.flags?.auth_revocable && (
             <span style={{
               fontSize: '10px',
               padding: '2px 6px',
@@ -282,20 +290,7 @@ export default function AssetCard({ asset, network, onClick }) {
               AUTH_REVOCABLE
             </span>
           )}
-          {asset.flags.auth_clawback_enabled && (
-            <span style={{
-              fontSize: '10px',
-              padding: '2px 6px',
-              background: 'var(--red-glow)',
-              color: 'var(--red)',
-              borderRadius: 'var(--radius-sm)',
-              border: '1px solid var(--red)'
-            }}>
-              CLAWBACK_ENABLED
-            </span>
-          )}
-        </div>
-      )}
+      </div>
 
       {/* Description */}
       {(asset.description || issuerInfo?.description) && (
@@ -361,7 +356,7 @@ export default function AssetCard({ asset, network, onClick }) {
                 wordBreak: 'break-all',
                 marginTop: '2px'
               }}>
-                {asset.issuer}
+                {asset.issuer || 'Missing issuer'}
               </div>
             </div>
             

--- a/src/components/assets/AssetTrustStatus.tsx
+++ b/src/components/assets/AssetTrustStatus.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import {
+  getAssetTrustlineStatus,
+  type AssetAuthorizationFlags,
+  type TrustlineAuthorizationFlags,
+} from '../../lib/assetTrustlineValidation';
+
+export interface AssetTrustStatusProps {
+  issuer?: string | null;
+  flags?: AssetAuthorizationFlags | null;
+  trustline?: TrustlineAuthorizationFlags | null;
+  showValidIssuer?: boolean;
+}
+
+const COLORS = {
+  green: 'var(--green)',
+  amber: 'var(--amber)',
+  red: 'var(--red)',
+  muted: 'var(--text-muted)',
+};
+
+function Badge({ label, title, color }: { label: string; title: string; color: string }) {
+  return (
+    <span
+      title={title}
+      aria-label={`${label}: ${title}`}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        padding: '2px 6px',
+        borderRadius: 'var(--radius-sm)',
+        border: `1px solid ${color}`,
+        background: 'var(--bg-elevated)',
+        color,
+        fontSize: '10px',
+        fontWeight: 600,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+export default function AssetTrustStatus({
+  issuer,
+  flags,
+  trustline,
+  showValidIssuer = true,
+}: AssetTrustStatusProps) {
+  const status = getAssetTrustlineStatus({ issuer, flags, trustline });
+  const authorization = {
+    'not-required': null,
+    required: { label: 'AUTHORIZATION REQUIRED', color: COLORS.amber },
+    authorized: { label: 'AUTHORIZED', color: COLORS.green },
+    'maintain-liabilities': { label: 'MAINTAIN LIABILITIES ONLY', color: COLORS.amber },
+    unauthorized: { label: 'UNAUTHORIZED', color: COLORS.red },
+  }[status.authorization.state];
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+      {(showValidIssuer || status.issuer.state !== 'valid') && (
+        <Badge
+          label={
+            status.issuer.state === 'valid'
+              ? 'VALID ISSUER'
+              : status.issuer.state === 'missing'
+                ? 'MISSING ISSUER'
+                : 'INVALID ISSUER'
+          }
+          title={status.issuer.message}
+          color={status.issuer.state === 'valid' ? COLORS.green : COLORS.red}
+        />
+      )}
+      {authorization && (
+        <Badge
+          label={authorization.label}
+          title={status.authorization.message}
+          color={authorization.color}
+        />
+      )}
+      {status.clawbackEnabled && (
+        <Badge
+          label="CLAWBACK ENABLED"
+          title="The issuer can reclaim this asset from holder trustlines."
+          color={COLORS.red}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/assets/index.js
+++ b/src/components/assets/index.js
@@ -5,3 +5,4 @@ export { default as AssetList } from './AssetList';
 export { default as AssetCard } from './AssetCard';
 export { default as PopularAssets } from './PopularAssets';
 export { default as TrustlineRecommendations } from './TrustlineRecommendations';
+export { default as AssetTrustStatus } from './AssetTrustStatus';

--- a/src/components/dashboard/Account.tsx
+++ b/src/components/dashboard/Account.tsx
@@ -12,6 +12,7 @@ import {
 import CopyableValue from './CopyableValue';
 import useAssetUsdEstimates, { formatEstimatedUsd } from '../../hooks/useAssetUsdEstimates';
 import AddressLabelBadge from '../addressLabels/AddressLabelBadge';
+import AssetTrustStatus from '../assets/AssetTrustStatus';
 import type { AccountOffer, ReservesInfo, InfoRowProps } from './types';
 
 function formatAsset(assetType: string, assetCode?: string): string {
@@ -455,6 +456,16 @@ export default function Account() {
                       {shortAddress((asset as Horizon.BalanceLineAsset).asset_issuer)}
                     </CopyableValue>
                   )}
+                  <div style={{ marginTop: '6px' }}>
+                    <AssetTrustStatus
+                      issuer={(asset as Horizon.BalanceLineAsset).asset_issuer}
+                      trustline={{
+                        is_authorized: (asset as Horizon.BalanceLineAsset).is_authorized,
+                        is_authorized_to_maintain_liabilities: (asset as Horizon.BalanceLineAsset)
+                          .is_authorized_to_maintain_liabilities,
+                      }}
+                    />
+                  </div>
                 </div>
                 <div
                   style={{

--- a/src/components/layout/widgets/AssetsWidget.tsx
+++ b/src/components/layout/widgets/AssetsWidget.tsx
@@ -4,6 +4,7 @@ import { formatXLM, shortAddress } from '../../../lib/stellar';
 import useAssetUsdEstimates, { formatEstimatedUsd } from '../../../hooks/useAssetUsdEstimates';
 import CopyableValue from '../../dashboard/CopyableValue';
 import WidgetBase from './WidgetBase';
+import AssetTrustStatus from '../../assets/AssetTrustStatus';
 
 export interface AssetsWidgetProps {
   onRefresh?: () => void;
@@ -15,6 +16,8 @@ export interface AssetBalance {
   asset_code?: string;
   asset_issuer?: string;
   balance: string;
+  is_authorized?: boolean;
+  is_authorized_to_maintain_liabilities?: boolean;
 }
 
 export default function AssetsWidget({ onRefresh, maxAssets = 5 }: AssetsWidgetProps) {
@@ -129,6 +132,13 @@ export default function AssetsWidget({ onRefresh, maxAssets = 5 }: AssetsWidgetP
                     {shortAddress(asset.asset_issuer, 4)}
                   </CopyableValue>
                 )}
+                <div style={{ marginTop: '6px' }}>
+                  <AssetTrustStatus
+                    issuer={asset.asset_issuer}
+                    trustline={asset}
+                    showValidIssuer={false}
+                  />
+                </div>
               </div>
               
               <div style={{ 

--- a/src/lib/__tests__/assetTrustlineValidation.test.ts
+++ b/src/lib/__tests__/assetTrustlineValidation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { getAssetTrustlineStatus } from '../assetTrustlineValidation';
+
+const VALID_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+
+describe('getAssetTrustlineStatus', () => {
+  it('reports a valid issuer and authorized primary trustline flow', () => {
+    const result = getAssetTrustlineStatus({
+      issuer: VALID_ISSUER,
+      flags: { auth_required: true },
+      trustline: { is_authorized: true },
+    });
+
+    expect(result.issuer.state).toBe('valid');
+    expect(result.authorization.state).toBe('authorized');
+    expect(result.clawbackEnabled).toBe(false);
+  });
+
+  it('distinguishes the missing issuer boundary from malformed input', () => {
+    const missing = getAssetTrustlineStatus({ issuer: '   ' });
+    const invalid = getAssetTrustlineStatus({ issuer: `${VALID_ISSUER.slice(0, -1)}B` });
+
+    expect(missing.issuer).toMatchObject({ state: 'missing', normalized: null });
+    expect(invalid.issuer.state).toBe('invalid');
+  });
+
+  it('fails closed when public-key validation is unavailable', () => {
+    const result = getAssetTrustlineStatus({
+      issuer: VALID_ISSUER,
+      validatePublicKey: () => {
+        throw new Error('unsupported environment');
+      },
+    });
+
+    expect(result.issuer.state).toBe('invalid');
+  });
+
+  it('distinguishes authorization-required, restricted, and clawback states', () => {
+    const required = getAssetTrustlineStatus({
+      issuer: VALID_ISSUER,
+      flags: { auth_required: true, auth_clawback_enabled: true },
+    });
+    const restricted = getAssetTrustlineStatus({
+      issuer: VALID_ISSUER,
+      trustline: { is_authorized: false, is_authorized_to_maintain_liabilities: true },
+    });
+
+    expect(required.authorization.state).toBe('required');
+    expect(required.clawbackEnabled).toBe(true);
+    expect(restricted.authorization.state).toBe('maintain-liabilities');
+  });
+});

--- a/src/lib/assetTrustlineValidation.ts
+++ b/src/lib/assetTrustlineValidation.ts
@@ -1,0 +1,111 @@
+import { StrKey } from '@stellar/stellar-sdk';
+
+export type IssuerValidationState = 'valid' | 'missing' | 'invalid';
+export type TrustlineAuthorizationState =
+  | 'not-required'
+  | 'required'
+  | 'authorized'
+  | 'maintain-liabilities'
+  | 'unauthorized';
+
+export interface AssetAuthorizationFlags {
+  auth_required?: boolean;
+  auth_clawback_enabled?: boolean;
+}
+
+export interface TrustlineAuthorizationFlags {
+  is_authorized?: boolean;
+  is_authorized_to_maintain_liabilities?: boolean;
+}
+
+export interface AssetTrustlineStatusInput {
+  issuer?: string | null;
+  flags?: AssetAuthorizationFlags | null;
+  trustline?: TrustlineAuthorizationFlags | null;
+  /** Injectable for deterministic consumers and tests. Defaults to Stellar StrKey validation. */
+  validatePublicKey?: (value: string) => boolean;
+}
+
+export interface AssetTrustlineStatus {
+  issuer: {
+    state: IssuerValidationState;
+    normalized: string | null;
+    message: string;
+  };
+  authorization: {
+    state: TrustlineAuthorizationState;
+    message: string;
+  };
+  clawbackEnabled: boolean;
+}
+
+const ISSUER_MESSAGES: Record<IssuerValidationState, string> = {
+  valid: 'Issuer is a valid Stellar ed25519 public key.',
+  missing: 'Issuer is missing. Do not create a trustline until an issuer is provided.',
+  invalid: 'Issuer is not a valid Stellar ed25519 public key.',
+};
+
+const AUTHORIZATION_MESSAGES: Record<TrustlineAuthorizationState, string> = {
+  'not-required': 'This asset does not require issuer authorization.',
+  required: 'Issuer authorization is required before this trustline can hold the asset.',
+  authorized: 'This trustline is authorized to transact with the asset.',
+  'maintain-liabilities': 'This trustline may maintain liabilities but cannot receive new funds.',
+  unauthorized: 'This trustline is not authorized by the issuer.',
+};
+
+function getIssuerState(
+  issuer: string | null | undefined,
+  validatePublicKey: (value: string) => boolean
+): { state: IssuerValidationState; normalized: string | null } {
+  const normalized = typeof issuer === 'string' ? issuer.trim() : '';
+  if (!normalized) return { state: 'missing', normalized: null };
+
+  try {
+    return validatePublicKey(normalized)
+      ? { state: 'valid', normalized }
+      : { state: 'invalid', normalized };
+  } catch {
+    // Validation failures are fail-closed: an issuer is never presented as safe
+    // when validation support is unavailable or unexpectedly throws.
+    return { state: 'invalid', normalized };
+  }
+}
+
+function getAuthorizationState(
+  authRequired: boolean,
+  trustline?: TrustlineAuthorizationFlags | null
+): TrustlineAuthorizationState {
+  if (trustline?.is_authorized === true) return 'authorized';
+  if (trustline?.is_authorized_to_maintain_liabilities === true) {
+    return 'maintain-liabilities';
+  }
+  if (trustline?.is_authorized === false) return 'unauthorized';
+  return authRequired ? 'required' : 'not-required';
+}
+
+/**
+ * Produces the security-relevant issuer and trustline state used by asset UIs.
+ * Missing/invalid issuers fail closed, and trustline state takes precedence over
+ * the asset-level authorization requirement when Horizon provides both.
+ */
+export function getAssetTrustlineStatus({
+  issuer,
+  flags,
+  trustline,
+  validatePublicKey = StrKey.isValidEd25519PublicKey,
+}: AssetTrustlineStatusInput): AssetTrustlineStatus {
+  const issuerResult = getIssuerState(issuer, validatePublicKey);
+  const authorizationState = getAuthorizationState(Boolean(flags?.auth_required), trustline);
+
+  return {
+    issuer: {
+      ...issuerResult,
+      message: ISSUER_MESSAGES[issuerResult.state],
+    },
+    authorization: {
+      state: authorizationState,
+      message: AUTHORIZATION_MESSAGES[authorizationState],
+    },
+    clawbackEnabled: Boolean(flags?.auth_clawback_enabled),
+  };
+}


### PR DESCRIPTION
## Summary

Asset and trustline views previously displayed issuer strings without validating that they were checksummed Stellar ed25519 public keys. Although raw Horizon flags appeared in asset cards, missing and malformed issuers were not distinguished, account trustlines did not expose authorization restrictions, and clawback capability was easy to miss.

This change adds one fail-closed interpretation layer for those security-relevant states and reuses it across asset discovery, account balances, and the compact assets widget.

## User impact

- Distinguishes valid, missing, and invalid issuer identifiers instead of presenting every string as usable.
- Prevents issuer metadata and market-data requests when an issuer is missing or invalid.
- Shows when an asset requires authorization, when a trustline is authorized or unauthorized, and when it may only maintain existing liabilities.
- Gives clawback-enabled assets an explicit warning that is separate from authorization state.
- Makes clear that structural issuer validity is not the same as issuer trust or domain verification.

## Root cause

Issuer rendering, asset-level flags, and Horizon trustline flags were handled independently in each component. There was no shared validation policy, so malformed input reached network helpers and account balance views omitted `is_authorized` and `is_authorized_to_maintain_liabilities` entirely.

## Implementation

- Added `getAssetTrustlineStatus`, backed by Stellar `StrKey` checksum validation.
- Validation fails closed if key validation is unavailable or unexpectedly throws.
- Added a reusable, accessible `AssetTrustStatus` badge group.
- Integrated the badges into asset cards, account asset balances, and the dashboard assets widget.
- Added focused unit coverage for the primary authorized flow, missing/malformed boundary inputs, unavailable-validation failure, restricted authorization, and clawback state.
- Expanded the assets guide with compatibility and security guidance.

## Validation

- `git diff --cached --check` passed before commit.
- Focused tests were added but not executed because this isolated worktree has no installed dependencies.
- Per project baseline guidance, dependency installation, the full test suite, build, lint, and CI workflows were intentionally not run.

Closes #770
