### PR TITLE
feat: require explicit Mainnet review step before writes

### DIFF
--- a/src/components/dashboard/ContractInteraction.tsx
+++ b/src/components/dashboard/ContractInteraction.tsx
@@ -11,6 +11,7 @@ import { usePreferences } from "../../hooks/usePreferences";
 import { getContractInteractions } from "../../lib/storage";
 import { Sparkles, AlertTriangle, AlertCircle, HelpCircle } from "lucide-react";
 import GasCostEstimator from "./GasCostEstimator";
+import MainnetReviewModal from "../security/MainnetReviewModal";
 
 const ARGUMENT_TYPES = [
   { value: 'string', label: 'String' },
@@ -186,6 +187,7 @@ export default function ContractInteraction() {
   const [error, setError] = useState('');
   const [simulationResult, setSimulationResult] = useState(null);
   const [invokeResult, setInvokeResult] = useState(null);
+  const [showMainnetReview, setShowMainnetReview] = useState(false);
 
   const { preferences, update } = usePreferences();
   const advancedPreferences = preferences?.advanced || {};
@@ -527,6 +529,14 @@ export default function ContractInteraction() {
   }
 
   async function handleInvoke() {
+    if (isMainnet) {
+      setShowMainnetReview(true);
+      return;
+    }
+    await _doInvoke();
+  }
+
+  async function _doInvoke() {
     setError('');
     setInvokeResult(null);
     setInvokeLoading(true);
@@ -548,6 +558,19 @@ export default function ContractInteraction() {
     } finally {
       setInvokeLoading(false);
     }
+  }
+
+  function buildMainnetReviewItems() {
+    const source = form.sourceAccount || connectedAddress || '—';
+    return [
+      { label: 'Network', value: 'Mainnet (Public)', highlight: true },
+      { label: 'Source', value: source ? `${source.slice(0, 8)}…${source.slice(-8)}` : '—', mono: true },
+      { label: 'Contract', value: form.contractId ? `${form.contractId.slice(0, 8)}…${form.contractId.slice(-8)}` : '—', mono: true },
+      { label: 'Function', value: form.functionName || '—', mono: true },
+      { label: 'Arguments', value: form.args.filter(a => a.value.trim()).length > 0
+          ? form.args.filter(a => a.value.trim()).map(a => `${a.name || a.type}: ${a.value}`).join(', ')
+          : 'none' },
+    ];
   }
 
   function handleReplay(record) {
@@ -885,7 +908,7 @@ export default function ContractInteraction() {
             }}
           >
             {isMainnet
-              ? "Mainnet mode: Simulation available, but transaction submission is disabled for safety."
+              ? "Mainnet mode: Simulation always available. Invoking on Mainnet requires an explicit review step."
               : "Testnet mode: Full simulation and submission available."}
           </div>
 
@@ -907,9 +930,9 @@ export default function ContractInteraction() {
             disabled={simulateLoading || invokeLoading || anomalies.some(a => a.severity === 'error')}
           />
           <ActionButton
-            label={invokeLoading ? "Invoking..." : "Invoke"}
+            label={invokeLoading ? "Invoking..." : isMainnet ? "Invoke on Mainnet…" : "Invoke"}
             onClick={handleInvoke}
-            disabled={isMainnet || invokeLoading || simulateLoading || anomalies.some(a => a.severity === 'error')}
+            disabled={invokeLoading || simulateLoading || anomalies.some(a => a.severity === 'error')}
             tone="secondary"
           />
         </div>
@@ -946,6 +969,23 @@ export default function ContractInteraction() {
 
           {invokeResult && <ResultBlock label="Invocation Result" data={invokeResult} />}
         </>
+      )}
+
+      {showMainnetReview && (
+        <MainnetReviewModal
+          actionTitle="Invoke Contract Function"
+          irreversible
+          items={buildMainnetReviewItems()}
+          warnings={[
+            "Contract invocations on Mainnet consume real XLM fees and may modify on-chain state.",
+            "Ensure you have simulated this call successfully before invoking.",
+          ]}
+          onConfirm={() => {
+            setShowMainnetReview(false);
+            _doInvoke();
+          }}
+          onCancel={() => setShowMainnetReview(false)}
+        />
       )}
     </div>
   );

--- a/src/components/dashboard/Contracts.tsx
+++ b/src/components/dashboard/Contracts.tsx
@@ -21,6 +21,7 @@ import {
 import TemplateLibrary from '../templates/TemplateLibrary'
 import ContractDebugger from './ContractDebugger.jsx'
 import TestRunner from '../testing/TestRunner'
+import MainnetReviewModal from '../security/MainnetReviewModal'
 
 const ARGUMENT_TYPES = [
   { value: 'string', label: 'String' },
@@ -175,6 +176,7 @@ export default function Contracts() {
   const [testEditor, setTestEditor] = useState(() => buildContractWorkspace('token').tests)
   const [deployPlan, setDeployPlan] = useState(null)
   const [debugSession, setDebugSession] = useState(null)
+  const [showMainnetReview, setShowMainnetReview] = useState(false)
 
   const isMainnet = network === 'mainnet'
   const inspectInputError = inspectInput.trim() !== '' && !isValidContractId(inspectInput.trim())
@@ -404,6 +406,14 @@ export default function Contracts() {
   }
 
   async function handleSubmit() {
+    if (isMainnet) {
+      setShowMainnetReview(true)
+      return
+    }
+    await _doSubmit()
+  }
+
+  async function _doSubmit() {
     setInvokeError('')
     setSubmitResult(null)
     setSubmitLoading(true)
@@ -448,7 +458,21 @@ export default function Contracts() {
     }
   }
 
+  function buildMainnetReviewItems() {
+    const source = invokeForm.sourceAccount || connectedAddress || '—'
+    return [
+      { label: 'Network', value: 'Mainnet (Public)', highlight: true },
+      { label: 'Source', value: source ? `${source.slice(0, 8)}…${source.slice(-8)}` : '—', mono: true },
+      { label: 'Contract', value: invokeForm.contractId ? `${invokeForm.contractId.slice(0, 8)}…${invokeForm.contractId.slice(-8)}` : '—', mono: true },
+      { label: 'Function', value: invokeForm.functionName || '—', mono: true },
+      { label: 'Arguments', value: invocationPreview.args.length > 0
+          ? invocationPreview.args.map((a: any) => `${a.name || a.type}: ${a.value}`).join(', ')
+          : 'none' },
+    ]
+  }
+
   return (
+    <>
     <div className="animate-in" style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
       <div style={{ fontFamily: 'var(--font-display)', fontSize: '22px', fontWeight: 700 }}>Soroban Contracts</div>
       <div style={{ display: 'flex', gap: '8px' }}>
@@ -788,7 +812,7 @@ export default function Contracts() {
         }}>
           <div style={{ fontSize: '12px', color: isMainnet ? 'var(--amber)' : 'var(--text-secondary)', lineHeight: 1.6 }}>
             {isMainnet
-              ? 'Mainnet safety mode is active. Simulation still works, but transaction submission is disabled.'
+              ? 'Mainnet mode: Simulation always available. Submitting on Mainnet requires an explicit review step.'
               : 'Submission is available on Testnet only. Your secret key is used locally to sign the prepared transaction before it is sent to Soroban RPC.'}
           </div>
 
@@ -810,9 +834,9 @@ export default function Contracts() {
             disabled={simulateLoading || submitLoading || anomalies.some(a => a.severity === 'error')}
           />
           <ActionButton
-            label={submitLoading ? 'Submitting...' : 'Submit'}
+            label={submitLoading ? 'Submitting...' : isMainnet ? 'Submit on Mainnet…' : 'Submit'}
             onClick={handleSubmit}
-            disabled={isMainnet || submitLoading || simulateLoading || anomalies.some(a => a.severity === 'error')}
+            disabled={submitLoading || simulateLoading || anomalies.some(a => a.severity === 'error')}
             tone="secondary"
           />
         </div>
@@ -894,5 +918,23 @@ export default function Contracts() {
         </Panel>
       )}
     </div>
+
+    {showMainnetReview && (
+      <MainnetReviewModal
+        actionTitle="Submit Contract Transaction"
+        irreversible
+        items={buildMainnetReviewItems()}
+        warnings={[
+          'Contract submissions on Mainnet consume real XLM fees and may modify on-chain state permanently.',
+          'Ensure simulation succeeded before submitting.',
+        ]}
+        onConfirm={() => {
+          setShowMainnetReview(false)
+          _doSubmit()
+        }}
+        onCancel={() => setShowMainnetReview(false)}
+      />
+    )}
+    </>
   )
 }

--- a/src/components/dashboard/TransactionSigner.tsx
+++ b/src/components/dashboard/TransactionSigner.tsx
@@ -10,6 +10,8 @@ import { loadPreferences, DEFAULT_PREFERENCES } from '../../lib/userPreferences'
 import type { UserPreferences } from '../../lib/userPreferences'
 import Card from './Card'
 import EnhancedTransactionConfirmation from '../security/EnhancedTransactionConfirmation'
+import MainnetReviewModal from '../security/MainnetReviewModal'
+import type { MainnetReviewItem } from '../security/MainnetReviewModal'
 import BiometricAuthOverlay from '../biometrics/BiometricAuthOverlay'
 import { useBehavioralBiometrics } from '../../hooks/useBehavioralBiometrics'
 
@@ -23,6 +25,7 @@ export default function TransactionSigner() {
   const [ledgerPrompt, setLedgerPrompt] = useState(false)
   const [showConfirmation, setShowConfirmation] = useState(false)
   const [showBiometricOverlay, setShowBiometricOverlay] = useState(false)
+  const [showMainnetReview, setShowMainnetReview] = useState(false)
   const [preferences, setPreferences] = useState<UserPreferences>(DEFAULT_PREFERENCES)
 
   // ─── Behavioral Biometrics ─────────────────────────────────────────────────
@@ -116,11 +119,54 @@ export default function TransactionSigner() {
   }
 
   const _proceedToSign = async () => {
+    // On Mainnet, show the explicit review step before confirmation/signing
+    if (network === 'mainnet' && !showMainnetReview) {
+      setShowMainnetReview(true)
+      return
+    }
     if (preferences.transactionConfirmation.enabled) {
       setShowConfirmation(true)
       return
     }
     await doSign()
+  }
+
+  const _buildMainnetReviewItems = (): MainnetReviewItem[] => {
+    const items: MainnetReviewItem[] = []
+    try {
+      const tx = StellarSdk.TransactionBuilder.fromXDR(xdr.trim(), networkPassphrase) as any
+      const source: string = tx.source || tx.sourceAccount?.accountId?.() || '—'
+      items.push({ label: 'Network', value: 'Mainnet (Public)', highlight: true })
+      items.push({ label: 'Source', value: `${source.slice(0, 8)}…${source.slice(-8)}`, mono: true })
+      const fee = tx.fee ?? '—'
+      items.push({ label: 'Fee', value: `${fee} stroops`, mono: true })
+      const ops: any[] = tx.operations || []
+      items.push({ label: 'Operations', value: String(ops.length) })
+      ops.forEach((op: any, idx: number) => {
+        if (op.type === 'payment' || op.type === 'createAccount') {
+          const dest: string = op.destination || '—'
+          items.push({
+            label: `Destination ${idx + 1}`,
+            value: `${dest.slice(0, 8)}…${dest.slice(-8)}`,
+            mono: true,
+          })
+          const amt = op.amount ?? op.startingBalance ?? '—'
+          const assetLabel =
+            !op.asset || (op.asset && typeof op.asset.isNative === 'function' && op.asset.isNative())
+              ? 'XLM'
+              : op.asset?.code ?? 'unknown'
+          items.push({ label: `Amount ${idx + 1}`, value: `${amt} ${assetLabel}`, highlight: true })
+        } else if (op.type === 'invokeHostFunction') {
+          items.push({ label: `Op ${idx + 1}`, value: 'Smart contract invocation' })
+        } else {
+          items.push({ label: `Op ${idx + 1}`, value: op.type ?? 'unknown' })
+        }
+      })
+    } catch {
+      items.push({ label: 'Network', value: 'Mainnet (Public)', highlight: true })
+      items.push({ label: 'Transaction', value: 'Unable to parse XDR for preview' })
+    }
+    return items
   }
 
   const doSign = async () => {
@@ -164,6 +210,21 @@ export default function TransactionSigner() {
 
   const handleCancelConfirmation = () => {
     setShowConfirmation(false)
+    setShowMainnetReview(false)
+    bio.abort()
+  }
+
+  const handleMainnetReviewConfirm = async () => {
+    setShowMainnetReview(false)
+    if (preferences.transactionConfirmation.enabled) {
+      setShowConfirmation(true)
+      return
+    }
+    await doSign()
+  }
+
+  const handleMainnetReviewCancel = () => {
+    setShowMainnetReview(false)
     bio.abort()
   }
 
@@ -467,6 +528,18 @@ export default function TransactionSigner() {
         )}
       </div>
     </Card>
+
+    {/* Mainnet review modal — must be confirmed before signing proceeds */}
+    {showMainnetReview && (
+      <MainnetReviewModal
+        actionTitle="Sign Transaction"
+        irreversible
+        items={_buildMainnetReviewItems()}
+        warnings={['You are about to sign a transaction on Stellar Mainnet. Real funds will be transferred.']}
+        onConfirm={handleMainnetReviewConfirm}
+        onCancel={handleMainnetReviewCancel}
+      />
+    )}
 
     {/* Biometric overlay — rendered as a portal-like fixed overlay */}
     {showBiometricOverlay && (

--- a/src/components/security/MainnetReviewModal.tsx
+++ b/src/components/security/MainnetReviewModal.tsx
@@ -1,0 +1,315 @@
+/**
+ * MainnetReviewModal
+ *
+ * Displays a mandatory review step before any write operation on Mainnet.
+ * Shows network, source, destination(s), assets, fees, and irreversibility
+ * warnings so the user can make an informed decision before signing.
+ */
+import React, { useState } from 'react'
+import { AlertTriangle, Shield, Globe, User, ArrowRight, Coins, Zap, X } from 'lucide-react'
+
+export interface MainnetReviewItem {
+  label: string
+  value: string
+  mono?: boolean
+  highlight?: boolean
+}
+
+export interface MainnetReviewModalProps {
+  /** Human-readable title for the action being reviewed */
+  actionTitle: string
+  /** Set to true when the action is irreversible (contract invoke, payment, etc.) */
+  irreversible?: boolean
+  /** Summary rows to display in the review table */
+  items: MainnetReviewItem[]
+  /** Additional warning lines shown in the caution box */
+  warnings?: string[]
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export default function MainnetReviewModal({
+  actionTitle,
+  irreversible = true,
+  items,
+  warnings = [],
+  onConfirm,
+  onCancel,
+}: MainnetReviewModalProps) {
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mainnet-review-title"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 9000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.72)',
+        padding: '16px',
+      }}
+    >
+      <div
+        style={{
+          background: 'var(--bg-card)',
+          border: '2px solid var(--amber, #f59e0b)',
+          borderRadius: 'var(--radius-lg)',
+          width: '100%',
+          maxWidth: '520px',
+          maxHeight: '90vh',
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            padding: '20px 24px 16px',
+            borderBottom: '1px solid var(--border)',
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: '12px',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <div
+              style={{
+                width: '40px',
+                height: '40px',
+                borderRadius: '50%',
+                background: 'rgba(245,158,11,0.15)',
+                border: '1px solid var(--amber, #f59e0b)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <Shield size={20} style={{ color: 'var(--amber, #f59e0b)' }} />
+            </div>
+            <div>
+              <div
+                id="mainnet-review-title"
+                style={{ fontSize: '16px', fontWeight: 700, color: 'var(--text-primary)' }}
+              >
+                Mainnet Review
+              </div>
+              <div style={{ fontSize: '12px', color: 'var(--amber, #f59e0b)', marginTop: '2px' }}>
+                {actionTitle}
+              </div>
+            </div>
+          </div>
+          <button
+            onClick={onCancel}
+            aria-label="Cancel and close"
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              color: 'var(--text-muted)',
+              padding: '4px',
+              borderRadius: '4px',
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Network badge */}
+        <div style={{ padding: '16px 24px 0' }}>
+          <div
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '6px',
+              padding: '6px 12px',
+              background: 'rgba(245,158,11,0.1)',
+              border: '1px solid var(--amber, #f59e0b)',
+              borderRadius: '9999px',
+              fontSize: '12px',
+              fontWeight: 700,
+              color: 'var(--amber, #f59e0b)',
+            }}
+          >
+            <Globe size={13} />
+            Stellar Mainnet (Public Network)
+          </div>
+        </div>
+
+        {/* Review items */}
+        <div style={{ padding: '16px 24px' }}>
+          <div
+            style={{
+              background: 'var(--bg-elevated)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-md)',
+              overflow: 'hidden',
+            }}
+          >
+            {items.map((item, i) => (
+              <div
+                key={i}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  gap: '12px',
+                  padding: '10px 14px',
+                  borderBottom: i < items.length - 1 ? '1px solid var(--border)' : undefined,
+                  background: item.highlight ? 'rgba(245,158,11,0.06)' : undefined,
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: '12px',
+                    color: 'var(--text-muted)',
+                    flexShrink: 0,
+                    minWidth: '110px',
+                  }}
+                >
+                  {item.label}
+                </span>
+                <span
+                  style={{
+                    fontSize: '13px',
+                    fontWeight: item.highlight ? 700 : 500,
+                    fontFamily: item.mono ? 'var(--font-mono)' : undefined,
+                    color: item.highlight ? 'var(--amber, #f59e0b)' : 'var(--text-primary)',
+                    textAlign: 'right',
+                    wordBreak: 'break-all',
+                  }}
+                >
+                  {item.value}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Irreversibility + custom warnings */}
+        <div style={{ padding: '0 24px 16px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          {irreversible && (
+            <div
+              style={{
+                display: 'flex',
+                gap: '10px',
+                padding: '12px 14px',
+                background: 'rgba(239,68,68,0.08)',
+                border: '1px solid rgba(239,68,68,0.4)',
+                borderRadius: 'var(--radius-md)',
+              }}
+            >
+              <AlertTriangle size={16} style={{ color: 'var(--red)', flexShrink: 0, marginTop: '1px' }} />
+              <div style={{ fontSize: '12px', color: 'var(--red)', lineHeight: 1.5 }}>
+                This action is <strong>irreversible</strong>. Once submitted to Mainnet it cannot be
+                undone. Verify every detail carefully.
+              </div>
+            </div>
+          )}
+
+          {warnings.map((w, i) => (
+            <div
+              key={i}
+              style={{
+                display: 'flex',
+                gap: '10px',
+                padding: '10px 14px',
+                background: 'rgba(245,158,11,0.08)',
+                border: '1px solid rgba(245,158,11,0.35)',
+                borderRadius: 'var(--radius-md)',
+              }}
+            >
+              <AlertTriangle size={14} style={{ color: 'var(--amber, #f59e0b)', flexShrink: 0, marginTop: '1px' }} />
+              <div style={{ fontSize: '12px', color: 'var(--amber, #f59e0b)', lineHeight: 1.5 }}>
+                {w}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Acknowledgement checkbox */}
+        <div style={{ padding: '0 24px 20px' }}>
+          <label
+            style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: '10px',
+              cursor: 'pointer',
+              padding: '12px 14px',
+              background: 'var(--bg-elevated)',
+              border: `1px solid ${acknowledged ? 'var(--green)' : 'var(--border)'}`,
+              borderRadius: 'var(--radius-md)',
+              transition: 'border-color 0.2s',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={acknowledged}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+              style={{ marginTop: '2px', flexShrink: 0, accentColor: 'var(--green)' }}
+            />
+            <span style={{ fontSize: '12px', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+              I have reviewed all details above and understand this operation will be submitted to{' '}
+              <strong>Stellar Mainnet</strong>.
+            </span>
+          </label>
+        </div>
+
+        {/* Actions */}
+        <div
+          style={{
+            padding: '16px 24px 20px',
+            borderTop: '1px solid var(--border)',
+            display: 'flex',
+            gap: '12px',
+          }}
+        >
+          <button
+            onClick={onCancel}
+            style={{
+              flex: 1,
+              padding: '11px 16px',
+              background: 'var(--bg-elevated)',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-md)',
+              fontSize: '13px',
+              cursor: 'pointer',
+              fontWeight: 600,
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={!acknowledged}
+            aria-disabled={!acknowledged}
+            style={{
+              flex: 2,
+              padding: '11px 16px',
+              background: acknowledged ? 'var(--amber, #f59e0b)' : 'var(--bg-elevated)',
+              color: acknowledged ? '#000' : 'var(--text-muted)',
+              border: 'none',
+              borderRadius: 'var(--radius-md)',
+              fontSize: '13px',
+              fontWeight: 700,
+              cursor: acknowledged ? 'pointer' : 'not-allowed',
+              transition: 'background 0.2s, color 0.2s',
+            }}
+          >
+            Confirm &amp; Proceed on Mainnet
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/security/__tests__/MainnetReviewModal.test.tsx
+++ b/src/components/security/__tests__/MainnetReviewModal.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import MainnetReviewModal from '../MainnetReviewModal'
+import type { MainnetReviewItem } from '../MainnetReviewModal'
+
+const baseItems: MainnetReviewItem[] = [
+  { label: 'Network', value: 'Mainnet (Public)', highlight: true },
+  { label: 'Source', value: 'GABCD123…XYZ98765', mono: true },
+  { label: 'Fee', value: '100 stroops', mono: true },
+]
+
+function setup(overrides: Partial<React.ComponentProps<typeof MainnetReviewModal>> = {}) {
+  const onConfirm = vi.fn()
+  const onCancel = vi.fn()
+  render(
+    <MainnetReviewModal
+      actionTitle="Sign Transaction"
+      irreversible
+      items={baseItems}
+      warnings={['Real funds will be transferred.']}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      {...overrides}
+    />
+  )
+  return { onConfirm, onCancel }
+}
+
+describe('MainnetReviewModal', () => {
+  // ── Primary flow ────────────────────────────────────────────────────────────
+
+  it('renders the action title', () => {
+    setup()
+    expect(screen.getByText('Sign Transaction')).toBeDefined()
+  })
+
+  it('displays all review items', () => {
+    setup()
+    expect(screen.getByText('Network')).toBeDefined()
+    expect(screen.getByText('Mainnet (Public)')).toBeDefined()
+    expect(screen.getByText('Source')).toBeDefined()
+    expect(screen.getByText('GABCD123…XYZ98765')).toBeDefined()
+  })
+
+  it('shows the Mainnet network badge', () => {
+    setup()
+    // Badge text "Stellar Mainnet (Public Network)" and acknowledgement both contain the phrase
+    const matches = screen.getAllByText(/Stellar Mainnet/i)
+    expect(matches.length).toBeGreaterThanOrEqual(1)
+    // Ensure the badge is present specifically
+    expect(screen.getByText('Stellar Mainnet (Public Network)')).toBeDefined()
+  })
+
+  it('displays custom warnings', () => {
+    setup()
+    expect(screen.getByText('Real funds will be transferred.')).toBeDefined()
+  })
+
+  it('confirm button is disabled until checkbox is checked', () => {
+    setup()
+    const confirmBtn = screen.getByRole('button', { name: /Confirm.*Proceed/i })
+    expect(confirmBtn).toHaveProperty('disabled', true)
+  })
+
+  it('enables confirm button after checking the acknowledgement', () => {
+    setup()
+    const checkbox = screen.getByRole('checkbox')
+    fireEvent.click(checkbox)
+    const confirmBtn = screen.getByRole('button', { name: /Confirm.*Proceed/i })
+    expect(confirmBtn).toHaveProperty('disabled', false)
+  })
+
+  it('calls onConfirm when confirmed after acknowledgement', () => {
+    const { onConfirm } = setup()
+    fireEvent.click(screen.getByRole('checkbox'))
+    fireEvent.click(screen.getByRole('button', { name: /Confirm.*Proceed/i }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT call onConfirm when confirm button is clicked without acknowledgement', () => {
+    const { onConfirm } = setup()
+    // Button is disabled — clicking a disabled button should not fire
+    const confirmBtn = screen.getByRole('button', { name: /Confirm.*Proceed/i })
+    fireEvent.click(confirmBtn)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  // ── Boundary cases ──────────────────────────────────────────────────────────
+
+  it('shows irreversibility warning when irreversible=true', () => {
+    setup({ irreversible: true })
+    expect(screen.getByText(/irreversible/i)).toBeDefined()
+  })
+
+  it('does NOT show irreversibility warning when irreversible=false', () => {
+    setup({ irreversible: false })
+    const msgs = screen.queryAllByText(/irreversible/i)
+    expect(msgs.length).toBe(0)
+  })
+
+  it('renders multiple review items correctly', () => {
+    const items: MainnetReviewItem[] = [
+      { label: 'Op 1', value: 'payment', highlight: false },
+      { label: 'Amount 1', value: '50 XLM', highlight: true },
+      { label: 'Destination 1', value: 'GXYZ…ABCD', mono: true },
+    ]
+    setup({ items })
+    expect(screen.getByText('Op 1')).toBeDefined()
+    expect(screen.getByText('payment')).toBeDefined()
+    expect(screen.getByText('Amount 1')).toBeDefined()
+    expect(screen.getByText('50 XLM')).toBeDefined()
+  })
+
+  it('renders with no warnings when warnings array is empty', () => {
+    // Should not throw and should still render the modal
+    setup({ warnings: [] })
+    expect(screen.getByText('Sign Transaction')).toBeDefined()
+  })
+
+  // ── Failure / cancel paths ──────────────────────────────────────────────────
+
+  it('calls onCancel when Cancel button is clicked', () => {
+    const { onCancel } = setup()
+    const cancelBtn = screen.getAllByRole('button', { name: /Cancel/i })[0]
+    fireEvent.click(cancelBtn)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onCancel when the close (X) button is clicked', () => {
+    const { onCancel } = setup()
+    const closeBtn = screen.getByRole('button', { name: /Cancel and close/i })
+    fireEvent.click(closeBtn)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('checkbox toggles acknowledgement state correctly', () => {
+    setup()
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+    fireEvent.click(checkbox)
+    expect(checkbox.checked).toBe(true)
+    fireEvent.click(checkbox)
+    expect(checkbox.checked).toBe(false)
+  })
+
+  it('has the correct aria attributes for accessibility', () => {
+    setup()
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+    expect(dialog.getAttribute('aria-labelledby')).toBe('mainnet-review-title')
+  })
+})


### PR DESCRIPTION
Closes #761 

### Summary

Before this change, users could sign transactions and submit contract calls on Stellar Mainnet without any network-aware confirmation step. The transaction signer would proceed directly to wallet signing, and the contract submission flows were simply hard-disabled on Mainnet with a static warning label — neither approach gave the user a structured opportunity to review what they were about to authorize.

This PR introduces a mandatory review modal that intercepts every Mainnet write before it reaches the wallet or RPC endpoint.

---

### What changed

**New component: `src/components/security/MainnetReviewModal.tsx`**

A reusable modal that requires explicit user acknowledgement before any Mainnet write proceeds. It surfaces:

- Network (Mainnet / Public Network badge)
- Source account
- Destination(s)
- Asset(s) and amount(s)
- Fee in stroops
- Operation type(s)
- An irreversibility warning
- Any caller-supplied contextual warnings

The confirm button is disabled until the user checks an acknowledgement checkbox. Cancel and the close (×) button both abort the flow cleanly.

**`TransactionSigner`**

When the connected network is Mainnet, clicking "Sign Transaction" now opens the review modal first. The modal parses the XDR envelope to extract source, fee, operation count, destinations, and amounts before the user sees anything. After confirming the review, the existing `EnhancedTransactionConfirmation` flow (if enabled in preferences) runs as normal, followed by the wallet signing step.

**`ContractInteraction`**

The "Invoke" button was previously hard-disabled on Mainnet. It is now enabled and opens the review modal instead, showing contract ID, function name, source account, and argument summary. The actual invocation only proceeds after the user passes the review gate.

**`Contracts`**

Same change as above for the "Submit" button in the Soroban Contracts panel.

---

### Testing

16 unit tests added in `src/components/security/__tests__/MainnetReviewModal.test.tsx`:

- Primary flow: renders all review items, confirms after acknowledgement, calls `onConfirm`
- Boundary cases: no warnings, `irreversible=false`, multiple operation items, empty warnings array
- Failure paths: cancel button, close (×) button, clicking confirm without checking the box
- Accessibility: `role="dialog"`, `aria-modal`, `aria-labelledby` verified

No new lint errors or type errors were introduced. The pre-existing error baseline (47 errors, 1501 warnings) is unchanged.

---

### Acceptance criteria

| Criterion | Status |
|---|---|
| Show network, source, destination, assets, fees, and irreversible actions before Mainnet signing | ✅ |
| All transaction and contract submission flows covered | ✅ |
| Clear handling for invalid input (XDR parse failure falls back to a safe summary) | ✅ |
| Automated tests cover primary flow, at least one boundary case, and at least one failure case | ✅ (16 tests) |
