### PR TITLE
New fix for #912 and #899

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish assets for (e.g. v1.2.3)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  sbom:
+    name: Generate & Publish SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate CycloneDX SBOM
+        id: sbom
+        run: |
+          set -euo pipefail
+          node scripts/generate-sbom.mjs --output dist/sbom.cyclonedx.json --format cyclonedx
+          COMPONENT_COUNT=$(node -e "const fs=require('fs'); const doc=JSON.parse(fs.readFileSync('dist/sbom.cyclonedx.json','utf8')); console.log(Array.isArray(doc.components)?doc.components.length:0);")
+          echo "component_count=${COMPONENT_COUNT}" >> "$GITHUB_OUTPUT"
+          echo "Generated SBOM with ${COMPONENT_COUNT} components." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload SBOM workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom-cyclonedx
+          path: dist/sbom.cyclonedx.json
+          retention-days: 90
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Attach SBOM to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.value }}
+          files: dist/sbom.cyclonedx.json
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  validate-sbom-script:
+    name: Validate SBOM Generator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run SBOM generator tests
+        run: npm run test -- tests/ci/generate-sbom.test.js

--- a/api/middleware/idempotency.js
+++ b/api/middleware/idempotency.js
@@ -1,0 +1,219 @@
+/**
+ * IDEMPOTENCY KEY MIDDLEWARE
+ * ==========================
+ * Accepts `Idempotency-Key` on mutating proxy requests so clients can safely
+ * retry POST / PUT / PATCH / DELETE calls without duplicating side effects.
+ *
+ * Behaviour
+ * ---------
+ * • Optional header — requests without a key pass through unchanged.
+ * • First request with a key executes normally; the response is cached.
+ * • Retries with the same key and identical payload return the cached response
+ *   with `Idempotency-Replayed: true`.
+ * • The same key with a different payload returns 409 Conflict.
+ * • A concurrent duplicate while the first request is in-flight returns 409 with
+ *   `Retry-After: 1`.
+ *
+ * Environment variables
+ * ---------------------
+ *   IDEMPOTENCY_ENABLED  – "false" disables the middleware (default: enabled)
+ *   IDEMPOTENCY_TTL_MS   – cache lifetime in ms (default: 86_400_000 / 24 h)
+ *   IDEMPOTENCY_STORE    – "memory" (default) | "redis"
+ *   REDIS_URL            – required when IDEMPOTENCY_STORE=redis
+ *
+ * Failure modes
+ * -------------
+ * 1. Invalid / missing key format when provided → 422 Unprocessable Entity
+ * 2. Same key, different body                   → 409 Conflict
+ * 3. In-flight duplicate                        → 409 + Retry-After
+ * 4. Store unavailable                          → fail-open (request proceeds)
+ * 5. IDEMPOTENCY_ENABLED=false                  → middleware is a no-op
+ */
+
+import crypto from 'node:crypto';
+import { getIdempotencyStore } from './idempotencyStore.js';
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const DEFAULT_TTL_MS = 86_400_000; // 24 hours
+const KEY_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+function config() {
+  const enabled = (process.env.IDEMPOTENCY_ENABLED || 'true').toLowerCase() !== 'false';
+
+  const rawTtl = process.env.IDEMPOTENCY_TTL_MS;
+  const ttlMs =
+    rawTtl && Number.isFinite(Number(rawTtl)) && Number(rawTtl) >= 60_000
+      ? Number(rawTtl)
+      : DEFAULT_TTL_MS;
+
+  return { enabled, ttlMs };
+}
+
+/**
+ * Stable fingerprint for method + path + JSON body.
+ *
+ * @param {import('express').Request} req
+ * @returns {string}
+ */
+export function requestFingerprint(req) {
+  const body = req.body === undefined || req.body === null ? '' : JSON.stringify(req.body);
+  return crypto
+    .createHash('sha256')
+    .update(`${req.method}\n${req.path}\n${body}`)
+    .digest('hex');
+}
+
+/**
+ * Validate an idempotency key supplied by the client.
+ *
+ * @param {unknown} key
+ * @returns {string|null} error message or null when valid
+ */
+export function validateIdempotencyKey(key) {
+  if (key === undefined || key === null || key === '') {
+    return 'Idempotency-Key header is required when idempotency is requested';
+  }
+
+  if (Array.isArray(key)) {
+    return 'Idempotency-Key must be a single header value';
+  }
+
+  const value = String(key).trim();
+  if (!KEY_PATTERN.test(value)) {
+    return 'Idempotency-Key must be 1–128 characters and contain only letters, numbers, hyphens, or underscores';
+  }
+
+  return null;
+}
+
+let _storePromise = null;
+
+async function ensureStore() {
+  if (!_storePromise) {
+    _storePromise = getIdempotencyStore();
+  }
+  return _storePromise;
+}
+
+/**
+ * Replay a previously stored response onto the current Express response.
+ *
+ * @param {import('express').Response} res
+ * @param {{ statusCode: number, headers: Record<string, string>, body: unknown }} record
+ */
+function replayResponse(res, record) {
+  res.set('Idempotency-Replayed', 'true');
+  for (const [name, value] of Object.entries(record.headers || {})) {
+    if (!['content-length', 'transfer-encoding'].includes(name.toLowerCase())) {
+      res.set(name, value);
+    }
+  }
+  res.status(record.statusCode).json(record.body);
+}
+
+/**
+ * Create the idempotency middleware.
+ */
+export function createIdempotencyMiddleware() {
+  const { enabled, ttlMs } = config();
+
+  return async function idempotencyMiddleware(req, res, next) {
+    if (!enabled) {
+      return next();
+    }
+
+    if (!MUTATING_METHODS.has(req.method)) {
+      return next();
+    }
+
+    const rawKey = req.headers['idempotency-key'];
+    if (rawKey === undefined) {
+      return next();
+    }
+
+    const validationError = validateIdempotencyKey(rawKey);
+    if (validationError) {
+      return res.status(422).json({
+        error: 'Unprocessable Entity',
+        message: validationError,
+      });
+    }
+
+    const key = String(rawKey).trim();
+    const fingerprint = requestFingerprint(req);
+
+    try {
+      const store = await ensureStore();
+      const existing = await store.get(key);
+
+      if (existing?.status === 'completed') {
+        if (existing.fingerprint !== fingerprint) {
+          return res.status(409).json({
+            error: 'Conflict',
+            message: 'Idempotency-Key was already used with a different request payload.',
+          });
+        }
+        return replayResponse(res, existing.response);
+      }
+
+      if (existing?.status === 'processing') {
+        res.set('Retry-After', '1');
+        return res.status(409).json({
+          error: 'Conflict',
+          message: 'A request with this Idempotency-Key is already in progress.',
+        });
+      }
+
+      const acquired = await store.begin(key, fingerprint, ttlMs);
+      if (!acquired) {
+        const latest = await store.get(key);
+        if (latest?.status === 'completed' && latest.fingerprint === fingerprint) {
+          return replayResponse(res, latest.response);
+        }
+
+        res.set('Retry-After', '1');
+        return res.status(409).json({
+          error: 'Conflict',
+          message: 'A request with this Idempotency-Key is already in progress.',
+        });
+      }
+
+      const originalJson = res.json.bind(res);
+      res.json = function jsonWithIdempotencyCapture(body) {
+        res.json = originalJson;
+
+        const responseRecord = {
+          statusCode: res.statusCode || 200,
+          headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+          },
+          body,
+        };
+
+        store
+          .complete(key, fingerprint, responseRecord, ttlMs)
+          .catch((err) => {
+            console.error('[idempotency] Failed to persist replay record\n', err);
+          });
+
+        return originalJson(body);
+      };
+
+      res.on('finish', () => {
+        if (res.headersSent && res.statusCode >= 400) {
+          store
+            .abandon(key)
+            .catch((err) => console.error('[idempotency] Failed to abandon in-flight key\n', err));
+        }
+      });
+
+      return next();
+    } catch (err) {
+      console.error('[idempotency] Store error — allowing request (fail-open)\n', err);
+      res.set('Idempotency-Degraded', 'true');
+      return next();
+    }
+  };
+}
+
+export const idempotencyMiddleware = createIdempotencyMiddleware();

--- a/api/middleware/idempotencyStore.js
+++ b/api/middleware/idempotencyStore.js
@@ -1,0 +1,193 @@
+/**
+ * IDEMPOTENCY STORE BACKENDS
+ * ==========================
+ * Pluggable storage for idempotency replay records. Uses an in-memory Map in
+ * development and Redis in production so retries stay consistent across
+ * horizontally scaled API instances.
+ */
+
+const DEFAULT_TTL_MS = 86_400_000;
+
+class MemoryIdempotencyStore {
+  constructor() {
+    /** @type {Map<string, { status: string, fingerprint: string, response?: object, expiresAt: number }>} */
+    this._records = new Map();
+    this._cleanupTimer = setInterval(() => this._cleanup(), 300_000);
+  }
+
+  _cleanup() {
+    const now = Date.now();
+    for (const [key, record] of this._records.entries()) {
+      if (record.expiresAt <= now) {
+        this._records.delete(key);
+      }
+    }
+  }
+
+  async get(key) {
+    const record = this._records.get(key);
+    if (!record) return null;
+    if (record.expiresAt <= Date.now()) {
+      this._records.delete(key);
+      return null;
+    }
+    return record;
+  }
+
+  async begin(key, fingerprint, ttlMs = DEFAULT_TTL_MS) {
+    const existing = await this.get(key);
+    if (existing) {
+      return false;
+    }
+
+    this._records.set(key, {
+      status: 'processing',
+      fingerprint,
+      expiresAt: Date.now() + ttlMs,
+    });
+    return true;
+  }
+
+  async complete(key, fingerprint, response, ttlMs = DEFAULT_TTL_MS) {
+    this._records.set(key, {
+      status: 'completed',
+      fingerprint,
+      response,
+      expiresAt: Date.now() + ttlMs,
+    });
+  }
+
+  async abandon(key) {
+    const record = this._records.get(key);
+    if (record?.status === 'processing') {
+      this._records.delete(key);
+    }
+  }
+
+  async disconnect() {
+    clearInterval(this._cleanupTimer);
+  }
+}
+
+class RedisIdempotencyStore {
+  /**
+   * @param {import('ioredis').default} redis
+   * @param {{ log?: Console }} [opts]
+   */
+  constructor(redis, opts = {}) {
+    this._redis = redis;
+    this._log = opts.log || console;
+  }
+
+  _key(key) {
+    return `idempotency:${key}`;
+  }
+
+  async get(key) {
+    try {
+      const raw = await this._redis.get(this._key(key));
+      return raw ? JSON.parse(raw) : null;
+    } catch (err) {
+      this._log.warn('[idempotency] Redis get failed\n', err.message);
+      throw err;
+    }
+  }
+
+  async begin(key, fingerprint, ttlMs = DEFAULT_TTL_MS) {
+    const redisKey = this._key(key);
+    const payload = JSON.stringify({
+      status: 'processing',
+      fingerprint,
+      expiresAt: Date.now() + ttlMs,
+    });
+
+    const result = await this._redis.set(redisKey, payload, 'PX', ttlMs, 'NX');
+    return result === 'OK';
+  }
+
+  async complete(key, fingerprint, response, ttlMs = DEFAULT_TTL_MS) {
+    const redisKey = this._key(key);
+    const payload = JSON.stringify({
+      status: 'completed',
+      fingerprint,
+      response,
+      expiresAt: Date.now() + ttlMs,
+    });
+    await this._redis.set(redisKey, payload, 'PX', ttlMs);
+  }
+
+  async abandon(key) {
+    try {
+      const record = await this.get(key);
+      if (record?.status === 'processing') {
+        await this._redis.del(this._key(key));
+      }
+    } catch (err) {
+      this._log.warn('[idempotency] Redis abandon failed\n', err.message);
+    }
+  }
+
+  async disconnect() {
+    try {
+      await this._redis.quit();
+    } catch {
+      // ignore shutdown errors
+    }
+  }
+}
+
+let _store = null;
+
+/**
+ * Resolve the configured idempotency store.
+ *
+ * @returns {Promise<MemoryIdempotencyStore|RedisIdempotencyStore>}
+ */
+export async function getIdempotencyStore(opts = {}) {
+  if (_store) return _store;
+
+  const log = opts.log || console;
+  const storeEnv = (process.env.IDEMPOTENCY_STORE || 'memory').toLowerCase();
+  const redisUrl = process.env.REDIS_URL;
+
+  if (storeEnv === 'redis') {
+    if (!redisUrl) {
+      log.warn('[idempotency] IDEMPOTENCY_STORE=redis but REDIS_URL is unset — using memory store');
+    } else {
+      try {
+        const { default: Redis } = await import('ioredis');
+        const redis = new Redis(redisUrl, {
+          maxRetriesPerRequest: 2,
+          retryStrategy(times) {
+            if (times > 3) return null;
+            return Math.min(times * 200, 2000);
+          },
+        });
+
+        await new Promise((resolve, reject) => {
+          redis.once('ready', resolve);
+          redis.once('error', reject);
+        });
+
+        log.info('[idempotency] Connected to Redis — using distributed store');
+        _store = new RedisIdempotencyStore(redis, { log });
+        return _store;
+      } catch (err) {
+        log.warn(
+          `[idempotency] Redis initialisation failed — falling back to in-memory store\n  ${err.message}`,
+        );
+      }
+    }
+  }
+
+  log.info('[idempotency] Using in-memory store (not shared across instances)');
+  _store = new MemoryIdempotencyStore();
+  return _store;
+}
+
+/** Reset cached store (testing helper). */
+export function _resetIdempotencyStoreCache() {
+  _store = null;
+}
+
+export { MemoryIdempotencyStore, RedisIdempotencyStore };

--- a/api/server.js
+++ b/api/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { createServer } from 'http';
 import { WebSocketServer } from 'ws';
 import { rateLimiter } from './middleware/rateLimiter.js';
+import { idempotencyMiddleware } from './middleware/idempotency.js';
 import { apiVersioningMiddleware } from './middleware/apiVersioning.js';
 import { oauthAuth } from './middleware/auth.js';
 import { router as accountsRouter } from './routes/accounts.js';
@@ -18,6 +19,7 @@ const wss = new WebSocketServer({ server });
 
 app.use(express.json());
 app.use(apiVersioningMiddleware);
+app.use(idempotencyMiddleware);
 app.use(rateLimiter);
 
 // Public API routes
@@ -35,6 +37,13 @@ app.get('/api/docs', (req, res) => {
     apiVersion: '1.0.0',
     version: '1.0',
     description: 'Stellar Dev Dashboard Public API',
+    idempotency: {
+      header: 'Idempotency-Key',
+      methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
+      docs: '/api/docs/idempotency',
+      notes:
+        'Optional on mutating proxy calls. Retries with the same key and payload replay the original response.',
+    },
     endpoints: {
       '/api/v1/accounts/:accountId': 'GET - Retrieve account data',
       '/api/v1/transactions': 'GET - Query transactions (query params: accountId, limit)',
@@ -53,6 +62,21 @@ app.get('/api/docs', (req, res) => {
       '/api/v1/gas/thresholds': 'GET/POST - Cost threshold configuration',
       '/ws': 'WebSocket - Subscribe to real-time updates'
     }
+  });
+});
+
+app.get('/api/docs/idempotency', (_req, res) => {
+  res.json({
+    header: 'Idempotency-Key',
+    supportedMethods: ['POST', 'PUT', 'PATCH', 'DELETE'],
+    format: '1–128 characters; letters, numbers, hyphens, and underscores only',
+    replayHeader: 'Idempotency-Replayed',
+    ttlHours: 24,
+    errors: {
+      409: 'Key reused with a different payload or a concurrent duplicate is in progress',
+      422: 'Malformed or missing Idempotency-Key when supplied',
+    },
+    documentation: 'docs/api/IDEMPOTENCY.md',
   });
 });
 

--- a/docs/RELEASE_SBOM.md
+++ b/docs/RELEASE_SBOM.md
@@ -1,0 +1,68 @@
+# Release SBOM Artifacts
+
+Every tagged release publishes a **Software Bill of Materials (SBOM)** so security and compliance teams can review third-party dependencies included in the dashboard.
+
+---
+
+## What is generated
+
+| Asset | Format | Location |
+|-------|--------|----------|
+| `sbom.cyclonedx.json` | CycloneDX JSON | GitHub Release attachment + workflow artifact |
+
+Generation uses `npm sbom` (npm 9+) wrapped by `scripts/generate-sbom.mjs`.
+
+---
+
+## Triggering a release
+
+The `.github/workflows/release.yml` workflow runs automatically when a version tag matching `v*` is pushed:
+
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+Operators can also run the workflow manually from GitHub Actions and supply a tag name.
+
+---
+
+## Local generation
+
+```bash
+npm ci
+node scripts/generate-sbom.mjs --output dist/sbom.cyclonedx.json --format cyclonedx
+```
+
+Optional SPDX output:
+
+```bash
+node scripts/generate-sbom.mjs --output dist/sbom.spdx.json --format spdx
+```
+
+---
+
+## Failure handling
+
+| Condition | Behaviour |
+|-----------|-----------|
+| Missing `package-lock.json` | Script exits with code `3` and prints guidance to run `npm ci` |
+| npm < 9 (no `npm sbom`) | Script exits with code `2` — unsupported environment |
+| Invalid CLI flags | Script exits with code `1` |
+| Release tag missing on manual dispatch | Workflow input validation prevents empty tags |
+| SBOM file missing at upload time | Release step fails (`fail_on_unmatched_files: true`) |
+
+---
+
+## Security notes
+
+- SBOMs list **direct and transitive** npm dependencies resolved from `package-lock.json`.
+- Treat SBOM files as public supply-chain metadata; they do not contain secrets.
+- Compare SBOMs across releases to detect unexpected dependency changes during upgrades.
+
+---
+
+## Automated coverage
+
+- `tests/ci/generate-sbom.test.js` — CLI parsing, format validation, and generation smoke test
+- `release.yml` `validate-sbom-script` job — runs the test suite on every tagged release workflow

--- a/docs/api/IDEMPOTENCY.md
+++ b/docs/api/IDEMPOTENCY.md
@@ -1,0 +1,80 @@
+# Idempotency Keys for Mutating API Proxy Calls
+
+The public API server accepts optional **idempotency keys** on mutating proxy endpoints so clients can safely retry `POST`, `PUT`, `PATCH`, and `DELETE` requests without creating duplicate side effects.
+
+Implementation lives in:
+
+- `api/middleware/idempotency.js`
+- `api/middleware/idempotencyStore.js`
+- wired globally in `api/server.js`
+
+---
+
+## Usage
+
+Send a unique key with every mutating request you may retry:
+
+```http
+POST /api/v1/gas/record HTTP/1.1
+Content-Type: application/json
+Idempotency-Key: gas-record-2026-08-31-001
+
+{"accountId":"GABC...","actualCost":1200}
+```
+
+If the network fails after the server processed the first attempt, resend the **exact same request** with the same key. The API returns the original response and sets:
+
+```http
+Idempotency-Replayed: true
+```
+
+---
+
+## Key format
+
+| Rule | Value |
+|------|-------|
+| Header name | `Idempotency-Key` |
+| Length | 1–128 characters |
+| Allowed characters | `A–Z`, `a–z`, `0–9`, `-`, `_` |
+| Required? | Optional — omit the header to skip idempotency handling |
+
+---
+
+## Responses
+
+| Status | When |
+|--------|------|
+| `200` / `201` / … | First successful execution, or a replay of a prior success |
+| `409 Conflict` | Same key reused with a different payload, or a duplicate arrived while the first request is still processing (`Retry-After: 1`) |
+| `422 Unprocessable Entity` | Malformed key when the header is present |
+
+When the backing store is unavailable the middleware **fails open** and sets `Idempotency-Degraded: true` so traffic is not blocked.
+
+---
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IDEMPOTENCY_ENABLED` | `true` | Set to `false` to disable middleware entirely |
+| `IDEMPOTENCY_TTL_MS` | `86400000` (24 h) | How long replay records are kept |
+| `IDEMPOTENCY_STORE` | `memory` | `memory` for single-instance dev; `redis` for production |
+| `REDIS_URL` | — | Required when `IDEMPOTENCY_STORE=redis` |
+
+---
+
+## Security & migration notes
+
+- Keys should be **unique per logical operation** (for example, include your client-generated UUID).
+- Do not reuse keys across different endpoints or payloads — the server fingerprints `method + path + JSON body`.
+- Replays return the stored response verbatim; rotate keys when intentionally changing request semantics.
+- Existing clients that omit the header behave exactly as before — this is a backward-compatible enhancement.
+
+---
+
+## Developer reference
+
+Machine-readable guidance is exposed at `GET /api/docs/idempotency`.
+
+Automated coverage: `tests/api/middleware/idempotency.test.js`.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -40,6 +40,7 @@ The API docs now include generated reference material and runnable examples.
 - [docs/api/REQUEST_RESPONSE_SAMPLES.md](REQUEST_RESPONSE_SAMPLES.md) — request/response payload examples for Horizon, Soroban RPC, CoinGecko, and Friendbot.
 - [docs/api/ERROR_REFERENCE.md](ERROR_REFERENCE.md) — developer reference for error categories, codes, and recovery strategies.
 - [docs/api/RATE_LIMITING.md](RATE_LIMITING.md) — client-side rate limiting, priority queues, and throttle configurations.
+- [docs/api/IDEMPOTENCY.md](IDEMPOTENCY.md) — idempotency keys for mutating public API proxy endpoints.
 - [docs/api/CHANGELOG.md](CHANGELOG.md) — API documentation changelog.
 - [docs/api/VERSION_HISTORY.md](generated/VERSION_HISTORY.md) — version history and release metadata.
 - [docs/api/examples/](examples/) — runnable example scripts for JavaScript and Python.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "build-storybook": "storybook build",
     "docs:validate-drift": "node scripts/validate-docs-drift.mjs",
     "docs:api:generate": "node scripts/generate-api-docs.mjs",
+    "sbom:generate": "node scripts/generate-sbom.mjs",
     "api:start": "node api/server.js"
   },
   "dependencies": {

--- a/scripts/generate-sbom.mjs
+++ b/scripts/generate-sbom.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Generate a CycloneDX SBOM for npm dependencies.
+ *
+ * Usage:
+ *   node scripts/generate-sbom.mjs [--output path] [--format cyclonedx|spdx]
+ *
+ * Exit codes:
+ *   0 — SBOM written successfully
+ *   1 — invalid CLI input
+ *   2 — unsupported environment (npm sbom unavailable)
+ *   3 — generation failed
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const SUPPORTED_FORMATS = new Set(['cyclonedx', 'spdx']);
+const DEFAULT_OUTPUT = 'dist/sbom.cyclonedx.json';
+
+function parseArgs(argv) {
+  const args = { output: DEFAULT_OUTPUT, format: 'cyclonedx' };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--output') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('Missing value for --output');
+      }
+      args.output = value;
+      i += 1;
+      continue;
+    }
+
+    if (token === '--format') {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error('Missing value for --format');
+      }
+      args.format = value.toLowerCase();
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${token}`);
+  }
+
+  if (!SUPPORTED_FORMATS.has(args.format)) {
+    throw new Error(`Unsupported format "${args.format}". Use cyclonedx or spdx.`);
+  }
+
+  return args;
+}
+
+function ensureNpmSbomAvailable() {
+  try {
+    execFileSync('npm', ['sbom', '--help'], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function generateSbom(format) {
+  const sbomFormat = format === 'spdx' ? 'spdx' : 'cyclonedx';
+  const output = execFileSync('npm', ['sbom', '--sbom-format', sbomFormat], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
+
+  const parsed = JSON.parse(output);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('npm sbom returned invalid JSON');
+  }
+
+  return parsed;
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`[sbom] ${err.message}`);
+    process.exit(1);
+  }
+
+  if (!existsSync('package-lock.json')) {
+    console.error('[sbom] package-lock.json is required. Run npm ci before generating an SBOM.');
+    process.exit(3);
+  }
+
+  if (!ensureNpmSbomAvailable()) {
+    console.error('[sbom] npm sbom is unavailable in this environment (requires npm 9+).');
+    process.exit(2);
+  }
+
+  try {
+    const sbom = generateSbom(args.format);
+    const outputPath = path.resolve(args.output);
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, `${JSON.stringify(sbom, null, 2)}\n`, 'utf8');
+
+    const componentCount = Array.isArray(sbom.components) ? sbom.components.length : null;
+    console.log(`[sbom] Wrote ${outputPath}${componentCount !== null ? ` (${componentCount} components)` : ''}`);
+  } catch (err) {
+    console.error('[sbom] Generation failed:', err.message || err);
+    process.exit(3);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export { parseArgs, generateSbom, ensureNpmSbomAvailable, SUPPORTED_FORMATS };

--- a/tests/api/middleware/idempotency.test.js
+++ b/tests/api/middleware/idempotency.test.js
@@ -1,0 +1,170 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for idempotency-key middleware on mutating proxy endpoints.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  createIdempotencyMiddleware,
+  requestFingerprint,
+  validateIdempotencyKey,
+} from '../../../api/middleware/idempotency.js';
+import { _resetIdempotencyStoreCache } from '../../../api/middleware/idempotencyStore.js';
+
+function mockReq(method, path, body, headers = {}) {
+  return {
+    method,
+    path,
+    body,
+    headers,
+  };
+}
+
+function mockRes() {
+  const res = {
+    statusCode: 200,
+    body: null,
+    _headers: {},
+    finished: false,
+    headersSent: false,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.body = data;
+      this.headersSent = true;
+      return this;
+    },
+    set(field, value) {
+      if (typeof field === 'object') {
+        for (const [k, v] of Object.entries(field)) {
+          this._headers[k.toLowerCase()] = v;
+        }
+      } else {
+        this._headers[field.toLowerCase()] = value;
+      }
+      return this;
+    },
+    on(event, handler) {
+      if (event === 'finish') {
+        this._finishHandler = handler;
+      }
+    },
+    emitFinish() {
+      this.finished = true;
+      this._finishHandler?.();
+    },
+  };
+  return res;
+}
+
+async function setupMiddleware() {
+  _resetIdempotencyStoreCache();
+  vi.resetModules();
+  delete process.env.IDEMPOTENCY_ENABLED;
+  delete process.env.IDEMPOTENCY_TTL_MS;
+  delete process.env.IDEMPOTENCY_STORE;
+  delete process.env.REDIS_URL;
+
+  const mod = await import('../../../api/middleware/idempotency.js');
+  return mod.createIdempotencyMiddleware();
+}
+
+describe('idempotency middleware', () => {
+  beforeEach(() => {
+    _resetIdempotencyStoreCache();
+  });
+
+  afterEach(() => {
+    _resetIdempotencyStoreCache();
+  });
+
+  it('passes through GET requests without inspecting headers', async () => {
+    const middleware = await setupMiddleware();
+    const req = mockReq('GET', '/api/v1/transactions', undefined, {
+      'idempotency-key': 'abc123',
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('caches and replays mutating responses for the same key and payload', async () => {
+    const middleware = await setupMiddleware();
+    const key = 'create-tx-001';
+    const req = mockReq('POST', '/api/v1/gas/record', { amount: 42 }, { 'idempotency-key': key });
+
+    const firstRes = mockRes();
+    const firstNext = vi.fn();
+    await middleware(req, firstRes, firstNext);
+    expect(firstNext).toHaveBeenCalled();
+
+    firstRes.json({ ok: true, id: 'abc' });
+    firstRes.emitFinish();
+
+    const replayReq = mockReq('POST', '/api/v1/gas/record', { amount: 42 }, { 'idempotency-key': key });
+    const replayRes = mockRes();
+    const replayNext = vi.fn();
+    await middleware(replayReq, replayRes, replayNext);
+
+    expect(replayNext).not.toHaveBeenCalled();
+    expect(replayRes._headers['idempotency-replayed']).toBe('true');
+    expect(replayRes.body).toEqual({ ok: true, id: 'abc' });
+  });
+
+  it('accepts idempotency keys at the maximum length boundary', () => {
+    const key = 'a'.repeat(128);
+    expect(validateIdempotencyKey(key)).toBeNull();
+  });
+
+  it('returns 422 for an invalid idempotency key', async () => {
+    const middleware = await setupMiddleware();
+    const req = mockReq('POST', '/api/v1/gas/record', { amount: 1 }, { 'idempotency-key': 'bad key!' });
+    const res = mockRes();
+    const next = vi.fn();
+
+    await middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(422);
+    expect(res.body.error).toBe('Unprocessable Entity');
+  });
+
+  it('returns 409 when the same key is reused with a different payload', async () => {
+    const middleware = await setupMiddleware();
+    const key = 'conflict-key';
+
+    const firstReq = mockReq('POST', '/api/v1/gas/record', { amount: 1 }, { 'idempotency-key': key });
+    const firstRes = mockRes();
+    await middleware(firstReq, firstRes, vi.fn());
+    firstRes.json({ ok: true });
+    firstRes.emitFinish();
+
+    const conflictReq = mockReq('POST', '/api/v1/gas/record', { amount: 2 }, { 'idempotency-key': key });
+    const conflictRes = mockRes();
+    await middleware(conflictReq, conflictRes, vi.fn());
+
+    expect(conflictRes.statusCode).toBe(409);
+    expect(conflictRes.body.message).toMatch(/different request payload/i);
+  });
+
+  it('is a no-op when IDEMPOTENCY_ENABLED=false', async () => {
+    process.env.IDEMPOTENCY_ENABLED = 'false';
+    const middleware = createIdempotencyMiddleware();
+    const req = mockReq('POST', '/api/v1/gas/record', { amount: 1 }, { 'idempotency-key': 'ignored' });
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('builds stable fingerprints for equivalent payloads', () => {
+    const reqA = mockReq('POST', '/api/v1/gas/record', { amount: 1 });
+    const reqB = mockReq('POST', '/api/v1/gas/record', { amount: 1 });
+    expect(requestFingerprint(reqA)).toBe(requestFingerprint(reqB));
+  });
+});

--- a/tests/ci/generate-sbom.test.js
+++ b/tests/ci/generate-sbom.test.js
@@ -1,0 +1,43 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseArgs,
+  generateSbom,
+  ensureNpmSbomAvailable,
+  SUPPORTED_FORMATS,
+} from '../../scripts/generate-sbom.mjs';
+
+describe('generate-sbom script', () => {
+  it('parses default output and format', () => {
+    const args = parseArgs([]);
+    expect(args.output).toBe('dist/sbom.cyclonedx.json');
+    expect(args.format).toBe('cyclonedx');
+  });
+
+  it('accepts explicit output and format flags', () => {
+    const args = parseArgs(['--output', 'tmp/custom.json', '--format', 'spdx']);
+    expect(args.output).toBe('tmp/custom.json');
+    expect(args.format).toBe('spdx');
+  });
+
+  it('rejects unsupported formats', () => {
+    expect(() => parseArgs(['--format', 'invalid'])).toThrow(/unsupported format/i);
+  });
+
+  it('generates a CycloneDX document when npm sbom is available', () => {
+    if (!ensureNpmSbomAvailable()) {
+      expect(SUPPORTED_FORMATS.has('cyclonedx')).toBe(true);
+      return;
+    }
+
+    const sbom = generateSbom('cyclonedx');
+    expect(sbom).toBeTypeOf('object');
+    expect(sbom.bomFormat || sbom.specVersion || sbom.components).toBeTruthy();
+  });
+
+  it('fails fast on unknown CLI arguments', () => {
+    expect(() => parseArgs(['--unexpected'])).toThrow(/unknown argument/i);
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements two 2026 roadmap items: safe retries for mutating public API proxy calls via idempotency keys, and automated CycloneDX SBOM publication on tagged releases.

### #912 — Idempotency keys for mutating proxy endpoints

- Added `api/middleware/idempotency.js` and `api/middleware/idempotencyStore.js` to accept optional `Idempotency-Key` headers on `POST`, `PUT`, `PATCH`, and `DELETE` requests.
- Wired the middleware globally in `api/server.js` (after JSON parsing, before rate limiting).
- First request with a valid key executes normally and caches the JSON response; retries with the same key and identical payload replay the cached response with `Idempotency-Replayed: true`.
- Clear failure handling:
  - `422` for malformed keys
  - `409` when the same key is reused with a different payload or while a duplicate is in-flight (`Retry-After: 1`)
  - Fail-open with `Idempotency-Degraded: true` when the backing store is unavailable
  - No-op when `IDEMPOTENCY_ENABLED=false`
- Pluggable store: in-memory (default) or Redis (`IDEMPOTENCY_STORE=redis` + `REDIS_URL`) for multi-instance deployments.
- Added developer guidance at `GET /api/docs/idempotency` and `docs/api/IDEMPOTENCY.md`.

### #899 — Publish SBOM artifacts for each tagged release

- Added `scripts/generate-sbom.mjs` to generate CycloneDX (or SPDX) SBOMs via `npm sbom`, with explicit exit codes for invalid input, unsupported environments, and generation failures.
- Added `.github/workflows/release.yml` triggered on `v*` tags (and manual dispatch) to:
  - Generate `dist/sbom.cyclonedx.json`
  - Upload it as a workflow artifact
  - Attach it to the matching GitHub Release
- Added `npm run sbom:generate` script alias.
- Added supply-chain documentation in `docs/RELEASE_SBOM.md`.

## Test plan

- [x] `tests/api/middleware/idempotency.test.js`
  - Primary flow: first mutating request succeeds; replay returns cached response with `Idempotency-Replayed: true`
  - Boundary: 128-character idempotency key accepted
  - Failure: invalid key → `422`; same key with different payload → `409`
  - Disabled mode: `IDEMPOTENCY_ENABLED=false` passes through unchanged
- [x] `tests/ci/generate-sbom.test.js`
  - Primary flow: CycloneDX SBOM generation succeeds when `npm sbom` is available
  - Boundary: explicit `--output` and `--format` flags parsed correctly
  - Failure: unsupported format and unknown CLI arguments rejected
- [x] Release workflow includes a `validate-sbom-script` job that runs SBOM tests on every release

## Documentation

- [x] `docs/api/IDEMPOTENCY.md` — usage, configuration, security, and migration notes
- [x] `docs/RELEASE_SBOM.md` — release trigger, local generation, failure handling, and security notes
- [x] `docs/api/README.md` — linked idempotency guide

## Compatibility & security notes

- Idempotency keys are **optional** and backward compatible; clients that omit the header behave exactly as before.
- Keys are fingerprinted against `method + path + JSON body` to prevent cross-endpoint or cross-payload replay abuse.
- SBOM files contain dependency metadata only (no secrets) and are intended for public supply-chain review.

closes #912
closes #899